### PR TITLE
Feature source updates

### DIFF
--- a/OpenPNM/Physics/models/generic_source_term.py
+++ b/OpenPNM/Physics/models/generic_source_term.py
@@ -9,563 +9,556 @@ import scipy as _sp
 
 def linear(physics,
            phase,
-           A1=0,
-           A2=0,
-           x=None,
+           A1='',
+           A2='',
+           x='',
+           return_rate=True,
            **kwargs):
     r"""
     For the following source term:
         .. math::
             r = A_{1}   x  +  A_{2} 
-    It returns the slope and intercept for the corresponding pores                 
+    If return_rate is True, it returns the value of source term for the provided x in each pore. 
+    If return_rate is False, it calculates the slope and intercept for the following linear form :                 
+        .. math::            
+            r = S_{1}   x  +  S_{2}               
 
     Parameters
     ----------
-    A1, A2 : float or array
-        These are the kinetic constants to be applied.  With A2 set to zero
-        this equation takes on the familiar for of r=kx, where k is A1.  
-        
+    A1 , A2 : string
+        The property name of the coefficients in the source term model. With A2 set to zero
+        this equation takes on the familiar for of r=kx.  
+    x : string or float/int or array/list
+        The property name or numerical value or array for the main quantity
     Notes
-    -----
-    It is possible to change the values of these constants at a later point.
-    The values are stored in the Physics object's models dictionary under the
-    chosen ``propname``.  The individual constants can be acesses as:
-    phys.models[propname][A1].    
-    
+    -----    
     Because this source term is linear in concentration (x) is it not necessary
     to iterate during the solver step.  Thus, when using the 
-    ``set_source_term`` method it is recommended to set the ``maxiter`` 
+    ``set_source_term`` method for an algorithm, it is recommended to set the ``maxiter`` 
     argument to 0.  This will save 1 unncessary solution of the system, since
     the solution would coverge after the first pass anyway.  
     
     """
-    length_A1 = _sp.size(A1)
-    length_A2 = _sp.size(A2)
-
-    if length_A1==physics.Np:
-        S1 = A1
-    elif length_A1==1:
-        S1 = A1*_sp.ones(physics.Np)        
-    elif length_A1>=phase.Np:
-        S1 = A1[physics.map_pores()]   
+    if x=='':   
+        X = _sp.ones(physics.Np)*_sp.nan
     else:
-        raise Exception('Wrong size for the parameter A1!') 
+        if type(x)==str:
+            x = 'pore.'+x.split('.')[-1]
+            try:    X = physics[x]
+            except: raise Exception(physics.name+' does not have the pore property :'+x+'!')
+        else:
+            X = _sp.array(x)      
 
-    if length_A2==physics.Np:
-        S2 = A2
-    elif length_A2==1:
-        S2 = A2*_sp.ones(physics.Np)        
-    elif length_A2>=phase.Np:
-        S2 = A2[physics.map_pores()]   
+    length_X = _sp.size(X)
+    if length_X!=physics.Np:
+        if length_X==1:
+            X = X*_sp.ones(physics.Np) 
+        elif length_X>=phase.Np:
+            X = X[physics.map_pores()] 
+        else:   raise Exception('Wrong size for the numerical array of x!')     
+
+    if A1 == '':    a1 = 0
     else:
-        raise Exception('Wrong size for the parameter A2!') 
-    
-    r = _sp.vstack((S1,S2)).T
-    return r
+        if type(A1)==str:
+            A1 = 'pore.'+A1.split('.')[-1]
+            try:    a1 = physics[A1]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A1+'!')
+        else:  raise Exception('A1 can be only string!')
+
+    if A2 == '':    a2 = 0
+    else:
+        if type(A2)==str:
+            A2 = 'pore.'+A2.split('.')[-1]
+            try:    a2 = physics[A2]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A2+'!')
+        else:  raise Exception('A2 can be only string!')
+
+    if return_rate:
+        return(a1*X**a2)
+    else:
+        S1 = a1
+        S2 = a2
+        return(_sp.vstack((S1,S2)).T)   
 
 def power_law(physics,
             phase,
-            A1=0,
-            A2=0,
-            A3=0,
-            x=None,        
+            A1='',
+            A2='',
+            A3='',
+            x='',
+            return_rate=True,
             **kwargs):
     r"""
     For the following source term:
         .. math::
             r = A_{1}   x^{A_{2}}  +  A_{3}
-    It calculates the slope and intercept for the following linear form:                 
+    If return_rate is True, it returns the value of source term for the provided x in each pore. 
+    If return_rate is False, it calculates the slope and intercept for the following linear form :                 
         .. math::            
             r = S_{1}   x  +  S_{2} 
     
     Parameters
     ----------
-    A1 -> A3 : float or array
-        The numerical values of the source term model's constant coefficients
-        
+    A1 -> A3 : string
+        The property name of the coefficients in the source term model
+    x : string or float/int or array/list
+        The property name or numerical value or array for the main quantity
     Notes
     -----
-    It is possible to change the values of these constants at a later point.
-    The values are stored in the Physics object's models dictionary under the
-    chosen ``propname``.  The individual constants can be acesses as:
-    phys.models[propname][A1].
     
     """
-    if x is None:   
-        X = _sp.zeros(physics.Np)
-        length_X = _sp.size(x)
+    if x=='':   
+        X = _sp.ones(physics.Np)*_sp.nan
+#        length_X = _sp.size(x)
     else:
-        length_X = _sp.size(x)
-        if length_X==physics.Np:
-            X = x
-        elif length_X==1:
-            X = x*_sp.ones(physics.Np) 
+        if type(x)==str:
+            x = 'pore.'+x.split('.')[-1]
+            try:    X = physics[x]
+            except: raise Exception(physics.name+' does not have the pore property :'+x+'!')
+        else:
+            X = _sp.array(x)      
+
+    length_X = _sp.size(X)
+    if length_X!=physics.Np:
+        if length_X==1:
+            X = X*_sp.ones(physics.Np) 
         elif length_X>=phase.Np:
