### PR TITLE
Better clear

### DIFF
--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -178,7 +178,9 @@ class Core(dict):
 
             **'complete'** : Removes all of the above AND sets the 'pore.all'
             and 'throat.all' labels to zero length.  This also removes any pore
-            and throat locations that were previously set.
+            and throat locations that were previously set.  This mode should be
+            used carefully since it can break some subtle aspects of the
+            framework; it is meant for advanced users and developers.
 
         Notes
         -----

--- a/test/unit/Base/CoreTest.py
+++ b/test/unit/Base/CoreTest.py
@@ -45,7 +45,7 @@ class CoreTest:
                                                       pores=Ps,
                                                       throats=Ts)
 
-    def test_clear(self):
+    def test_clear_complete(self):
         net = OpenPNM.Network.Cubic(shape=[3, 3, 3])
         b = sorted(list(net.keys()))
         dict_ = net.copy()
@@ -59,6 +59,40 @@ class CoreTest:
         assert net.Nt == 54
         a = sorted(list(net.keys()))
         assert a == b
+
+    def test_clear_props(self):
+        net = OpenPNM.Network.Cubic(shape=[3, 3, 3])
+        net.clear(mode='props')
+        assert len(net.props()) == 0
+
+    def test_clear_labels(self):
+        net = OpenPNM.Network.Cubic(shape=[3, 3, 3])
+        net.clear(mode='labels')
+        assert len(net.labels()) == 2
+        assert net.Np == 27
+        assert net.Nt == 54
+
+    def test_clear_labels_and_props(self):
+        net = OpenPNM.Network.Cubic(shape=[3, 3, 3])
+        net.clear(mode=['labels', 'props'])
+        assert len(net.labels()) == 2
+        assert net.Np == 27
+        assert net.Nt == 54
+        assert len(net.props()) == 0
+
+    def test_clear_models(self):
+        net = OpenPNM.Network.Cubic(shape=[3, 3, 3])
+        geo = OpenPNM.Geometry.Stick_and_Ball(network=net,
+                                              pores=net.Ps,
+                                              throats=net.Ts)
+        geo.clear(mode='props')
+        assert len(geo.props()) == 0
+        geo['pore.seed'] = sp.rand(geo.Np)
+        geo.models.regenerate()
+        assert len(geo.props()) > 0
+        geo.clear(mode=['props', 'models'])
+        geo.models.regenerate()
+        assert len(geo.props()) == 0
 
     def test_props_all(self):
         a = self.geo.props()

--- a/test/unit/Geometry/GenericGeometryTest.py
+++ b/test/unit/Geometry/GenericGeometryTest.py
@@ -61,3 +61,19 @@ class GenericGeometryTest:
         except:
             flag = True
         assert flag
+
+    def test_clear(self):
+        self.geo2.clear(mode='complete')
+        assert len(self.geo2.props()) == 0
+        assert len(self.geo2['pore.all']) == 0
+        assert len(self.geo2['throat.all']) == 0
+        assert self.net.num_pores(self.geo2.name) == 0
+        assert self.net.num_throats(self.geo2.name) == 0
+        # Repair geo2 for use in other tests?
+        ctrl = self.net.controller
+        ctrl.purge_object(self.geo2)
+        P = self.net.pores('top')
+        T = self.net.find_neighbor_throats(pores=P, mode='intersection')
+        self.geo2 = OpenPNM.Geometry.GenericGeometry(network=self.net,
+                                                     pores=P,
+                                                     throats=T)

--- a/test/unit/Physics/GenericPhysicsTest.py
+++ b/test/unit/Physics/GenericPhysicsTest.py
@@ -67,3 +67,14 @@ class GenericPhysicsTest:
         assert phase in ctrl.values()
         assert phys.name in phase.physics()
         assert phase.name in phys.phases()
+
+    def test_clear(self):
+        self.phys2 = OpenPNM.Physics.GenericPhysics(network=self.net,
+                                                    phase=self.phase2,
+                                                    geometry=self.geo1)
+        self.phys2.clear(mode='complete')
+        assert len(self.phys2.props()) == 0
+        assert len(self.phys2['pore.all']) == 0
+        assert len(self.phys2['throat.all']) == 0
+        assert self.net.num_pores(self.phys2.name) == 0
+        assert self.net.num_throats(self.phys2.name) == 0


### PR DESCRIPTION
The PR address issue #468.  The point is to add some functionality and control to the Core clear method.  As it is now, it's a hammer that breaks everything.  This PR adds a 'modes' argument that lets the user clear the thing(s) they actually want.  The default behavior is still the same so it should remain backwards compatible.