### PR TITLE
Remove saving of vtp and net files

### DIFF
--- a/test/integration/test_topological_manipulations.py
+++ b/test/integration/test_topological_manipulations.py
@@ -1,5 +1,5 @@
 import OpenPNM
-import pytest
+from os.path import join
 import scipy as sp
 from OpenPNM.Utilities import topology
 ctrl = OpenPNM.Base.Controller()
@@ -15,7 +15,7 @@ def test_subdivide():
     pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
     assert pn.Np == (125+4*64-4)
     assert pn.Nt == (300+(4*144)-16+15*16+16)
-    ctrl.export(network=pn, filename='nano')
+    ctrl.export(network=pn, filename=join(TEMP_DIR, 'nano'))
 
 
 def test_clone_and_trim():

--- a/test/unit/Base/ControllerTest.py
+++ b/test/unit/Base/ControllerTest.py
@@ -50,7 +50,7 @@ class ControllerTest:
 
     def test_save_and_load_simulation(self):
         a = OpenPNM.Network.Cubic(shape=[10, 10, 10])
-        self.controller.save_simulation(a)
+        self.controller.save_simulation(a, join(TEMP_DIR, 'test_simulation'))
         assert a in self.controller.values()
 
     def test_ghost_object(self):


### PR DESCRIPTION
This PR corrects two tests that were testing OpenPNM's saving functionality outside of `TEMP_DIR`

cc/ @jgostick 