-            X = x[physics.map_pores()] 
-        else:   raise Exception('Wrong size for the guess value!')     
+            X = X[physics.map_pores()] 
+        else:   raise Exception('Wrong size for the numerical array of x!')     
 
-    length_A1 = _sp.size(A1)
-    length_A2 = _sp.size(A2)
-    length_A3 = _sp.size(A3)
-
-    if length_A1==physics.Np:
-        a1 = A1
-    elif length_A1==1:
-        a1 = A1*_sp.ones(physics.Np)        
-    elif length_A1>=phase.Np:
-        a1 = A1[physics.map_pores()]   
+    if A1 == '':    a1 = 0
     else:
-        raise Exception('Wrong size for the parameter A1!') 
+        if type(A1)==str:
+            A1 = 'pore.'+A1.split('.')[-1]
+            try:    a1 = physics[A1]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A1+'!')
+        else:  raise Exception('A1 can be only string!')
 
-    if length_A2==physics.Np:
-        a2 = A2
-    elif length_A2==1:
-        a2 = A2*_sp.ones(physics.Np)        
-    elif length_A2>=phase.Np:
-        a2 = A2[physics.map_pores()]   
+    if A2 == '':    a2 = 0
     else:
-        raise Exception('Wrong size for the parameter A2!') 
+        if type(A2)==str:
+            A2 = 'pore.'+A2.split('.')[-1]
+            try:    a2 = physics[A2]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A2+'!')
+        else:  raise Exception('A2 can be only string!')
 
-    if length_A3==physics.Np:
-        a3 = A3
-    elif length_A3==1:
-        a3 = A3*_sp.ones(physics.Np)        
-    elif length_A3>=phase.Np:
-        a3 = A3[physics.map_pores()]   
+    if A3 == '':    a3 = 0
     else:
-        raise Exception('Wrong size for the parameter A3!') 
- 
-    S1 = a1*a2*X**(a2-1)
-    S2 = a1*X**a2*(1-a2)+a3
-    r = _sp.vstack((S1,S2)).T    
-    return r
+        if type(A3)==str:
+            A3 = 'pore.'+A3.split('.')[-1]
+            try:    a3 = physics[A3]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A3+'!')
+        else:  raise Exception('A3 can be only string!')
+
+    if return_rate:
+        return(a1*X**a2 +a3)
+    else:
+        S1 = a1*a2*X**(a2-1)
+        S2 = a1*X**a2*(1-a2)+a3
+        return(_sp.vstack((S1,S2)).T)    
+
 
 def exponential(physics,
-                phase,
-                A1=0,
-                A2=0,
-                A3=0,
-                A4=0,
-                A5=0,
-                A6=0,
-                x=None,        
-                **kwargs):
+            phase,
+            A1='',
+            A2='',
+            A3='',
+            A4='',
+            A5='',
+            A6='',
+            x='',
+            return_rate=True,
+            **kwargs):
     r"""
     For the following source term:
         .. math::
             r =  A_{1} A_{2}^{( A_{3} x^{ A_{4} } + A_{5})} + A_{6} 
-    It calculates the slope and intercept for the following linear form:                 
+    If return_rate is True, it returns the value of source term for the provided x in each pore. 
+    If return_rate is False, it calculates the slope and intercept for the following linear form :                 
         .. math::            
             r = S_{1}   x  +  S_{2} 
     
     Parameters
     ----------
-    A1 -> A6 : float or array
-        The numerical values of the source term model's constant coefficients
-    
+    A1 -> A6 : string
+        The property name of the coefficients in the source term model
+    x : string or float/int or array/list
+        The property name or numerical value or array for the main quantity
     Notes
     -----
-    It is possible to change the values of these constants at a later point.
-    The values are stored in the Physics object's models dictionary under the
-    chosen ``propname``.  The individual constants can be acesses as:
-    phys.models[propname][A1].
     
-    """        
-    
-    if x is None:   
-        X = _sp.zeros(physics.Np)
-        length_X = _sp.size(x)
+    """
+    if x=='':   
+        X = _sp.ones(physics.Np)*_sp.nan
+#        length_X = _sp.size(x)
     else:
-        length_X = _sp.size(x)
-        if length_X==physics.Np:
-            X = x
-        elif length_X==1:
-            X = x*_sp.ones(physics.Np)  
+        if type(x)==str:
+            x = 'pore.'+x.split('.')[-1]
+            try:    X = physics[x]
+            except: raise Exception(physics.name+' does not have the pore property :'+x+'!')
+        else:
+            X = _sp.array(x)      
+
+    length_X = _sp.size(X)
+    if length_X!=physics.Np:
+        if length_X==1:
+            X = X*_sp.ones(physics.Np) 
         elif length_X>=phase.Np:
-            X = x[physics.map_pores()] 
-        else:   raise Exception('Wrong size for the guess value!')     
+            X = X[physics.map_pores()] 
+        else:   raise Exception('Wrong size for the numerical array of x!')     
 
-    length_A1 = _sp.size(A1)
-    length_A2 = _sp.size(A2)
-    length_A3 = _sp.size(A3)
-    length_A4 = _sp.size(A4)
-    length_A5 = _sp.size(A5)
-    length_A6 = _sp.size(A6)
-
-    if length_A1==physics.Np:
-        a1 = A1
-    elif length_A1==1:
-        a1 = A1*_sp.ones(physics.Np)        
-    elif length_A1>=phase.Np:
-        a1 = A1[physics.map_pores()]   
+    if A1 == '':    a1 = 1
     else:
-        raise Exception('Wrong size for the parameter A1!') 
+        if type(A1)==str:
+            A1 = 'pore.'+A1.split('.')[-1]
+            try:    a1 = physics[A1]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A1+'!')
+        else:  raise Exception('A1 can be only string!')
 
-    if length_A2==physics.Np:
-        a2 = A2
-    elif length_A2==1:
-        a2 = A2*_sp.ones(physics.Np)        
-    elif length_A2>=phase.Np:
-        a2 = A2[physics.map_pores()]   
+    if A2 == '':    a2 = 0
     else:
-        raise Exception('Wrong size for the parameter A2!') 
+        if type(A2)==str:
+            A2 = 'pore.'+A2.split('.')[-1]
+            try:    a2 = physics[A2]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A2+'!')
+        else:  raise Exception('A2 can be only string!')
 
-    if length_A3==physics.Np:
-        a3 = A3
-    elif length_A3==1:
-        a3 = A3*_sp.ones(physics.Np)        
-    elif length_A3>=phase.Np:
-        a3 = A3[physics.map_pores()]   
+    if A3 == '':    a3 = 0
     else:
-        raise Exception('Wrong size for the parameter A3!')  
+        if type(A3)==str:
+            A3 = 'pore.'+A3.split('.')[-1]
+            try:    a3 = physics[A3]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A3+'!')
+        else:  raise Exception('A3 can be only string!')
 
-    if length_A4==physics.Np:
-        a4 = A4
-    elif length_A4==1:
-        a4 = A4*_sp.ones(physics.Np)        
-    elif length_A4>=phase.Np:
-        a4 = A4[physics.map_pores()]   
-    else:
-        raise Exception('Wrong size for the parameter A4!') 
-        
-        
-    if length_A5==physics.Np:
-        a5 = A5
-    elif length_A5==1:
-        a5 = A5*_sp.ones(physics.Np)        
-    elif length_A5>=phase.Np:
-        a5 = A5[physics.map_pores()]   
-    else:
-        raise Exception('Wrong size for the parameter A5!')         
 
-    if length_A6==physics.Np:
-        a6 = A6
-    elif length_A6==1:
-        a6 = A6*_sp.ones(physics.Np)        
-    elif length_A6>=phase.Np:
-        a6 = A6[physics.map_pores()]   
+    if A4 == '':    a4 = 0
     else:
-        raise Exception('Wrong size for the parameter A6!') 
+        if type(A4)==str:
+            A4 = 'pore.'+A4.split('.')[-1]
+            try:    a4 = physics[A4]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A4+'!')
+        else:  raise Exception('A4 can be only string!')
 
-    S1 = a1*a3*a4*_sp.log(a2)*a2**(a3*X**a4+a5)*X**(a4-1)
-    S2 = a1*a2**(a3*X**a4+a5)*(1-a3*a4*_sp.log(a2)*X**a4)+a6
-    r = _sp.vstack((S1,S2)).T    
-    return r
+    if A5 == '':    a5 = 0
+    else:
+        if type(A5)==str:
+            A5 = 'pore.'+A5.split('.')[-1]
+            try:    a5 = physics[A5]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A5+'!')
+        else:  raise Exception('A5 can be only string!')
+
+    if A6 == '':    a6 = 0
+    else:
+        if type(A6)==str:
+            A6 = 'pore.'+A6.split('.')[-1]
+            try:    a6 = physics[A6]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A6+'!')
+        else:  raise Exception('A6 can be only string!')
+
+    if return_rate:
+        return(a1*a2**(a3*X**a4 +a5)+a6)
+    else:
+        S1 = a1*a3*a4*_sp.log(a2)*a2**(a3*X**a4+a5)*X**(a4-1)
+        S2 = a1*a2**(a3*X**a4+a5)*(1-a3*a4*_sp.log(a2)*X**a4)+a6
+        return(_sp.vstack((S1,S2)).T) 
 
 
 def natural_exponential(physics,
                         phase,
-                        A1=0,
-                        A2=0,
-                        A3=0,
-                        A4=0,
-                        A5=0,
-                        x=None,        
+                        A1='',
+                        A2='',
+                        A3='',
+                        A4='',
+                        A5='',
+                        x='',
+                        return_rate=True,
                         **kwargs):
     r"""
     For the following source term:
         .. math::
             r =   A_{1} exp( A_{2}  x^{ A_{3} } + A_{4} )+ A_{5} 
