### PR TITLE
Pandas export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib pandas
   - pip install transforms3d
   - pip install -r test_requirements.txt
   - python setup.py install

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -366,7 +366,7 @@ class Controller(dict):
         ----------
         network : OpenPNM Network Object
             This Network and all of its phases will be written to the specified
-            file.  If no Netowrk is given it will check to ensure that only one
+            file.  If no Network is given it will check to ensure that only one
             Network exists on the Controller and use that.  If there is more
             than one Network an error is thrown.
         filename : string, optional
@@ -376,25 +376,44 @@ class Controller(dict):
         fileformat : string
             The type of file to create.  Options are:
 
-            1. VTK: Suitable for visualizing in VTK capable software such as Paraview
-            2. MAT: Suitable for loading data into Matlab for post-processing
+            **'VTK'**: Suitable for visualizing in VTK capable software such
+            as Paraview
+
+            **'MAT'**: Suitable for loading data into Matlab for post-
+            processing
+
+            **'CSV'**: Suitable for analyzing data in a spreadsheet program
+            such as Excel.  This will save two files, one containing pore data
+            and one containing throat data.  These indicators are appended to
+            to file names.
 
         """
+        import OpenPNM.Utilities.IO as io
+
         if network is None:
             if len(self.networks()) == 1:
                 network = self.networks()[0]
             else:
                 raise Exception('Multiple Networks found, please specify \
                                 which to export')
-        import OpenPNM.Utilities.IO as io
-        if fileformat == 'VTK':
+        # Generate filename if necessary
+        if filename == '':
+            filename = network.name
+
+        fileformat = fileformat.lower()
+        if fileformat == 'vtk':
             phases = network._phases
             io.VTK.save(filename=filename, network=network, phases=phases)
             return
-        if fileformat == 'MAT':
+        elif fileformat == 'mat':
             phases = network._phases
             io.MAT.save(filename=filename, network=network, phases=phases)
             return
+        elif fileformat == 'csv':
+            phases = network._phases
+            io.CSV.save(network=network, filename=filename, phases=phases)
+        else:
+            raise ValueError(fileformat+' is not a valid format')
 
     def _script(self, filename, mode='read'):
         r"""

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -209,6 +209,37 @@ class Core(dict):
         if 'models' in mode:
             self.models.clear()
 
+    def data(self, pores=None, throats=None):
+        r"""
+        Returns dictionary containing numerical data values for all properties
+        assigned to the specified pore and/or throat locations.
+
+        Parameters
+        ----------
+        pores and throats : array_like
+            A list of pore and/or throat locations for which property values
+            are desired.
+
+        Returns
+        -------
+        A dictionary whose keys are the pore and/or throat properties that
+        are defined on the object, with each entry containing a Numpy array
+        of the numerical data values at the specified locations.
+        """
+        pores = self._parse_locations(pores)
+        throats = self._parse_locations(throats)
+        dict_ = {}
+        if (sp.size(pores) == 0) and (sp.size(throats) == 0):
+            pores = self.Ps
+            throats = self.Ts
+        if sp.size(pores) > 0:
+            for item in self.props(element='pore'):
+                dict_.update({item: self[item][pores]})
+        if sp.size(throats) > 0:
+            for item in self.props(element='throat'):
+                dict_.update({item: self[item][throats]})
+        return Tools.PrintableDict(dict_)
+
     # -------------------------------------------------------------------------
     """Model Manipulation Methods"""
     # -------------------------------------------------------------------------

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -209,37 +209,6 @@ class Core(dict):
         if 'models' in mode:
             self.models.clear()
 
