### PR TITLE
Feature/subnets again

### DIFF
--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -200,7 +200,7 @@ class Controller(dict):
             del self[net.name]
         elif mode == 'single':
             name = obj.name
-            for item in self.keys():
+            for item in list(self.keys()):
                 # Remove label arrays from all other objects
                 self[item].pop('pore.'+name,None)
                 self[item].pop('throat.'+name,None)

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -453,12 +453,12 @@ class Controller(dict):
         self.clear()
         net = _copy.deepcopy(network)
         self.update(net)
-        for item in self.keys():
-            rand_str = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
-            new_name = item + '_' + rand_str
+        rand_str = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
+        for item in list(self.keys()):
             temp = self.pop(item)
+            new_name = temp.name + '_' + rand_str
             temp.name = new_name
-            self[new_name] = temp
+            self[temp.name] = temp
         self.update(bak)
         return net
 

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -415,7 +415,7 @@ class Controller(dict):
 
     comments = property(fget=_get_comments,fset=_set_comments)
 
-    def clone_simulation(self,network):
+    def clone_simulation(self,network,name=None):
         r'''
         Accepts a Network object and creates a complete clone including all 
         associated objects.  All objects in the cloned simulation are 
@@ -445,11 +445,14 @@ class Controller(dict):
         bak.update(self)
         self.clear()
         net = _copy.deepcopy(network)
+        net['pore.'+network.name] = network.Ps
+        net['throat.'+network.name] = network.Ts
         self.update(net)
-        rand_str = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
+        if name == None:
+            name = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
         for item in list(self.keys()):
             temp = self.pop(item)
-            new_name = temp.name + '_' + rand_str
+            new_name = temp.name + '|' + name
             temp.name = new_name
             self[temp.name] = temp
         self.update(bak)

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -134,17 +134,22 @@ class Controller(dict):
     def update(self,arg):
         r'''
         This is a subclassed version of the standard dict's ``update`` method.  
-        It can accept a dictionary as usual, but also an OpenPNM Network 
-        object, from which all the associated objects are extracted and added 
-        to the Controller.
+        It can accept a dictionary of OpenPNM Core objects in which case it 
+        adds the objects to the Controller.  It can also accept an OpenPNM 
+        Network object in which case it extracts all associated objects and 
+        adds them to the Controller.  In both cases it adds the Controller to
+        all object's ``controller`` attribute.
         
         Notes
         -----
         The Network (and other Core objects) do not store Algorithms, so this
-        update will not add any Algorithm objects to the Controller.  This may 
+        update will not add any Algorithm objects to the Controller.  This may
+        change.  
         '''
         if arg.__class__ == dict:
-            super(Controller,self).update(arg)
+            for item in arg.keys():
+                self[item] = arg[item]
+                arg[item]._ctrl = self
         else:
             mro = [item.__name__ for item in arg.__class__.__mro__]
             if 'GenericNetwork' in mro:

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -440,7 +440,9 @@ class Controller(dict):
         --------
         None yet
         '''
-        
+        if network._parent != None:
+            logger.error('Cannot clone a network that is already a clone')
+            return
         bak = {}
         bak.update(self)
         self.clear()
@@ -452,9 +454,12 @@ class Controller(dict):
             name = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
         for item in list(self.keys()):
             temp = self.pop(item)
-            new_name = temp.name + '|' + name
+            temp._parent = net
+            new_name = temp.name + '_' + name
             temp.name = new_name
             self[temp.name] = temp
+        # Overwrite new Network's parent with cloned Network
+        net._parent = network
         self.update(bak)
         return net
 

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -452,19 +452,18 @@ class Controller(dict):
         bak.update(self)
         self.clear()
         net = _copy.deepcopy(network)
-        net['pore.'+network.name] = network.Ps
-        net['throat.'+network.name] = network.Ts
         self.update(net)
         if name == None:
             name = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
         for item in list(self.keys()):
             temp = self.pop(item)