-    It calculates the slope and intercept for the following linear form:                 
+    If return_rate is True, it returns the value of source term for the provided x in each pore. 
+    If return_rate is False, it calculates the slope and intercept for the following linear form :                 
         .. math::            
             r = S_{1}   x  +  S_{2} 
     
     Parameters
     ----------
-    A1 -> A5 : float or array
-        The numerical values of the source term model's constant coefficients
-    
+    A1 -> A5 : string
+        The property name of the coefficients in the source term model
+    x : string or float/int or array/list
+        The property name or numerical value or array for the main quantity
     Notes
     -----
-    It is possible to change the values of these constants at a later point.
-    The values are stored in the Physics object's models dictionary under the
-    chosen ``propname``.  The individual constants can be acesses as:
-    phys.models[propname][A1].
     
-    """        
-    
-    if x is None:   
-        X = _sp.zeros(physics.Np)
-        length_X = _sp.size(x)
+    """
+    if x=='':   
+        X = _sp.ones(physics.Np)*_sp.nan
+#        length_X = _sp.size(x)
     else:
-        length_X = _sp.size(x)
-        if length_X==physics.Np:
-            X = x
-        elif length_X==1:
-            X = x*_sp.ones(physics.Np)  
+        if type(x)==str:
+            x = 'pore.'+x.split('.')[-1]
+            try:    X = physics[x]
+            except: raise Exception(physics.name+' does not have the pore property :'+x+'!')
+        else:
+            X = _sp.array(x)      
+
+    length_X = _sp.size(X)
+    if length_X!=physics.Np:
+        if length_X==1:
+            X = X*_sp.ones(physics.Np) 
         elif length_X>=phase.Np:
-            X = x[physics.map_pores()] 
-        else:   raise Exception('Wrong size for the guess value!')     
+            X = X[physics.map_pores()] 
+        else:   raise Exception('Wrong size for the numerical array of x!')     
 