-    def data(self, pores=None, throats=None):
-        r"""
-        Returns dictionary containing numerical data values for all properties
-        assigned to the specified pore and/or throat locations.
-
-        Parameters
-        ----------
-        pores and throats : array_like
-            A list of pore and/or throat locations for which property values
-            are desired.
-
-        Returns
-        -------
-        A dictionary whose keys are the pore and/or throat properties that
-        are defined on the object, with each entry containing a Numpy array
-        of the numerical data values at the specified locations.
-        """
-        pores = self._parse_locations(pores)
-        throats = self._parse_locations(throats)
-        dict_ = {}
-        if (sp.size(pores) == 0) and (sp.size(throats) == 0):
-            pores = self.Ps
-            throats = self.Ts
-        if sp.size(pores) > 0:
-            for item in self.props(element='pore'):
-                dict_.update({item: self[item][pores]})
-        if sp.size(throats) > 0:
-            for item in self.props(element='throat'):
-                dict_.update({item: self[item][throats]})
-        return Tools.PrintableDict(dict_)
-
     # -------------------------------------------------------------------------
     """Model Manipulation Methods"""
     # -------------------------------------------------------------------------

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -283,24 +283,30 @@ class Pandas():
         Returns a dict containing 2 Pandas DataFrames with 'pore' and 'throat'
         data in each.
         """
-        # Gather list of prop names
+        # Initialize pore and throat data dictionary with conns and coords
+        pdata = {'pore_coords': network['pore.coords']}
+        tdata = {'throat_conns': network['throat.conns']}
+
+        # Gather list of prop names from network and geometries
         pprops = set(network.props('pore'))
         for item in network._geometries:
             pprops = pprops.union(set(item.props('pore')))
         tprops = set(network.props('throats'))
         for item in network._geometries:
             tprops = tprops.union(set(item.props('throat')))
-        # Add props to tdata and pdata
-        pdata = {}
-        tdata = {}
 
+        # Select data from network and geometries using keys
         for item in pprops:
-            key = 'pore.'+network.name+'_'+item.split('.')[1]
+            key = 'pore_'+network.name+'_'+item.split('.')[1]
             pdata.update({key: network[item]})
         for item in tprops:
-            key = 'throat.'+network.name+'_'+item.split('.')[1]
+            key = 'throat_'+network.name+'_'+item.split('.')[1]
             tdata.update({key: network[item]})
+        # Remove coords and conns from pdata and tdata
+        pdata.pop('pore_'+network.name+'_coords')
+        tdata.pop('throat_'+network.name+'_conns')
 
+        # Gather list of prop names from phases and physics
         for phase in phases:
             # Gather list of prop names
             pprops = set(phase.props('pore'))

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -295,9 +295,11 @@ class Pandas():
         tdata = {}
 
         for item in pprops:
-            pdata.update({network.name+'.'+item: network[item]})
+            key = 'pore.'+network.name+'_'+item.split('.')[1]
+            pdata.update({key: network[item]})
         for item in tprops:
-            tdata.update({network.name+'.'+item: network[item]})
+            key = 'throat.'+network.name+'_'+item.split('.')[1]
+            tdata.update({key: network[item]})
 
         for phase in phases:
             # Gather list of prop names

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -356,8 +356,8 @@ class CSV():
         dfp = dataframes['pore.DataFrame']
         dft = dataframes['throat.DataFrame']
         f = open(filename+'_pore.csv', mode='x')
-        dfp.to_csv(f)
+        dfp.to_csv(f, index=False)
         f.close()
         f = open(filename+'_throat.csv', mode='x')
-        dft.to_csv(f)
+        dft.to_csv(f, index=False)
         f.close()

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -290,19 +290,10 @@ class Pandas():
         tprops = set(network.props('throats'))
         for item in network._geometries:
             tprops = tprops.union(set(item.props('throat')))
-        # Add props to tdata and pdata, starting with coords and conns
+        # Add props to tdata and pdata
         pdata = {}
-        pdata.update({network.name+'.'+'pore.coordsX':
-                      network['pore.coords'][:, 0]})
-        pdata.update({network.name+'.'+'pore.coordsY':
-                      network['pore.coords'][:, 1]})
-        pdata.update({network.name+'.'+'pore.coordsZ':
-                      network['pore.coords'][:, 2]})
         tdata = {}
-        tdata.update({network.name+'.'+'throat.conns1':
-                      network['throat.conns'][:, 0]})
-        tdata.update({network.name+'.'+'throat.conns2':
-                      network['throat.conns'][:, 0]})
+
         for item in pprops:
             pdata.update({network.name+'.'+item: network[item]})
         for item in tprops:
@@ -322,13 +313,22 @@ class Pandas():
             for item in tprops:
                 tdata.update({phase.name+'.'+item: phase[item]})
 
-        # Scan data and remove non-1D arrays
+        # Scan data and convert non-1d arrays to strings
         for item in list(pdata.keys()):
             if _sp.shape(pdata[item]) != (network.Np,):
-                pdata.pop(item)
+                array = pdata.pop(item)
+                temp = _sp.empty((_sp.shape(array)[0], ), dtype=object)
+                for row in range(temp.shape[0]):
+                    temp[row] = str(array[row, :]).strip('[]')
+                pdata.update({item: temp})
+
         for item in list(tdata.keys()):
             if _sp.shape(tdata[item]) != (network.Nt,):
-                tdata.pop(item)
+                array = tdata.pop(item)
+                temp = _sp.empty((_sp.shape(array)[0], ), dtype=object)
+                for row in range(temp.shape[0]):
+                    temp[row] = str(array[row, :]).strip('[]')
+                tdata.update({item: temp})
 
         data = {'pore.DataFrame': _pd.DataFrame.from_dict(pdata),
                 'throat.DataFrame': _pd.DataFrame.from_dict(tdata)}

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -284,8 +284,8 @@ class Pandas():
         data in each.
         """
         # Initialize pore and throat data dictionary with conns and coords
-        pdata = {'pore_coords': network['pore.coords']}
-        tdata = {'throat_conns': network['throat.conns']}
+        pdata = {}
+        tdata = {}
 
         # Gather list of prop names from network and geometries
         pprops = set(network.props('pore'))
@@ -297,14 +297,11 @@ class Pandas():
 
         # Select data from network and geometries using keys
         for item in pprops:
-            key = 'pore_'+network.name+'_'+item.split('.')[1]
+            key = 'pore_'+item.split('.')[1]
             pdata.update({key: network[item]})
         for item in tprops:
