### PR TITLE
Fixed a bug in the late_pore_filling model

### DIFF
--- a/OpenPNM/Physics/models/multiphase.py
+++ b/OpenPNM/Physics/models/multiphase.py
@@ -48,7 +48,7 @@ def conduit_conductance(physics, phase, network, throat_conductance,
     calculated.
 
     """
-    throats = phase.throats(physics.name)
+    throats = phase.Ts
     if mode == 'loose':
         closed_conduits = -sp.array(phase[throat_occupancy], dtype=bool)
     else:
@@ -96,7 +96,7 @@ def late_pore_filling(physics, phase, network, Pc, Swp_star=0.2, eta=3,
 
 
     """
-    pores = phase.pores(physics.name)
+    pores = phase.Ps
     prop = phase[throat_capillary_pressure]
     neighborTs = network.find_neighbor_throats(pores, flatten=False)
     Pc_star = sp.array([sp.amin(prop[row]) for row in neighborTs])
@@ -105,5 +105,5 @@ def late_pore_filling(physics, phase, network, Pc, Swp_star=0.2, eta=3,
         values = Swp*phase[pore_occupancy]*(Pc_star < Pc)
     else:
         values = (1-Swp)*(1-phase[pore_occupancy])*(Pc_star < Pc)
-    values = values[phase.throats(physics.name)]
+    values = values[phase.pores(physics.name)]
     return values

--- a/OpenPNM/Physics/models/multiphase.py
+++ b/OpenPNM/Physics/models/multiphase.py
@@ -50,20 +50,20 @@ def conduit_conductance(physics, phase, network, throat_conductance,
     """
     throats = phase.Ts
     if mode == 'loose':
-        closed_conduits = -sp.array(phase[throat_occupancy], dtype=bool)
+        closed_conduits = ~sp.array(phase[throat_occupancy], dtype=bool)
     else:
-        throats_closed = -sp.array(phase[throat_occupancy], dtype=bool)
+        throats_closed = ~sp.array(phase[throat_occupancy], dtype=bool)
         connected_pores = network.find_connected_pores(throats)
         pores_1 = connected_pores[:, 0]
         pores_2 = connected_pores[:, 1]
-        pores_1_closed = -sp.array(phase[pore_occupancy][pores_1], dtype=bool)
-        pores_2_closed = -sp.array(phase[pore_occupancy][pores_2], dtype=bool)
+        pores_1_closed = ~sp.array(phase[pore_occupancy][pores_1], dtype=bool)
+        pores_2_closed = ~sp.array(phase[pore_occupancy][pores_2], dtype=bool)
         if mode == 'medium':
             closed_conduits = throats_closed | (pores_1_closed & pores_2_closed)
 
         if mode == 'strict':
             closed_conduits = pores_1_closed | throats_closed | pores_2_closed
-    open_conduits = -closed_conduits
+    open_conduits = ~closed_conduits
     throat_value = phase[throat_conductance]
     value = throat_value*open_conduits + throat_value*closed_conduits*factor
     value = value[phase.throats(physics.name)]

--- a/test/unit/Physics/models/MultiPhaseTest.py
+++ b/test/unit/Physics/models/MultiPhaseTest.py
@@ -1,3 +1,99 @@
+import OpenPNM
+import scipy as sp
+import OpenPNM.Physics.models as pm
+
+
 class MultiPhaseTest:
-    def test_conduit_conductance(self):
+    def setup_class(self):
+        self.net = OpenPNM.Network.Cubic(shape=[3, 3, 3])
+        self.phase = OpenPNM.Phases.GenericPhase(network=self.net)
+        self.phase['pore.occupancy'] = sp.ones(self.net.Np)
+        self.phase['throat.occupancy'] = sp.ones(self.net.Nt)
+        p = sp.arange(7, 10)
+        t = self.net.find_neighbor_throats(p)
+        self.phase['pore.occupancy'][p] = 0.
+        self.phase['throat.occupancy'][t] = 0.
+        Ps1 = sp.arange(10)
+        Ts1 = self.net.find_neighbor_throats(Ps1)
+        self.phys1 = OpenPNM.Physics.GenericPhysics(network=self.net,
+                                                    phase=self.phase,
+                                                    pores=Ps1, throats=Ts1)
+        Ps2 = sp.arange(10, self.net.Np)
+        Ts2 = self.net.Ts[~sp.in1d(self.net.Ts, Ts1)]
+        self.phys2 = OpenPNM.Physics.GenericPhysics(network=self.net,
+                                                    phase=self.phase,
+                                                    pores=Ps2, throats=Ts2)
+        self.phys1['throat.capillary_pressure'] = 5000
+        self.phys1['throat.diffusive_conductance'] = 2
+        self.phys2['throat.capillary_pressure'] = 5000
+        self.phys2['throat.diffusive_conductance'] = 3
+
+    def test_conduit_conductance_strict(self):
+        self.phase['pore.occupancy'][[19, 25]] = 0
+        t1 = self.net.Ts[self.phase['throat.occupancy'] == 0]
+        t2 = self.net.Ts[~sp.in1d(self.net.Ts, t1)]
+        self.phys1.models.add(propname='throat.cond_conductance',
+                              throat_conductance='throat.diffusive_conductance',
+                              model=pm.multiphase.conduit_conductance,
+                              mode='strict', factor=0)
+        self.phys2.models.add(propname='throat.cond_conductance',
+                              throat_conductance='throat.diffusive_conductance',
+                              model=pm.multiphase.conduit_conductance,
+                              mode='strict', factor=0)
+        assert ~sp.all(self.phase['throat.cond_conductance'] == 0)
+        assert sp.all(self.phase['throat.cond_conductance'][t1] == 0)
+        assert ~sp.all(self.phase['throat.cond_conductance'][t2] != 0)
+
+    def test_conduit_conductance_medium(self):
+        self.phase['pore.occupancy'][[19, 25]] = 0
+        self.phase['pore.occupancy'][6] = 0
+        t1 = self.net.Ts[self.phase['throat.occupancy'] == 0.]
+        t2 = self.net.find_connecting_throat(6, 7)[0]
+        t3 = self.net.Ts[~sp.in1d(self.net.Ts, sp.concatenate((t1, t2)))]
+        self.phys1.models.add(propname='throat.cond_conductance',
+                              throat_conductance='throat.diffusive_conductance',
+                              model=pm.multiphase.conduit_conductance,
+                              mode='medium', factor=0)
+        self.phys2.models.add(propname='throat.cond_conductance',
+                              throat_conductance='throat.diffusive_conductance',
+                              model=pm.multiphase.conduit_conductance,
+                              mode='medium', factor=0)
+        assert sp.all(self.phase['throat.cond_conductance'][t1] == 0)
+        assert self.phase['throat.cond_conductance'][t2] == 0
+        assert sp.all(self.phase['throat.cond_conductance'][t3] != 0)
+
+    def test_conduit_conductance_loose(self):
+        self.phase['pore.occupancy'][[19, 20]] = 0
+        t1 = self.net.Ts[self.phase['throat.occupancy'] == 0]
+        t2 = self.net.Ts[~sp.in1d(self.net.Ts, t1)]
+        self.phys1.models.add(propname='throat.cond_conductance',
+                              throat_conductance='throat.diffusive_conductance',
+                              model=pm.multiphase.conduit_conductance,
+                              mode='loose', factor=0)
+        self.phys2.models.add(propname='throat.cond_conductance',
+                              throat_conductance='throat.diffusive_conductance',
+                              model=pm.multiphase.conduit_conductance,
+                              mode='loose', factor=0)
+        assert sp.all(self.phase['throat.cond_conductance'][t1] == 0)
+        assert sp.all(self.phase['throat.cond_conductance'][t2] != 0)
+
+    def test_late_throat_filling(self):
         pass
+
+    def test_late_pore_filling(self):
+
+        self.phys1.models.add(propname='pore.late_p',
+                              model=pm.multiphase.late_pore_filling,
+                              wetting_phase=True, Pc=5500)
+        self.phys2.models.add(propname='pore.late_p',
+                              model=pm.multiphase.late_pore_filling,
+                              wetting_phase=True, Pc=5500)
+        self.phys1.models.add(propname='pore.late_p_n',
+                              model=pm.multiphase.late_pore_filling,
+                              Pc=5500)
+        self.phys2.models.add(propname='pore.late_p_n',
+                              model=pm.multiphase.late_pore_filling,
+                              Pc=5500)
+        p = self.phase['pore.occupancy'] == 0
+        assert sp.allclose(self.phase['pore.late_p'][~p], 0.15026296)
+        assert sp.allclose(self.phase['pore.late_p_n'][p], 0.84973704)


### PR DESCRIPTION
It was the same problem with the conduit conductance model. It was written with the old OpenPNM style.
In the new form, everything must be calculated for the phase, but only values of the physics should be returned.