-    length_A1 = _sp.size(A1)
-    length_A2 = _sp.size(A2)
-    length_A3 = _sp.size(A3)
-    length_A4 = _sp.size(A4)
-    length_A5 = _sp.size(A5)
-
-    if length_A1==physics.Np:
-        a1 = A1
-    elif length_A1==1:
-        a1 = A1*_sp.ones(physics.Np)        
-    elif length_A1>=phase.Np:
-        a1 = A1[physics.map_pores()]   
+    if A1 == '':    a1 = 1
     else:
-        raise Exception('Wrong size for the parameter A1!') 
+        if type(A1)==str:
+            A1 = 'pore.'+A1.split('.')[-1]
+            try:    a1 = physics[A1]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A1+'!')
+        else:  raise Exception('A1 can be only string!')
 
-    if length_A2==physics.Np:
-        a2 = A2
-    elif length_A2==1:
-        a2 = A2*_sp.ones(physics.Np)        
-    elif length_A2>=phase.Np:
-        a2 = A2[physics.map_pores()]   
+    if A2 == '':    a2 = 0
     else:
-        raise Exception('Wrong size for the parameter A2!') 
+        if type(A2)==str:
+            A2 = 'pore.'+A2.split('.')[-1]
+            try:    a2 = physics[A2]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A2+'!')
+        else:  raise Exception('A2 can be only string!')
 
-    if length_A3==physics.Np:
-        a3 = A3
-    elif length_A3==1:
-        a3 = A3*_sp.ones(physics.Np)        
-    elif length_A3>=phase.Np:
-        a3 = A3[physics.map_pores()]   
+    if A3 == '':    a3 = 0
     else:
-        raise Exception('Wrong size for the parameter A3!')  
+        if type(A3)==str:
+            A3 = 'pore.'+A3.split('.')[-1]
+            try:    a3 = physics[A3]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A3+'!')
+        else:  raise Exception('A3 can be only string!')
 
-    if length_A4==physics.Np:
-        a4 = A4
-    elif length_A4==1:
-        a4 = A4*_sp.ones(physics.Np)        
-    elif length_A4>=phase.Np:
-        a4 = A4[physics.map_pores()]   
+
+    if A4 == '':    a4 = 0
     else:
-        raise Exception('Wrong size for the parameter A4!') 
-        
-        
-    if length_A5==physics.Np:
-        a5 = A5
-    elif length_A5==1:
-        a5 = A5*_sp.ones(physics.Np)        
-    elif length_A5>=phase.Np:
-        a5 = A5[physics.map_pores()]   
+        if type(A4)==str:
+            A4 = 'pore.'+A4.split('.')[-1]
+            try:    a4 = physics[A4]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A4+'!')
+        else:  raise Exception('A4 can be only string!')
+
+    if A5 == '':    a5 = 0
     else:
-        raise Exception('Wrong size for the parameter A5!')         
+        if type(A5)==str:
+            A5 = 'pore.'+A5.split('.')[-1]
+            try:    a5 = physics[A5]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A5+'!')
+        else:  raise Exception('A5 can be only string!')
 
+    if return_rate:
+        return(a1*_sp.exp(a2*X**a3+a4) +a5)
+    else:
+        S1 = a1*a2*a3*X**(a3-1)*_sp.exp(a2*X**a3+a4)
+        S2 = a1*_sp.exp(a2*X**a3+a4)*(1-a2*a3*X**a3)+a5
+        return(_sp.vstack((S1,S2)).T) 
 