-            temp._parent = net
+            temp._parent = network
             new_name = temp.name + '_' + name
             temp.name = new_name
             self[temp.name] = temp
-        # Overwrite new Network's parent with cloned Network
-        net._parent = network
+        # Add parent Network numbering to clone
+        net['pore.'+network.name] = network.Ps
+        net['throat.'+network.name] = network.Ts
         self.update(bak)
         return net
 

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -218,10 +218,12 @@ class Controller(dict):
         # Remove object from simulation dict
         del self[name]
 
-    def clone_object(self,obj):
+    def ghost_object(self,obj):
         r'''
-        Clone an OpenPNM Object, without associating the new object with the
-        parent simulation.
+        Create a ghost OpenPNM Object containing all the data, methods and 
+        associations of the original object, but without registering the ghost
+        anywhere.   This ghost is intended as a disposable object, for 
+        instance, to receive simulation data without overwriting existing data.
 
         Parameters
         ----------
@@ -234,17 +236,12 @@ class Controller(dict):
         to the objects associated with the original object.  The cloned object is
         not associated with the Network.
 
-        Notes
-        -----
-        This method is intended to create a disposable object, for instance, to
-        receive simulation data without overwriting existing data.
-
         Examples
         --------
         >>> import OpenPNM
         >>> sim = OpenPNM.Base.Controller()
         >>> pn = OpenPNM.Network.TestNet()
-        >>> pn2 = sim.clone_object(pn)
+        >>> pn2 = sim.ghost_object(pn)
         >>> pn is pn2  # A clone of pn is created
         False
         >>> pn2.keys() == pn.keys()

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -32,40 +32,22 @@ class Controller(dict):
     def __str__(self):
         header = ('-'*60)
         print(header)
-        print('Networks')
+        print("{c:<10s} {a:<25s} {b:<25s}".format(a='Class', b='Name', c='Type'))
         print(header)
-        print("{a:<25s} {b:<25s}".format(a='Class', b='Object Name'))
-        print(header)
-        for item in self.network():
-            print("{a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name))
-        print(header)
-        print('Geometries')
-        print(header)
-        print("{a:<25s} {b:<25s}".format(a='Class', b='Object Name'))
+        for item in self.networks():
+            print("{c:<10s} {a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name, c='Network'))
         print(header)
         for item in self.geometries():
-            print("{a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name))
-        print(header)
-        print('Phases')
-        print(header)
-        print("{a:<25s} {b:<25s}".format(a='Class', b='Object Name'))
+            print("{c:<10s} {a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name, c='Geometry'))
         print(header)
         for item in self.phases():
-            print("{a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name))
-        print(header)
-        print('Physics')
-        print(header)
-        print("{a:<25s} {b:<25s}".format(a='Class', b='Object Name'))
+            print("{c:<10s} {a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name, c='Phase'))
         print(header)
         for item in self.physics():
-            print("{a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name))
-        print(header)
-        print('Algorithms')
-        print(header)
-        print("{a:<25s} {b:<25s}".format(a='Class', b='Object Name'))
+            print("{c:<10s} {a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name, c='Physics'))
         print(header)
         for item in self.algorithms():
-            print("{a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name))
+            print("{c:<10s} {a:<25s} {b:<25s}".format(a=item.__class__.__name__, b=item.name, c='Algorithm'))
         print(header)
         return ''
         
@@ -82,7 +64,7 @@ class Controller(dict):
         r'''
         Prints a heirarchical list of object associations
         '''
-        for net in self.network():
+        for net in self.networks():
             header = ('-'*60)
             print(header)
             print('Network: '+net.name)
@@ -340,7 +322,7 @@ class Controller(dict):
         True
         '''
         if filename == '':
-            filename = self.network()[0].name
+            filename = self.networks()[0].name
         else:
             filename = filename.split('.')[0]
 
