### PR TITLE
Changed the way duplicate throats are found.  

### DIFF
--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -928,20 +928,23 @@ class GenericNetwork(Core):
                     health['trim_pores'].extend(temp[c[i]])
 
         # Check for duplicate throats
-        i = self['throat.conns'][:, 0]
-        j = self['throat.conns'][:, 1]
-        v = sp.array(self['throat.all'], dtype=int)
-        adjmat = sprs.coo_matrix((v, (i, j)), [self.Np, self.Np])
+        adjmat = self.create_adjacency_matrix(sprsfmt='coo')
+        incmat = self.create_incidence_matrix(sprsfmt='lil')
         temp = adjmat.tolil()  # Convert to lil to combine duplicates
         # Compile lists of which specfic throats are duplicates
         # Be VERY careful here, as throats are not in order
         mergeTs = []
         for i in range(0, self.Np):
-            if sp.any(sp.array(temp.data[i]) > 1):
+            # If any row has an element more than 1 it means duplicates throats
+            if sp.any(sp.array(temp.data[i], dtype=int) > 1):
                 ind = sp.where(sp.array(temp.data[i]) > 1)[0]
-                P = sp.array(temp.rows[i])[ind]
-                Ts = self.find_connecting_throat(P1=i, P2=P)[0]
-                mergeTs.append(Ts)
+                Ps = sp.array(temp.rows[i])[ind]
+                Ts = []
+                a = set(incmat.rows[i])
+                for neighbor in Ps:
+                    b = set(incmat.rows[neighbor])
+                    Ts.extend(a.intersection(b))
+                mergeTs.append(list(Ts))
         health['duplicate_throats'] = mergeTs
 
         # Check for bidirectional throats

--- a/test/unit/Network/GenericNetworkTest.py
+++ b/test/unit/Network/GenericNetworkTest.py
@@ -157,6 +157,7 @@ class GenericNetworkTest:
         P12 = net['throat.conns'][0]
         net.extend(throat_conns=[P12])
         a = net.check_network_health()
+        assert len(a['duplicate_throats']) == 1
         assert len(a['duplicate_throats'][0]) == 2
 
     def test_check_network_health_triplicate_throats(self):
@@ -165,6 +166,7 @@ class GenericNetworkTest:
         net.extend(throat_conns=[P12])
         net.extend(throat_conns=[P12])
         a = net.check_network_health()
+        assert len(a['duplicate_throats']) == 1
         assert len(a['duplicate_throats'][0]) == 3
 
     def test_check_network_health_multiple_duplicate_throats(self):
@@ -174,6 +176,7 @@ class GenericNetworkTest:
         P12 = net['throat.conns'][1]
         net.extend(throat_conns=[P12])
         a = net.check_network_health()
+        assert len(a['duplicate_throats']) == 2
         assert len(a['duplicate_throats'][1]) == 2
 
     def test_check_network_health_bidirectional_throats(self):


### PR DESCRIPTION
Fixed issue #555.  It was finding correct throats, but apparently not all of them.  This fix works, but may not be fast as it converts to sets inside a for loop.  Optimize later if needed.