-    S1 = a1*a2*a3*X**(a3-1)*_sp.exp(a2*X**a3+a4)
-    S2 = a1*_sp.exp(a2*X**a3+a4)*(1-a2*a3*X**a3)+a5
-    r = _sp.vstack((S1,S2)).T    
-    return r
-    
-    
 def logarithm(physics,
-              phase,
-              A1=0,
-              A2=0,
-              A3=0,
-              A4=0,
-              A5=0,
-              A6=0,
-              x=None,        
-              **kwargs):
+            phase,
+            A1='',
+            A2='',
+            A3='',
+            A4='',
+            A5='',
+            A6='',
+            x='',
+            return_rate=True,
+            **kwargs):
     r"""
     For the following source term:
         .. math::
             r =  A_{1}   Log_{ A_{2} }( A_{3} x^{ A_{4} }+ A_{5})+ A_{6}  
-    It calculates the slope and intercept for the following linear form:                 
+    If return_rate is True, it returns the value of source term for the provided x in each pore. 
+    If return_rate is False, it calculates the slope and intercept for the following linear form :                 
         .. math::            
             r = S_{1}   x  +  S_{2} 
     
     Parameters
     ----------
-    A1 -> A6 : float or array
-        The numerical values of the source term model's constant coefficients
-    
+    A1 -> A6 : string
+        The property name of the coefficients in the source term model
+    x : string or float/int or array/list
+        The property name or numerical value or array for the main quantity
     Notes
     -----
-    It is possible to change the values of these constants at a later point.
-    The values are stored in the Physics object's models dictionary under the
-    chosen ``propname``.  The individual constants can be acesses as:
-    phys.models[propname][A1].
     
-    """     
-    
-    if x is None:   
-        X = _sp.zeros(physics.Np)
-        length_X = _sp.size(x)
+    """
+    if x=='':   
+        X = _sp.ones(physics.Np)*_sp.nan
+#        length_X = _sp.size(x)
     else:
-        length_X = _sp.size(x)
-        if length_X==physics.Np:
-            X = x
-        elif length_X==1:
-            X = x*_sp.ones(physics.Np)  
+        if type(x)==str:
+            x = 'pore.'+x.split('.')[-1]
+            try:    X = physics[x]
+            except: raise Exception(physics.name+' does not have the pore property :'+x+'!')
+        else:
+            X = _sp.array(x)      
+
+    length_X = _sp.size(X)
+    if length_X!=physics.Np:
+        if length_X==1:
+            X = X*_sp.ones(physics.Np) 
         elif length_X>=phase.Np:
-            X = x[physics.map_pores()] 
-        else:   raise Exception('Wrong size for the guess value!')     
+            X = X[physics.map_pores()] 
+        else:   raise Exception('Wrong size for the numerical array of x!')     
 
-    length_A1 = _sp.size(A1)
-    length_A2 = _sp.size(A2)
-    length_A3 = _sp.size(A3)
-    length_A4 = _sp.size(A4)
-    length_A5 = _sp.size(A5)
-    length_A6 = _sp.size(A6)
-
-    if length_A1==physics.Np:
-        a1 = A1
-    elif length_A1==1:
-        a1 = A1*_sp.ones(physics.Np)        
-    elif length_A1>=phase.Np:
-        a1 = A1[physics.map_pores()]   
+    if A1 == '':    a1 = 1
     else:
-        raise Exception('Wrong size for the parameter A1!') 
+        if type(A1)==str:
+            A1 = 'pore.'+A1.split('.')[-1]
+            try:    a1 = physics[A1]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A1+'!')
+        else:  raise Exception('A1 can be only string!')
 
-    if length_A2==physics.Np:
-        a2 = A2
-    elif length_A2==1:
-        a2 = A2*_sp.ones(physics.Np)        
-    elif length_A2>=phase.Np:
-        a2 = A2[physics.map_pores()]   
+    if A2 == '':    a2 = 0
     else:
-        raise Exception('Wrong size for the parameter A2!') 
+        if type(A2)==str:
+            A2 = 'pore.'+A2.split('.')[-1]
+            try:    a2 = physics[A2]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A2+'!')
+        else:  raise Exception('A2 can be only string!')
 
-    if length_A3==physics.Np:
-        a3 = A3
-    elif length_A3==1:
-        a3 = A3*_sp.ones(physics.Np)        
-    elif length_A3>=phase.Np:
-        a3 = A3[physics.map_pores()]   
+    if A3 == '':    a3 = 0
     else:
-        raise Exception('Wrong size for the parameter A3!')  
+        if type(A3)==str:
+            A3 = 'pore.'+A3.split('.')[-1]
+            try:    a3 = physics[A3]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A3+'!')
+        else:  raise Exception('A3 can be only string!')
 
-    if length_A4==physics.Np:
-        a4 = A4
-    elif length_A4==1:
-        a4 = A4*_sp.ones(physics.Np)        
-    elif length_A4>=phase.Np:
-        a4 = A4[physics.map_pores()]   
+
+    if A4 == '':    a4 = 0
     else:
-        raise Exception('Wrong size for the parameter A4!') 
+        if type(A4)==str:
+            A4 = 'pore.'+A4.split('.')[-1]
+            try:    a4 = physics[A4]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A4+'!')
+        else:  raise Exception('A4 can be only string!')
+
+    if A5 == '':    a5 = 0
+    else:
+        if type(A5)==str:
+            A5 = 'pore.'+A5.split('.')[-1]
+            try:    a5 = physics[A5]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A5+'!')
+        else:  raise Exception('A5 can be only string!')
+
+    if A6 == '':    a6 = 0
+    else:
+        if type(A6)==str:
+            A6 = 'pore.'+A6.split('.')[-1]
+            try:    a6 = physics[A6]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A6+'!')
+        else:  raise Exception('A6 can be only string!')
+
+    if return_rate:
+        return(a1*_sp.log(a3*X**a4 +a5)/_sp.log(a2)+a6)
+    else:
+        S1 = a1*a3*a4*X**(a4-1)/(_sp.log(a2)*(a3*X**a4+a5))
+        S2 = a1*_sp.log(a3*X**a4+a5)/_sp.log(a2)+a6-a1*a3*a4*X**a4/(_sp.log(a2)*(a3*X**a4+a5))
+        return(_sp.vstack((S1,S2)).T) 
         
-        
-    if length_A5==physics.Np:
-        a5 = A5
-    elif length_A5==1:
-        a5 = A5*_sp.ones(physics.Np)        
-    elif length_A5>=phase.Np:
-        a5 = A5[physics.map_pores()]   
-    else:
-        raise Exception('Wrong size for the parameter A5!')         
 
-    if length_A6==physics.Np:
-        a6 = A6
-    elif length_A6==1:
-        a6 = A6*_sp.ones(physics.Np)        
-    elif length_A6>=phase.Np:
-        a6 = A6[physics.map_pores()]   
-    else:
-        raise Exception('Wrong size for the parameter A6!') 
-
-    S1 = a1*a3*a4*X**(a4-1)/(_sp.log(a2)*(a3*X**a4+a5))
-    S2 = a1*_sp.log(a3*X**a4+a5)/_sp.log(a2)+a6-a1*a3*a4*X**a4/(_sp.log(a2)*(a3*X**a4+a5))
-    r = _sp.vstack((S1,S2)).T    
-    return r
-    
 def natural_logarithm(physics,
                       phase,
-                      A1=0,
-                      A2=0,
-                      A3=0,
-                      A4=0,
-                      A5=0,
-                      x=None,        
+                      A1='',
+                      A2='',
+                      A3='',
+                      A4='',
+                      A5='',
+                      x='',
+                      return_rate=True,
                       **kwargs):
     r"""
     For the following source term:
         .. math::
             r =   A_{1}  Ln( A_{2} x^{ A_{3} }+ A_{4})+ A_{5}    
-    It calculates the slope and intercept for the following linear form:                 
+    If return_rate is True, it returns the value of source term for the provided x in each pore. 
+    If return_rate is False, it calculates the slope and intercept for the following linear form :                 
         .. math::            
             r = S_{1}   x  +  S_{2} 
     
     Parameters
     ----------
-    A1 -> A5 : float or array
-        The numerical values of the source term model's constant coefficients
-    
+    A1 -> A5 : string
+        The property name of the coefficients in the source term model
+    x : string or float/int or array/list
+        The property name or numerical value or array for the main quantity
     Notes
     -----