@@ -387,12 +369,12 @@ class Controller(dict):
         '''
         import OpenPNM.Utilities.IO as io
         if fileformat == 'VTK':
-            net = self.network()[0]
+            net = self.networks()[0]
             phases = net._phases
             io.VTK.save(filename=filename,network=net,phases=phases)
             return
         if fileformat == 'MAT':
-            net = self.network()[0]
+            net = self.networks()[0]
             phases = net._phases
             io.MAT.save(filename=filename,network=net,phases=phases)
             return

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -114,13 +114,24 @@ class Core(dict):
     simulation = property(_get_sim,_set_sim)
 
     def _set_name(self,name):
-        if self._name is not None:
-            raise Exception('Renaming objects can have catastrophic consequences')
-        elif self._sim.get(name) is not None:
+        if self._sim.get(name) is not None:
             raise Exception('An object named '+name+' already exists')
         elif name is None:
             name = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
             name = self.__module__.split('.')[-1].strip('__') + '_' + name
+        elif self._name is not None:
+            logger.warning('Changing object names is tricky business')
+            objs = []
+            if self._net is not None:
+                objs.append(self._net)
+            objs.extend(self._geometries)
+            objs.extend(self._phases)
+            objs.extend(self._physics)
+            for item in objs:
+                if 'pore.'+self.name in item.keys():
+                    item['pore.'+name] = item.pop('pore.'+self.name)
+                if 'throat.'+self.name in item.keys():
+                    item['throat.'+name] = item.pop('throat.'+self.name)
         self._name = name
 
     def _get_name(self):

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -28,6 +28,7 @@ class Core(dict):
         obj._geometries = []
         obj._physics = []
         obj._net = None
+        obj._parent = None
         #Initialize ordered dict for storing property models
         obj.models = ModelsDict()
         return obj    
@@ -1108,18 +1109,23 @@ class Core(dict):
     def _map(self,element,locations,target,return_mapping=False):
         r'''
         '''
-        if self._net is None:  # self is a parent Network
-            net = self
-        else:
-            try:
-                if self._net._net is None:  # self is a subset Network
-                    net = self._net
-                else:
-                    net = self._net._net  # self is associated with a subset
-            except:
-                net = self._net  # self is associated with a parent Network
+        # Ensure parent has been assigned, which may happen to uncloned simulations
+        if self._parent == None:  
+            self._parent = self._net
+        if target._parent == None:
+            target._parent == target._net
+
+        # Initialized things            
         locations = sp.array(locations,ndmin=1)
         mapping = {}
+        
+        # Now determine how source and target are related
+        if self._parent is target._parent:  # Siblings which are not Networks
+            net = self._net
+        elif (self._net is None) and (target._parent is self):  # Siblings, self is a Network
+            net = self
+        elif target is self._net: # Siblings, and self is not a Network
+            net = self._net
 
         # Retrieve Network size masks
         maskS = net[element+'.'+self.name]

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -196,8 +196,8 @@ class Core(dict):
         if obj_name != '':
             obj = []
             if obj_name in ctrl.keys():
-                obj.append(ctrl[obj_name])
-            return obj[0]
+                obj = ctrl[obj_name]
+            return obj
         elif obj_type != '':
             if obj_type in ['Geometry','Geometries','geometry','geometries']:
                 objs = ctrl.geometries()
@@ -311,7 +311,11 @@ class Core(dict):
             else:
                 net = [self._net]
         else:
-            net = self._find_object(obj_name=name)
+            net = []
+            temp = self._find_object(obj_name=name)
+            if hasattr(temp,'_isa'):
+                if temp._isa('Network'):
+                    net = temp
         return net
 
     #--------------------------------------------------------------------------

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -290,17 +290,15 @@ class Core(dict):
     def network(self,name=''):
         r'''
         Retrieves the network associated with the object.  If the object is
-        a network, then it returns the parent network from which the present
-        object derives, or returns an empty list if it has no parents.
+        a network, then it returns a handle to itself.
 
         Parameters
         ----------
         name : string, optional
