### PR TITLE
Work flow scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - python setup.py install
 
 script:
-    - py.test --pep8 --cov=. --cov-config=.coveragerc
+    - ./bin/test pep8 cov
 
 after_success:
     - coveralls

--- a/OpenPNM/__init__.py
+++ b/OpenPNM/__init__.py
@@ -40,7 +40,7 @@ import scipy as sp
 if sp.__version__ < '0.14.0':
     raise Exception('OpenPNM requires SciPy version 0.14.0 or greater')
 
-__version__ = '1.1'
+__version__ = '1.1.0'
 
 __requires__ = ['scipy']
 

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+import subprocess
+
+subprocess.call(['python3', 'setup.py', 'sdist'])

--- a/bin/clean
+++ b/bin/clean
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import re
+
+DIRECTORIES_TO_DELETE = [
+    '.cache',
+    'OpenPNM.egg-info',
+    'dist',
+    'build'
+]
+
+FILES_TO_DELETE = [
+    'test.pnm',
+    'test_net.pnm',
+    'nano.vtp',
+    '.coverage'
+]
+
+BYTE_CODE = '.+\.pyc'
+
+for f in FILES_TO_DELETE:
+    try:
+        os.remove(f)
+    except:
+        continue
+
+for root, dirs, files in os.walk('./'):
+    dirs_to_delete = [d for d in dirs if d in DIRECTORIES_TO_DELETE]
+    for d in dirs_to_delete:
+        shutil.rmtree(os.path.join(root, d))
+    files_to_delete = [f for f in files if re.match(BYTE_CODE, f)]
+    for f in files_to_delete:
+        os.remove(os.path.join(root, f))
+
+print('Project cleaned.')

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import os
+import OpenPNM
+import subprocess
+
+VERSION = OpenPNM.__version__
+
+
+def publish():
+    subprocess.call(['python3', 'setup.py', 'upload', '-r', 'pypi'])
+    print('Done.')
+
+pwd = os.getcwd()
+egg_info = os.path.join(pwd, 'OpenPNM.egg-info')
+dist = os.path.join(pwd, 'dist')
+
+if os.path.isdir(egg_info) and os.path.isdir(dist):
+    response = input('Are you sure you want to publish version ' + VERSION +
+                     ' of OpenPNM? (y/n): ')
+    if response is 'y':
+        publish()
+else:
+    print('There is no build of OpenPNM present, run ./bin/build,'
+          ' and try again.')

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+
+command = ['py.test']
+
+if 'pep8' in sys.argv:
+    command.append('--pep8')
+
+if 'cov' in sys.argv:
+    command.extend(['--cov=.', '--cov-config=.coveragerc'])
+
+subprocess.call(command)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys
+import OpenPNM
+
 sys.path.append(os.getcwd())
 
 try:
@@ -12,7 +14,7 @@ except ImportError:
 setup(
     name = 'OpenPNM',
     description = 'A framework for conducting pore network modeling simulations of multiphase transport in porous materials.',
-    version = '1.1',
+    version = OpenPNM.__version__,
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
This PR adds a series of scripts to aid in the development of OpenPNM. They are all located in the `bin/` directory and can be called via:
```
$ bin/<script_name>
```

There are four scripts currently:
* `bin/test` Runs the test suite, the arguments `pep8` and/or `cov` can be added in order to test pep8 and test coverage respectively.
* `bin/build`: Builds OpenPNM
* `bin/publish`: Published OpenPNM to Pypi (It will probably prompt you for you pypi user info).
* `bin/clean`: Removes all files that result from any sort of build or test command

`bin/publish` should only run when we are ready for a release.

Please review: @jgostick @RodericDay 