-    It is possible to change the values of these constants at a later point.
-    The values are stored in the Physics object's models dictionary under the
-    chosen ``propname``.  The individual constants can be acesses as:
-    phys.models[propname][A1].
     
-    """         
-    
-    if x is None:   
-        X = _sp.zeros(physics.Np)
-        length_X = _sp.size(x)
+    """
+    if x=='':   
+        X = _sp.ones(physics.Np)*_sp.nan
+#        length_X = _sp.size(x)
     else:
-        length_X = _sp.size(x)
-        if length_X==physics.Np:
-            X = x
-        elif length_X==1:
-            X = x*_sp.ones(physics.Np)  
+        if type(x)==str:
+            x = 'pore.'+x.split('.')[-1]
+            try:    X = physics[x]
+            except: raise Exception(physics.name+' does not have the pore property :'+x+'!')
+        else:
+            X = _sp.array(x)      
+
+    length_X = _sp.size(X)
+    if length_X!=physics.Np:
+        if length_X==1:
+            X = X*_sp.ones(physics.Np) 
         elif length_X>=phase.Np:
-            X = x[physics.map_pores()] 
-        else:   raise Exception('Wrong size for the guess value!')     
+            X = X[physics.map_pores()] 
+        else:   raise Exception('Wrong size for the numerical array of x!')     
 
-    length_A1 = _sp.size(A1)
-    length_A2 = _sp.size(A2)
-    length_A3 = _sp.size(A3)
-    length_A4 = _sp.size(A4)
-    length_A5 = _sp.size(A5)
-
-    if length_A1==physics.Np:
-        a1 = A1
-    elif length_A1==1:
-        a1 = A1*_sp.ones(physics.Np)        
-    elif length_A1>=phase.Np:
-        a1 = A1[physics.map_pores()]   
+    if A1 == '':    a1 = 1
     else:
-        raise Exception('Wrong size for the parameter A1!') 
+        if type(A1)==str:
+            A1 = 'pore.'+A1.split('.')[-1]
+            try:    a1 = physics[A1]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A1+'!')
+        else:  raise Exception('A1 can be only string!')
 
-    if length_A2==physics.Np:
-        a2 = A2
-    elif length_A2==1:
-        a2 = A2*_sp.ones(physics.Np)        
-    elif length_A2>=phase.Np:
-        a2 = A2[physics.map_pores()]   
+    if A2 == '':    a2 = 0
     else:
-        raise Exception('Wrong size for the parameter A2!') 
+        if type(A2)==str:
+            A2 = 'pore.'+A2.split('.')[-1]
+            try:    a2 = physics[A2]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A2+'!')
+        else:  raise Exception('A2 can be only string!')
 
-    if length_A3==physics.Np:
-        a3 = A3
-    elif length_A3==1:
-        a3 = A3*_sp.ones(physics.Np)        
-    elif length_A3>=phase.Np:
-        a3 = A3[physics.map_pores()]   
+    if A3 == '':    a3 = 0
     else:
-        raise Exception('Wrong size for the parameter A3!')  
+        if type(A3)==str:
+            A3 = 'pore.'+A3.split('.')[-1]
+            try:    a3 = physics[A3]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A3+'!')
+        else:  raise Exception('A3 can be only string!')
 
-    if length_A4==physics.Np:
-        a4 = A4
-    elif length_A4==1:
-        a4 = A4*_sp.ones(physics.Np)        
-    elif length_A4>=phase.Np:
-        a4 = A4[physics.map_pores()]   
+
+    if A4 == '':    a4 = 0
     else:
-        raise Exception('Wrong size for the parameter A4!') 
-        
-        
-    if length_A5==physics.Np:
-        a5 = A5
-    elif length_A5==1:
-        a5 = A5*_sp.ones(physics.Np)        
-    elif length_A5>=phase.Np:
-        a5 = A5[physics.map_pores()]   
+        if type(A4)==str:
+            A4 = 'pore.'+A4.split('.')[-1]
+            try:    a4 = physics[A4]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A4+'!')
+        else:  raise Exception('A4 can be only string!')
+
+    if A5 == '':    a5 = 0
     else:
-        raise Exception('Wrong size for the parameter A5!')         
+        if type(A5)==str:
+            A5 = 'pore.'+A5.split('.')[-1]
+            try:    a5 = physics[A5]
+            except: raise Exception(physics.name+'/'+phase.name+' does not have the pore property :'+A5+'!')
+        else:  raise Exception('A5 can be only string!')
 
 
-    S1 = a1*a2*a3*X**(a3-1)/(a2*X**a3+a4)
-    S2 = a1*_sp.log(a2*X**a3+a4)+a5-a1*a2*a3*X**a3/(a2*X**a3+a4)
-    r = _sp.vstack((S1,S2)).T    
-    return r
+    if return_rate:
+        return(a1*_sp.log(a2*X**a3 +a4)+a5)
+    else:
+        S1 = a1*a2*a3*X**(a3-1)/(a2*X**a3+a4)
+        S2 = a1*_sp.log(a2*X**a3+a4)+a5-a1*a2*a3*X**a3/(a2*X**a3+a4)
+        return(_sp.vstack((S1,S2)).T)         

--- a/tests/test_source1.py
+++ b/tests/test_source1.py
@@ -12,31 +12,49 @@ Ps = pn.pores('boundary')
 Ts = pn.find_neighbor_throats(pores=Ps,mode='not_intersection')
 boun = OpenPNM.Geometry.Boundary(network=pn,pores=Ps,throats=Ts)
 
-air = OpenPNM.Phases.Air(network=pn)
-
+air = OpenPNM.Phases.Air(network=pn,name='air')
 #---------------------------------------------------------------------------------------------
 phys_air = OpenPNM.Physics.Standard(network=pn,phase=air,pores=sp.r_[600:pn.Np],throats=pn.Ts)
 #Add some source terms to phys_air1