-            The name of the Geometry object to retrieve.
+            The name of the Network object to retrieve.
 
         Returns
         -------
-            If name is NOT provided, then the name of the parent is returned.
             If a name IS provided, then the parent netowrk object is returned.
 
         Notes
@@ -308,12 +306,12 @@ class Core(dict):
         This doesn't quite work yet...we have to decide how to treat sub-nets first
         '''
         if name == '':
-            try:
-                net = self._net.name
-            except:
-                net = []
+            if self._net is None:
+                net = [self]
+            else:
+                net = [self._net]
         else:
-            net = self._net
+            net = self._find_object(obj_name=name)
         return net
 
     #--------------------------------------------------------------------------

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1279,28 +1279,30 @@ class Core(dict):
         Ts = self._map(element='throat',locations=throats,target=target,return_mapping=return_mapping)
         return Ts
         
-    def _isa(self,keyword,obj=None):
+    def _isa(self,keyword=None,obj=None):
         r'''
         '''
+        if keyword is None:
+            mro = [item.__name__ for item in self.__class__.__mro__]
         if obj is None:
             query = False
             mro = [item.__name__ for item in self.__class__.__mro__]
             if keyword in ['net','Network','GenericNetwork']:
                 if 'GenericNetwork' in mro:
                     query = True
-            if keyword in ['geom','Geometry','GenericGeometry']:
+            elif keyword in ['geom','Geometry','GenericGeometry']:
                 if 'GenericGeometry' in mro:
                     query = True
-            if keyword in ['phase','Phase','GenericPhase']:
+            elif keyword in ['phase','Phase','GenericPhase']:
                 if 'GenericPhase' in mro:
                     query = True
-            if keyword in ['phys','Physics','GenericPhysics']:
+            elif keyword in ['phys','Physics','GenericPhysics']:
                 if 'GenericPhysics' in mro:
                     query = True
-            if keyword in ['alg','Algorithm','GenericAlgorithm']:
+            elif keyword in ['alg','Algorithm','GenericAlgorithm']:
                 if 'GenericAlgorithm' in mro:
                     query = True
-            if keyword in ['clone']:
+            elif keyword in ['clone']:
                 if self._net is None:
                     if self._parent is not None:
                         query = True

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -10,7 +10,7 @@ from OpenPNM.Base import logging, Tools
 from OpenPNM.Base import ModelsDict
 logger = logging.getLogger()
 from OpenPNM.Base import Controller
-sim = Controller()
+ctrl = Controller()
 
 class Core(dict):
     r'''
@@ -23,7 +23,7 @@ class Core(dict):
         obj.update({'throat.all': sp.array([],ndmin=1,dtype=bool)})
         #Initialize phase, physics, and geometry tracking lists
         obj._name = None
-        obj._sim = {}
+        obj._ctrl = {}
         obj._phases = []
         obj._geometries = []
         obj._physics = []
@@ -39,7 +39,7 @@ class Core(dict):
         super(Core,self).__init__()
         logger.debug('Initializing Core class')
         self.name = name
