### PR TITLE
Fix bug460

### DIFF
--- a/OpenPNM/Physics/__GenericPhysics__.py
+++ b/OpenPNM/Physics/__GenericPhysics__.py
@@ -57,10 +57,9 @@ class GenericPhysics(OpenPNM.Base.Core):
 
         # Associate with Phase
         if phase is None:
-            self._phases.append(GenericPhase())
-        else:
-            phase._physics.append(self)  # Register self with phase
-            self._phases.append(phase)  # Register phase with self
+            phase = GenericPhase(network=self._net)
+        phase._physics.append(self)  # Register self with phase
+        self._phases.append(phase)  # Register phase with self
 
         if geometry is not None:
             if (sp.size(pores) > 0) or (sp.size(throats) > 0):

--- a/OpenPNM/Physics/__GenericPhysics__.py
+++ b/OpenPNM/Physics/__GenericPhysics__.py
@@ -89,6 +89,25 @@ class GenericPhysics(OpenPNM.Base.Core):
         else:  # ...Then check Network
             return self._phases[0][key][self._phases[0][element + '.' + self.name]]
 
+    def _set_phase(self, phase):
+        current_phase = self._phases[0]
+        # Remove labels of self from current phase
+        pore_label = current_phase.pop('pore.'+self.name)
+        throat_label = current_phase.pop('throat.'+self.name)
+        # Add labels of self to new phase
+        phase['pore.'+self.name] = pore_label
+        phase['throat.'+self.name] = throat_label
+        # Replace phase reference on self
+        self._phases[0] = phase
+        # Remove physics reference on current phase
+        current_phase._physics.remove(self)
+        phase._physics.append(self)
+
+    def _get_phase(self):
+        return self._phases[0]
+
+    parent_phase = property(fget=_get_phase, fset=_set_phase)
+
     def set_locations(self, pores=[], throats=[], mode='add'):
         r"""
         Set the pore and throat locations of the Physics object

--- a/test/unit/Physics/GenericPhysicsTest.py
+++ b/test/unit/Physics/GenericPhysicsTest.py
@@ -37,6 +37,7 @@ class GenericPhysicsTest:
         flag = False
         try:
             OpenPNM.Physics.GenericPhysics(network=self.net,
+                                           phase=self.phase1,
                                            pores=[0])
         except:
             flag = True
@@ -46,6 +47,7 @@ class GenericPhysicsTest:
         flag = False
         try:
             OpenPNM.Physics.GenericPhysics(network=self.net,
+                                           phase=self.phase1,
                                            geometry=self.geo1)
         except:
             flag = True
@@ -56,3 +58,12 @@ class GenericPhysicsTest:
         assert a is None
         a = self.phys1['pore.'+self.phys1.name]
         assert sp.sum(a) == self.phys1.Np
+
+    def test_instantiation_with_no_geom_or_phase(self):
+        phys = OpenPNM.Physics.GenericPhysics(network=self.net)
+        ctrl = phys.controller
+        assert phys in ctrl.values()
+        phase = phys._phases[0]
+        assert phase in ctrl.values()
+        assert phys.name in phase.physics()
+        assert phase.name in phys.phases()


### PR DESCRIPTION
This PR fixes issue #460 
When create a Physics object without sending a phase, the code used to create and EMPTY generic phase.  Now it creates a generic phase that is the associated with the network.  