+phys_air['pore.item1'] = 0.5e-13
+phys_air['pore.item2'] = 1.5
+phys_air['pore.item3'] = 2.5e-14
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah1',
-                   A1=0.5e-13,
-                   A2=1.5,
-                   A3=2.5e-14)
+                   A1='pore.item1',
+                   A2='pore.item2',
+                   A3='pore.item3',
+                   x='mole_fraction',
+                   regen_mode='deferred')
+#phys_air.models['pore.blah1']['regen_mode'] = 'normal'
+
+phys_air['pore.item4'] = 0.3e-11
+phys_air['pore.item5'] = 0.5
+phys_air['pore.item6'] = 2
+phys_air['pore.item7'] = -0.34
+phys_air['pore.item8'] = 2e-14
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.natural_exponential,
                    propname='pore.blah2',
-                   A1=0.3e-11,
-                   A2=0.5,
-                   A3=2,
-                   A4=-0.34,
-                   A5=2e-14)
+                   A1='item4',
+                   A2='item5',
+                   A3='pore.item6',
+                   A4='pore.item7',
+                   A5='pore.item8',
+                   x='mole_fraction',
+                   regen_mode='deferred')
 #-----------------------------------------------------------------------------------------------                   
 phys_air2 = OpenPNM.Physics.Standard(network=pn,phase=air,pores=sp.r_[0:600])
 #Add some source terms to phys_air2
+phys_air2['pore.item9'] = 1.5e-13
+phys_air2['pore.item10'] = 1.7
+phys_air2['pore.item11'] = 1.5e-14
 phys_air2.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah1',
-                   A1=1.5e-13,
-                   A2=1.7,
-                   A3=1.5e-14)
+                   A1='item9',
+                   A2='item10',
+                   A3='item11',
+                   x='mole_fraction',
+                   regen_mode='deferred')
 #-----------------------------------------------------------------------------------------------                   
 alg = OpenPNM.Algorithms.FickianDiffusion(network=pn,phase=air)
 BC1_pores = pn.pores('right_boundary')
@@ -44,11 +62,16 @@ alg.set_boundary_conditions(bctype='Dirichlet', bcvalue=0.6, pores=BC1_pores)
 BC2_pores = pn.pores('left_boundary')
 alg.set_boundary_conditions(bctype='Neumann_group', bcvalue=0.2*1e-11, pores=BC2_pores)
 #-----------------------------------------------------------------------------------------------                   
-alg.set_source_term(source_name='pore.blah1',pores=sp.r_[500:700],tol = 1e-10)
+alg.set_source_term(source_name='pore.blah1',pores=sp.r_[500:700])
 alg.set_source_term(source_name='pore.blah2',pores=sp.r_[800:900])
 alg.setup()
 alg.solve()
 alg.return_results()
+#-----------------------------------------------------------------------------------------------                   
+# This part is not necessary for validation, just for returning the rate values back to the physics
+phys_air.regenerate()
+phys_air2.regenerate()
+#-----------------------------------------------------------------------------------------------
 print('--------------------------------------------------------------')
 print('steps: ',alg._steps)
 print('tol_reached: ',alg._tol_reached)

--- a/tests/test_source2.py
+++ b/tests/test_source2.py
@@ -13,25 +13,38 @@ Ts = pn.find_neighbor_throats(pores=Ps,mode='not_intersection')
 boun = OpenPNM.Geometry.Boundary(network=pn,pores=Ps,throats=Ts)
 
 air = OpenPNM.Phases.Air(network=pn)
-
 #---------------------------------------------------------------------------------------------
 Ps = pn.pores()
 Ts = pn.throats()
 phys_air = OpenPNM.Physics.Standard(network=pn,phase=air,pores=Ps,throats=Ts)
 #Add some additional models to phys_air
+phys_air['pore.item1'] = 0.5e-13
+phys_air['pore.item2'] = 1.5
+phys_air['pore.item3'] = 2.5e-14
+phys_air['pore.item4'] = 0.16e-14
+phys_air['pore.item5'] = 10
+phys_air['pore.item6'] = 4
+phys_air['pore.item7'] = -1.4
+phys_air['pore.item8'] = 0.133
+phys_air['pore.item9'] = -5.1e-14
+
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah1',
-                   A1=0.5e-13,
-                   A2=1.5,
-                   A3=2.5e-14)
+                   A1='item1',
+                   A2='pore.item2',
+                   A3='item3',
+                   x='mole_fraction',
+                   regen_mode='on_demand')
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.logarithm,
                    propname='pore.blah2',
-                   A1=0.16e-14,
-                   A2=10,
-                   A3=4,
-                   A4=-1.4,
-                   A5=0.133,
-                   A6=-5.1e-14)
+                   A1='pore.item4',
+                   A2='item5',
+                   A3='item6',
+                   A4='item7',
+                   A5='item8',
+                   A6='pore.item9',
+                   x='mole_fraction',
+                   regen_mode='on_demand')
 #------------------------------------------------------------------------------
 '''Perform Fickian Diffusion'''
 #------------------------------------------------------------------------------
@@ -49,6 +62,11 @@ alg.set_source_term(source_name='pore.blah2',pores=sp.r_[800:900],tol=1e-11)
 alg.setup()
 alg.solve(iterative_solver='cg',tol=1e-20)
 alg.return_results()
+#-----------------------------------------------------------------------------------------------                   
+# This part is not necessary for validation, just for returning the rate values back to the physics
+phys_air.regenerate('pore.blah1')
+phys_air.regenerate('pore.blah2')
+#------------------------------------------------------------------------------------------------
 print('--------------------------------------------------------------')
 print('steps: ',alg._steps)
 print('tol_reached: ',alg._tol_reached)

--- a/tests/test_source3.py
+++ b/tests/test_source3.py
@@ -19,15 +19,21 @@ Ps = pn.pores()
 Ts = pn.throats()
 phys_air = OpenPNM.Physics.Standard(network=pn,phase=air,pores=Ps,throats=Ts)
 #Add some additional models to phys_air