-            key = 'throat_'+network.name+'_'+item.split('.')[1]
+            key = 'throat_'+item.split('.')[1]
             tdata.update({key: network[item]})
-        # Remove coords and conns from pdata and tdata
-        pdata.pop('pore_'+network.name+'_coords')
-        tdata.pop('throat_'+network.name+'_conns')
 
         # Gather list of prop names from phases and physics
         for phase in phases:
@@ -317,9 +314,9 @@ class Pandas():
                 tprops = tprops.union(set(item.props('throat')))
             # Add props to tdata and pdata
             for item in pprops:
-                pdata.update({phase.name+'.'+item: phase[item]})
+                pdata.update({item+'_'+phase.name: phase[item]})
             for item in tprops:
-                tdata.update({phase.name+'.'+item: phase[item]})
+                tdata.update({item+'_'+phase.name: phase[item]})
 
         # Scan data and convert non-1d arrays to strings
         for item in list(pdata.keys()):

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -1,4 +1,4 @@
-from OpenPNM.Utilities import misc
+from OpenPNM.Utilities import misc as _misc
 import scipy as _sp
 import numpy as _np
 import pandas as _pd
@@ -46,11 +46,12 @@ class VTK():
             The Network containing the data to be written
 
         filename : string, optional
-            Filename to write data.  If no name is given the file is named after
-            ther network
+            Filename to write data.  If no name is given the file is named
+            after ther network
 
         phases : list, optional
-            A list contain OpenPNM Phase object(s) containing data to be written
+            A list contain OpenPNM Phase object(s) containing data to be
+            written
 
         Examples
         --------
@@ -60,8 +61,10 @@ class VTK():
         ...                                       pores=pn.pores(),
         ...                                       throats=pn.throats())
         >>> air = OpenPNM.Phases.Air(network=pn)
-        >>> phys = OpenPNM.Physics.Standard(network=pn, phase=air,
-        ...                                 pores=pn.pores(), throats=pn.throats())
+        >>> phys = OpenPNM.Physics.Standard(network=pn,
+        ...                                 phase=air,
+        ...                                 pores=pn.pores(),
+        ...                                 throats=pn.throats())
 
         >>> import OpenPNM.Utilities.IO as io
         >>> io.VTK.save(pn,'test_pn.vtp',[air])
@@ -82,7 +85,7 @@ class VTK():
         for phase in phases:
             objs.append(phase)
         objs.append(network)
-        am = misc.amalgamate_data(objs=objs)
+        am = _misc.amalgamate_data(objs=objs)
         key_list = list(sorted(am.keys()))
         points = network['pore.coords']
         pairs = network['throat.conns']
@@ -142,8 +145,8 @@ class VTK():
 
         Notes
         -----
-        This will NOT reproduce original simulation, since all models and object
-        relationships are lost.
+        This will NOT reproduce original simulation, since all models and
+        object relationships are lost.
         """
         network = OpenPNM.Network.GenericNetwork()
         tree = _ET.parse(filename)
@@ -204,8 +207,8 @@ class MAT():
     @staticmethod
     def save(network, filename='', phases=[]):
         r"""
-        Write Network to a Mat file for exporting to Matlab. This method will be
-        enhanced in a future update, and it's functionality may change!
+        Write Network to a Mat file for exporting to Matlab. This method will
+        be enhanced in a future update, and it's functionality may change!
 
         Parameters
         ----------
@@ -274,9 +277,11 @@ class MAT():
 
 class Pandas():
 
-    def save(network, phases=[]):
+    @staticmethod
+    def get_data_frames(network, phases=[]):
         r"""
-        Returns a tuple containing Pandas DataFrames
+        Returns a dict containing 2 Pandas DataFrames with 'pore' and 'throat'
+        data in each.
         """
         # Gather list of prop names
         pprops = set(network.props('pore'))
@@ -326,6 +331,25 @@ class Pandas():
                 tdata.pop(item)
 
         data = {'pore.DataFrame': _pd.DataFrame.from_dict(pdata),
-                'thorat.DataFrame': _pd.DataFrame.from_dict(tdata)}
+                'throat.DataFrame': _pd.DataFrame.from_dict(tdata)}
 
         return data
+
+
+class CSV():
+
+    @staticmethod
+    def save(network, filename='', phases=[]):
+        if filename == '':
+            filename = network.name
+        if filename.endswith('.csv'):
+            filename = filename.rstrip('.csv')
+        dataframes = Pandas.get_data_frames(network=network, phases=phases)
+        dfp = dataframes['pore.DataFrame']
+        dft = dataframes['throat.DataFrame']
+        f = open(filename+'_pore.csv', mode='x')
+        dfp.to_csv(f)
+        f.close()
+        f = open(filename+'_throat.csv', mode='x')
+        dft.to_csv(f)
+        f.close()


### PR DESCRIPTION
Added an IO.export option that outputs all pore and throat data to a set of Pandas DataFrames.  

In addition to providing a helpful output/storage format, they can used for database style lookups of the properties on a given pore.  It might be worth adding a helper method to the code somewhere that uses this.