### PR TITLE
fix_add_boundary_pores

### DIFF
--- a/OpenPNM/Network/__Cubic__.py
+++ b/OpenPNM/Network/__Cubic__.py
@@ -251,14 +251,8 @@ class Cubic(GenericNetwork):
             return sp.array([], dtype=sp.int64)
         # Clone the specifed pores
         self.clone_pores(pores=Ps)
+        newPs = self.pores('pore.clone')
         del self['pore.clone']
-        # Find throat connections by finding nearby neighbors
-        temp = self.find_nearby_pores(pores=Ps,
-                                      distance=1e-10,
-                                      excl_self=False)
-        newPs = temp[:, 1]
-        # Assign new throat connections
-        self.extend(throat_conns=temp)
         # Offset the cloned pores
         self['pore.coords'][newPs] += offset
         # Apply labels to boundary pores (trim leading 'pores' if present)

--- a/test/unit/Network/CubicTest.py
+++ b/test/unit/Network/CubicTest.py
@@ -51,14 +51,17 @@ class CubicTest:
         net = OpenPNM.Network.Cubic(shape=[3, 3, 3], spacing=1)
         net.add_boundary_pores(pores=net.pores('top'), offset=[0, 0, 1])
         assert net.Np == 36
+        assert net.Nt == 63
 
     def test_add_boundary_pores_2D(self):
         net = OpenPNM.Network.Cubic(shape=[3, 3, 1], spacing=1)
         Ps = net.Ps
         net.add_boundary_pores(pores=Ps, offset=[0, 0, 1])
         assert net.Np == 18
+        assert net.Nt == 21
         net.add_boundary_pores(pores=Ps, offset=[0, 0, -1])
         assert net.Np == 27
+        assert net.Nt == 30
 
     def test_add_boundary_pores_custom_label(self):
         net = OpenPNM.Network.Cubic(shape=[3, 3, 3], spacing=1)


### PR DESCRIPTION
Throat connections to the boundary pores were being added twice, AND there were no tests for this!  Both fixed.