+phys_air['pore.item1'] = 0.5e-13
+phys_air['pore.item2'] = 1.5
+phys_air['pore.item3'] = 2.5e-14
+phys_air['pore.item4'] = 0.9e-13
+phys_air['pore.item5'] = -4e-14
+
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah1',
-                   A1=0.5e-13,
-                   A2=1.5,
-                   A3=2.5e-14)
+                   A1='pore.item1',
+                   A2='pore.item2',
+                   A3='pore.item3')
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.linear,
                    propname='pore.blah2',
-                   A1=0.9e-13,
-                   A2=-4e-14)
+                   A1='pore.item4',
+                   A2='pore.item5')
 #------------------------------------------------------------------------------
 '''Perform Fickian Diffusion'''
 #------------------------------------------------------------------------------

--- a/tests/test_source4.py
+++ b/tests/test_source4.py
@@ -17,31 +17,55 @@ air = OpenPNM.Phases.Air(network=pn)
 #---------------------------------------------------------------------------------------------
 phys_air = OpenPNM.Physics.Standard(network=pn,phase=air,pores=sp.r_[600:pn.Np],throats=pn.Ts)
 #Add some source terms to phys_air1
+phys_air['pore.item1'] = 0.5e-13
+phys_air['pore.item2'] = 1.5
+phys_air['pore.item3'] = 2.5e-14
+phys_air['pore.item4'] = 0.9e-13
+phys_air['pore.item5'] = 1.9
+phys_air['pore.item6'] = 4.15e-14
+phys_air['pore.item7'] = 0.3e-11
+phys_air['pore.item8'] = 0.5
+phys_air['pore.item9'] = 2
+phys_air['pore.item10'] = -0.34
+phys_air['pore.item11'] = 2e-14
+
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah1',
-                   A1=0.5e-13,
-                   A2=1.5,
-                   A3=2.5e-14)
+                   A1='item1',
+                   A2='item2',
+                   A3='item3',
+                   x='mole_fraction',
+                   regen_mode='deferred')
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah2',
-                   A1=0.9e-13,
-                   A2=1.9,
-                   A3=4.15e-14)
+                   A1='item4',
+                   A2='item5',
+                   A3='item6',
+                   x='mole_fraction',
+                   regen_mode='deferred')
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.natural_exponential,
                    propname='pore.blah3',
-                   A1=0.3e-11,
-                   A2=0.5,
-                   A3=2,
-                   A4=-0.34,
-                   A5=2e-14)
+                   A1='item7',
+                   A2='item8',
+                   A3='item9',
+                   A4='item10',
+                   A5='item11',
+                   x='mole_fraction',
+                   regen_mode='deferred')
 #-----------------------------------------------------------------------------------------------                   
 phys_air2 = OpenPNM.Physics.Standard(network=pn,phase=air,pores=sp.r_[0:600])
 #Add some source terms to phys_air2
+phys_air2['pore.item1'] = 1.5e-13
+phys_air2['pore.item2'] = 1.7
+phys_air2['pore.item3'] = 1.5e-14
+
 phys_air2.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah1',
-                   A1=1.5e-13,
-                   A2=1.7,
-                   A3=1.5e-14)
+                   A1='item1',
+                   A2='item2',
+                   A3='item3',
+                   x='pore.mole_fraction',
+                   regen_mode='deferred')
 #-----------------------------------------------------------------------------------------------                   
 alg = OpenPNM.Algorithms.FickianDiffusion(network=pn,phase=air)
 BC1_pores = pn.pores('right_boundary')

--- a/tests/test_source5.py
+++ b/tests/test_source5.py
@@ -19,26 +19,41 @@ Ps = pn.pores()
 Ts = pn.throats()
 phys_air = OpenPNM.Physics.Standard(network=pn,phase=air,pores=Ps,throats=Ts)
 #Add some additional models to phys_air
+phys_air['pore.item1'] = 0.5e-13
+phys_air['pore.item2'] = 1.5
+phys_air['pore.item3'] = 2.5e-14
+phys_air['pore.item4'] = 0.16e-14
+phys_air['pore.item5'] = 10
+phys_air['pore.item6'] = 4
+phys_air['pore.item7'] = -1.4
+phys_air['pore.item8'] = 0.133
+phys_air['pore.item9'] = -5.1e-14
+phys_air['pore.item10'] = 0.8e-11
+phys_air['pore.item11'] = 0.5
+phys_air['pore.item12'] = 2
+phys_air['pore.item13'] = -0.34
+phys_air['pore.item14'] = 2e-14
+
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.power_law,
                    propname='pore.blah1',
-                   A1=0.5e-13,
-                   A2=1.5,
-                   A3=2.5e-14)
+                   A1='pore.item1',
+                   A2='pore.item2',
+                   A3='pore.item3')
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.logarithm,
                    propname='pore.blah2',
-                   A1=0.16e-14,
-                   A2=10,
-                   A3=4,
-                   A4=-1.4,
-                   A5=0.133,
-                   A6=-5.1e-14)
+                   A1='pore.item4',
+                   A2='pore.item5',
+                   A3='pore.item6',
+                   A4='pore.item7',
+                   A5='pore.item8',
+                   A6='pore.item9')
 phys_air.add_model(model=OpenPNM.Physics.models.generic_source_term.natural_exponential,
                    propname='pore.blah3',
-                   A1=0.8e-11,
-                   A2=0.5,
-                   A3=2,
-                   A4=-0.34,
-                   A5=2e-14)
+                   A1='pore.item10',
+                   A2='pore.item11',
+                   A3='pore.item12',
+                   A4='pore.item13',
+                   A5='pore.item14')
 #------------------------------------------------------------------------------
 '''Perform Fickian Diffusion'''
 #------------------------------------------------------------------------------


### PR DESCRIPTION
- This includes the new changes for the arguments in generic_source_term model of physics.
- The source parameters like A1, A2, ... should be sent only as string inputs such as 'pore.item' instead of the actual numerical values. The method looks into the physics or phase dictionaries to find the property.
- For examples, refer to the source tests in the test folder.