### PR TITLE
Bugfix multiphase

### DIFF
--- a/OpenPNM/Algorithms/__GenericLinearTransport__.py
+++ b/OpenPNM/Algorithms/__GenericLinearTransport__.py
@@ -25,12 +25,17 @@ class GenericLinearTransport(GenericAlgorithm):
         super().__init__(**kwargs)
         if phase is None:
             self._phase = GenericPhase()
+            self._phases.append(self._phase)
         else:
             self._phase = phase  # Register phase with self
             if sp.size(phase) != 1:
                 self._phases = phase
             else:
                 self._phases.append(phase)
+        for comp in self._phases:
+            if comp.Np != self.Np:
+                raise Exception(comp.name + ' has different Np size than the' +
+                                ' algorithm ' + self.name)
 
     def setup(self, conductance, quantity, super_pore_conductance):
         r"""
@@ -50,8 +55,7 @@ class GenericLinearTransport(GenericAlgorithm):
                              quantity.split('.')[-1]
             # Check health of conductance vector
             if self._phase.check_data_health(props=self._conductance).health:
-                m = self._net.map_throats(target=self._phase, throats=self.Ts)
-                self['throat.conductance'] = self._phase[self._conductance][m]
+                self['throat.conductance'] = self._phase[self._conductance]
             else:
                 raise Exception('The provided throat conductance has problems')
         else:
@@ -295,8 +299,6 @@ class GenericLinearTransport(GenericAlgorithm):
                         phys.models[source_name]['return_rate'] = return_rate
                         phys.models[source_name]['regen_mode'] = regen_mode
                         map_pores = phys.map_pores()
-                        map_pores = self._phase.map_pores(target=self._net,
-                                                          pores=map_pores)
                         loc = pores[sp.in1d(pores, map_pores)]
                         if mode == 'merge':
                             try:

--- a/OpenPNM/Physics/models/multiphase.py
+++ b/OpenPNM/Physics/models/multiphase.py
@@ -66,6 +66,7 @@ def conduit_conductance(physics, phase, network, throat_conductance,
     open_conduits = -closed_conduits
     throat_value = phase[throat_conductance]
     value = throat_value*open_conduits + throat_value*closed_conduits*factor
+    value = value[phase.throats(physics.name)]    
     return value
 
 
@@ -104,4 +105,5 @@ def late_pore_filling(physics, phase, network, Pc, Swp_star=0.2, eta=3,
         values = Swp*phase[pore_occupancy]*(Pc_star < Pc)
     else:
         values = (1-Swp)*(1-phase[pore_occupancy])*(Pc_star < Pc)
+    value = value[phase.throats(physics.name)]    
     return values

--- a/OpenPNM/Physics/models/multiphase.py
+++ b/OpenPNM/Physics/models/multiphase.py
@@ -105,5 +105,5 @@ def late_pore_filling(physics, phase, network, Pc, Swp_star=0.2, eta=3,
         values = Swp*phase[pore_occupancy]*(Pc_star < Pc)
     else:
         values = (1-Swp)*(1-phase[pore_occupancy])*(Pc_star < Pc)
-    value = value[phase.throats(physics.name)]    
+    values = values[phase.throats(physics.name)]
     return values

--- a/OpenPNM/Physics/models/multiphase.py
+++ b/OpenPNM/Physics/models/multiphase.py
@@ -66,7 +66,7 @@ def conduit_conductance(physics, phase, network, throat_conductance,
     open_conduits = -closed_conduits
     throat_value = phase[throat_conductance]
     value = throat_value*open_conduits + throat_value*closed_conduits*factor
-    value = value[phase.throats(physics.name)]    
+    value = value[phase.throats(physics.name)]
     return value
 
 


### PR DESCRIPTION
This PR fixes a bug in the multiphase model, so the model can work with the cloned physics too. 
The other commit is for checking the phase and algorithm length in the solver. I did not add this check to the generic algorithm, because we don't want to limit the user's ability for making new customized algorithms. But as for generic linear transport class, the length of phase and algorithm should always match together.
