### PR TITLE
Adding Coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+omit =
+    *__init__*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build/
 dist/
 .coverage
+*.vtp

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pnm
 build/
 dist/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ install:
     - conda update -q conda
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy matplotlib
     - source activate test-environment
-    - pip install pytest
+    - pip install pytest python-coveralls coverage
     - python setup.py install
 
 script:
     - py.test
+
+after_success:
+    - coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 OpenPNM
 =======
 
-.. image:: https://travis-ci.org/PMEAL/OpenPNM.svg?branch=add-travis-ci
-    :target: https://travis-ci.org/PMEAL/OpenPNM
+.. image:: https://travis-ci.org/PMEAL/OpenPNM.svg?branch=develop :target: https://travis-ci.org/PMEAL/OpenPNM
+.. image:: https://coveralls.io/repos/PMEAL/OpenPNM/badge.svg :target: https://coveralls.io/r/PMEAL/OpenPNM
 
 .. contents::
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --doctest-modules --ignore=setup.py --ignore=run_script.py --ignore=versioneer.py --ignore=OpenPNM_install.py --cov coveralls --cov-report term-missing
+addopts = --doctest-modules --cov=OpenPNM --cov-report term-missing
 norecursedirs = examples tests docs "article recreation" LocalFiles

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --doctest-modules --ignore=setup.py --ignore=run_script.py --ignore=versioneer.py --ignore=OpenPNM_install.py
+addopts = --doctest-modules --ignore=setup.py --ignore=run_script.py --ignore=versioneer.py --ignore=OpenPNM_install.py --cov coveralls --cov-report term-missing
 norecursedirs = examples tests docs "article recreation" LocalFiles

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+--index-url https://pypi.python.org/simple/
+-e .

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ setup(
         'matplotlib'
     ],
     tests_require = [
-        'pytest'
+        'pytest',
+        'python-coveralls',
+        'coverage'
     ],
     author = 'OpenPNM Team',
     author_email = 'jeff.gostick@mcgill.ca',


### PR DESCRIPTION
The addition of [coveralls](http://coveralls.io) will allow us to track and eventually boast our test coverage.

To get a report in your console be sure to have `pytest` installed and then run:
```
$ py.test
```
It will then print the analysis of each file and tell you the coverage. TravisCI is configured to uploaded these stats to coveralls once the build passes.

Please review: @jgostick @maghighi 