-        self.simulation = sim
+        self.controller = ctrl
         
     def __repr__(self):
         return '<%s.%s object at %s>' % (
@@ -102,19 +102,19 @@ class Core(dict):
                 logger.warning('Cannot write vector with an array of the wrong length: '+key)
                 pass
             
-    def _set_sim(self,simulation):
-        if self.name in simulation.keys():
+    def _set_ctrl(self,controller):
+        if self.name in controller.keys():
             raise Exception('An object with that name is already present in simulation')
-        self._sim = simulation
-        simulation.update({self.name: self})
+        self._ctrl = controller
+        controller.update({self.name: self})
 
-    def _get_sim(self):
-        return self._sim
+    def _get_ctrl(self):
+        return self._ctrl
 
-    simulation = property(_get_sim,_set_sim)
+    controller = property(_get_ctrl,_set_ctrl)
 
     def _set_name(self,name):
-        if self._sim.get(name) is not None:
+        if self._ctrl.get(name) is not None:
             raise Exception('An object named '+name+' already exists')
         elif name is None:
             name = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
@@ -194,18 +194,18 @@ class Core(dict):
         '''
         if obj_name != '':
             obj = []
-            if obj_name in sim.keys():
-                obj.append(sim[obj_name])
+            if obj_name in ctrl.keys():
+                obj.append(ctrl[obj_name])
             return obj[0]
         elif obj_type != '':
             if obj_type in ['Geometry','Geometries','geometry','geometries']:
-                objs = sim.geometries()
+                objs = ctrl.geometries()
             elif obj_type in ['Phase','Phases','phase','phases']:
-                objs = sim.phases()
+                objs = ctrl.phases()
             elif obj_type in ['Physics','physics']:
-                objs = sim.physics()
+                objs = ctrl.physics()
             elif obj_type in ['Network','Networks','network','networks']:
-                objs = sim.network()
+                objs = ctrl.network()
             return objs
 
     def physics(self,phys_name=[]):

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1142,16 +1142,16 @@ class Core(dict):
             elif self is target._parent:  # self is parent Network
                 maskS = self[element+'.all']
                 maskT = ~self[element+'.all']
-                maskT = target[element+'.'+self.name]
+                maskT[target[element+'.'+self.name]] = True
             else:
-                print('This situation has not been considered yet')
+                print('2: This situation has not been considered yet')
                 return
         elif (self._net != None) and (target._net != None):  # Neither are Networks
             if self._net is target._net:  # self and target are siblings
                 maskS = self._net[element+'.'+self.name]
                 maskT = self._net[element+'.'+target.name]
             else:
-                print('This situation has not been considered yet')
+                print('3: This situation has not been considered yet')
                 return
 
         # Convert source locations to Network indices
@@ -1245,6 +1245,11 @@ class Core(dict):
         target : OpenPNM object, optional
             The object for which a list of pores is desired.  If no object is
             supplied then the object's associated Network is used.
+            
+        return_mapping : boolean (default is False)
+            If True, a dictionary containing 'source' locations, and 'target'
+            locations is returned.  Any 'source' locations not found in the
+            'target' object are removed from the list.
 
         Returns
         -------

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -78,7 +78,7 @@ class Core(dict):
         if key.split('.')[1] in ['all']:
             if key in self.keys():
                 if sp.shape(self[key]) == (0,):
-                    logger.info(key+' is being defined.')
+                    logger.debug(key+' is being defined.')
                     super(Core, self).__setitem__(key,value)
                 else:
                     logger.warning(key+' is already defined.')
@@ -120,7 +120,7 @@ class Core(dict):
             name = ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for _ in range(5))
             name = self.__module__.split('.')[-1].strip('__') + '_' + name
         elif self._name is not None:
-            logger.warning('Changing object names is tricky business')
+            logger.info('Changing the name of '+self.name+' to '+name)
             objs = []
             if self._net is not None:
                 objs.append(self._net)

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1280,6 +1280,47 @@ class Core(dict):
                 target = self._net
         Ts = self._map(element='throat',locations=throats,target=target,return_mapping=return_mapping)
         return Ts
+        
+    def _isa(self,keyword,obj=None):
+        r'''
+        '''
+        if obj is None:
+            query = False
+            mro = [item.__name__ for item in self.__class__.__mro__]
+            if keyword in ['net','Network','GenericNetwork']:
+                if 'GenericNetwork' in mro:
+                    query = True
+            if keyword in ['geom','Geometry','GenericGeometry']:
+                if 'GenericGeometry' in mro:
+                    query = True
+            if keyword in ['phase','Phase','GenericPhase']:
+                if 'GenericPhase' in mro:
+                    query = True
+            if keyword in ['phys','Physics','GenericPhysics']:
+                if 'GenericPhysics' in mro:
+                    query = True
+            if keyword in ['alg','Algorithm','GenericAlgorithm']:
+                if 'GenericAlgorithm' in mro:
+                    query = True
+            if keyword in ['clone']:
+                if self._net is None:
+                    if self._parent is not None:
+                        query = True
+                else:
+                    if self._net._parent is not None:
+                        query = True
+            return query
+        else:
+            query = False
+            if keyword in ['sibling']:
+                if (self._isa('net')) and (obj._net is self):
+                    query = True
+                elif (obj._isa('net')) and (self._net is obj):
+                    query = True
+                elif self._net is obj._net:
+                    query = True
+            return query
+            
 
     def check_data_health(self,props=[],element='',quiet=False):
         r'''

--- a/OpenPNM/Base/__ModelsDict__.py
+++ b/OpenPNM/Base/__ModelsDict__.py
@@ -68,13 +68,13 @@ class GenericModel(dict):
         return self['model'](**kwargs)
         
     def _find_master(self):
-        sim = Controller()
+        ctrl = Controller()
         master = []
-        for item in sim.keys():
-            if sim[item].models is not None:
-                for model in sim[item].models.keys():
-                    if sim[item].models[model] is self:
-                        master.append(sim[item])
+        for item in ctrl.keys():
+            if ctrl[item].models is not None:
+                for model in ctrl[item].models.keys():
+                    if ctrl[item].models[model] is self:
+                        master.append(ctrl[item])
         if len(master) > 1:
             raise Exception('More than one master found! This model dictionary has been associated with multiple objects. To use the same dictionary multiple times use the copy method.')
         return master[0]
@@ -312,11 +312,11 @@ class ModelsDict(OrderedDict):
             self.move_to_end(item)
         
     def _find_master(self):
-        sim = Controller()
+        ctrl = Controller()
         master = []
-        for item in sim.keys():
-            if sim[item].models is self:
-                master.append(sim[item])
+        for item in ctrl.keys():
+            if ctrl[item].models is self:
+                master.append(ctrl[item])
         if len(master) > 1:
             raise Exception('More than one master found! This model dictionary has been associated with multiple objects. To use the same dictionary multiple times use the copy method.')
         return master[0]

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -723,6 +723,9 @@ class GenericNetwork(Core):
         296
 
         '''
+        for net in self.controller.networks():
+            if net._parent is self:
+                raise Exception('This Network has been cloned, cannot trim')
 
         if pores != []:
             pores = sp.array(pores,ndmin=1)

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -51,7 +51,13 @@ class GenericNetwork(Core):
             return self._interleave_data(key,self.geometries())
         else:
             return super(GenericNetwork,self).__getitem__(key)
-
+            
+    def _set_net(self,network):
+        pass
+    def _get_net(self):
+        return self
+    _net = property(fset=_set_net,fget=_get_net)
+    
     #--------------------------------------------------------------------------
     '''Graph Theory and Network Query Methods'''
     #--------------------------------------------------------------------------

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -747,12 +747,14 @@ class GenericNetwork(Core):
             item.update({'pore.all' : sp.ones((sp.sum(Pnet),),dtype=bool)})
             item.update({'throat.all' : sp.ones((sp.sum(Tnet),),dtype=bool)})
             # Overwrite remaining data and info
-            for key in item.keys():
+            for key in list(item.keys()):
                 if key.split('.')[1] not in ['all']:
                     temp = item.pop(key)
                     if key.split('.')[0] == 'throat':
+                        logger.debug('Trimming {a} from {b}'.format(a=key,b=item.name))
                         item[key] = temp[Ts]
                     if key.split('.')[0] == 'pore':
+                        logger.debug('Trimming {a} from {b}'.format(a=key,b=item.name))
                         item[key] = temp[Ps]
 
         #Remap throat connections
@@ -768,12 +770,14 @@ class GenericNetwork(Core):
         # Write throat connections specifically
         self.update({'throat.conns' : sp.vstack((Tnew1,Tnew2)).T})
         # Overwrite remaining data and info
-        for item in self.keys():
+        for item in list(self.keys()):
             if item.split('.')[-1] not in ['conns','all']:
                 temp = self.pop(item)
                 if item.split('.')[0] == 'throat':
+                    logger.debug('Trimming {a} from {b}'.format(a=item,b=self.name))
                     self[item] = temp[Tkeep]
                 if item.split('.')[0] == 'pore':
+                    logger.debug('Trimming {a} from {b}'.format(a=item,b=self.name))
                     self[item] = temp[Pkeep]
 
         #Reset network graphs

--- a/run_script.py
+++ b/run_script.py
@@ -1,7 +1,7 @@
 import OpenPNM
 print('-----> Using OpenPNM version: '+OpenPNM.__version__)
 
-sim = OpenPNM.Base.Controller()
+ctrl = OpenPNM.Base.Controller()
 #==============================================================================
 '''Build Topological Network'''
 #==============================================================================

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -4,30 +4,33 @@ import OpenPNM
 import pytest
 
 def test_controller():
+    # The following tests check if the Controller's ghost, save, load and clear methods work
     ctrl = OpenPNM.Base.Controller()
+    ctrl.clear()  # Clear controller to make sure it has not lingering objects
+    ctrl.loglevel = 50
     pn = OpenPNM.Network.TestNet()
     geom = OpenPNM.Geometry.TestGeometry(network=pn,pores=pn.Ps,throats=pn.Ts)
     loc1 = geom.__repr__()
     loc2 = ctrl[geom.name].__repr__()
-    assert loc1 == loc2
-    geom2 = ctrl.clone_object(geom)
+    assert loc1 == loc2  # Ensure both locations hold same object
+    geom2 = ctrl.ghost_object(geom)  # Create a ghost object
     loc3 = geom2.__repr__()
-    assert geom.__repr__() == loc1
-    assert loc3 != loc1
-    ctrl.save('test_net')
-    ctrl.clear()
+    assert geom.__repr__() == loc1  # Ensure geom is still same object
+    assert loc3 != loc1  # Ensure identities are not getting swapped
+    ctrl.save('test_net')  # Save current state
+    ctrl.clear()  # Clear Controller
     assert ctrl.keys() == {}.keys()  # Empty dict
-    assert pn.simulation == {}  # Controller is now an empty dict
-    assert geom.simulation is pn.simulation  # Share a common dict
-    ctrl.load('test_net')
+    assert pn.controller == {}  # Controller is now an empty dict
+    assert geom.controller == pn.controller  # Both have empty dict's
+    ctrl.load('test_net')  # Load saved state
     assert pn.name in ctrl.keys()  # Ensure loaded objects match originals
     assert geom.name in ctrl.keys()
-    pn2 = ctrl.network()[0]  # Retrieve loaded Network from the Controller dict
+    pn2 = ctrl[pn.name]  # Retrieve loaded Network from the Controller dict
     assert pn is not pn2  # They have the same properties, but are different objects
-    geom2 = ctrl.geometries()[0]  # Retrieve Geometry from Controller
+    geom2 = ctrl[geom.name]  # Retrieve Geometry from Controller
     assert 'pore.'+geom2.name in pn2.keys()  # Confirm Geometry label is in Network
     ctrl.purge_object(geom2)  # Purge Geometry from simulation
-    assert geom2.name not in ctrl.keys()  # Geometry is purges from Controller
+    assert geom2.name not in ctrl.keys()  # Geometry is purged from Controller
     assert 'pore.'+geom2.name not in pn2.keys()  # Geometry label is removed from Simulation objects too
     
 def test_cubic_standard_call():


### PR DESCRIPTION
Major upgrades to allow for cloning simulations (i.e. subnets).  This involved redoing the clone_simulation method on the Controller object, and adjustments to the map_pores/throats on the Core object.  Numerous other changes were required to make this work.  Some other useful changes were also made during this process that were a bit tangential but related.  