### PR TITLE
Bugfix/issue375

### DIFF
--- a/OpenPNM/Base/__ModelsDict__.py
+++ b/OpenPNM/Base/__ModelsDict__.py
@@ -91,8 +91,9 @@ class ModelWrapper(dict):
 
 class GenericModel(ModelWrapper):
     r"""
-    This class is deprecated, and is replaced by ModelWrapper.  This is kept
-    here to support legacy issues.
+    This class was deprecated, and replaced by ModelWrapper.  Unfortunately,
+    this broke the ability to load files that were saved prior to the
+    deprecation.  This is placed here as a 'wrapper' to the new ModelsWraper.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/OpenPNM/Base/__ModelsDict__.py
+++ b/OpenPNM/Base/__ModelsDict__.py
@@ -9,7 +9,6 @@ from collections import OrderedDict
 from OpenPNM.Base import logging, Controller
 logger = logging.getLogger()
 
-
 class ModelWrapper(dict):
     r"""
     Accepts a model from the OpenPNM model library, as well as all required
@@ -90,6 +89,13 @@ class ModelWrapper(dict):
                             'method.')
         return master[0]
 
+class GenericModel(ModelWrapper):
+    r"""
+    This class is deprecated, and is replaced by ModelWrapper.  This is kept
+    here to support legacy issues.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
 class ModelsDict(OrderedDict):
     r"""


### PR DESCRIPTION
This creates a shell class called GenericModel which is just a child of ModelWrapper.  This is need to correct backwards compatibility issues since we changed the name of the GenericModel class without thinking about the consequences on loading old files.  @TomTranter has confirmed that this fixes the issue.  