### PR TITLE
Improved object lookup 2

### DIFF
--- a/OpenPNM/Algorithms/__GenericAlgorithm__.py
+++ b/OpenPNM/Algorithms/__GenericAlgorithm__.py
@@ -39,9 +39,8 @@ class GenericAlgorithm(Core):
         logger.name = self.name
 
         if network is None:
-            self._net = GenericNetwork()
-        else:
-            self._net = network
+            network = GenericNetwork()
+        self.network.update({network.name: network})
 
         # Initialize label 'all' in the object's own info dictionaries
         self['pore.all'] = self._net['pore.all']

--- a/OpenPNM/Algorithms/__GenericLinearTransport__.py
+++ b/OpenPNM/Algorithms/__GenericLinearTransport__.py
@@ -25,17 +25,17 @@ class GenericLinearTransport(GenericAlgorithm):
         super().__init__(**kwargs)
         if phase is None:
             self._phase = GenericPhase()
-            self._phases.append(self._phase)
+            self.phases.update({self._phase.name: self._phase})
         else:
             self._phase = phase  # Register phase with self
             if sp.size(phase) != 1:
-                self._phases = phase
+                raise Exception('The GenericLinearTransport class can only ' +
+                                'operate on a single phase')
             else:
-                self._phases.append(phase)
-        for comp in self._phases:
-            if comp.Np != self.Np:
-                raise Exception(comp.name + ' has different Np size than the' +
-                                ' algorithm ' + self.name)
+                self.phases.update({phase.name: phase})
+        if self._net is not phase._net:
+            raise Exception(phase.name + 'and this algorithm are associated' +
+                            ' with different networks.')
 
     def set_boundary_conditions(self, bctype='', bcvalue=None, pores=None,
                                 throats=None, mode='merge'):

--- a/OpenPNM/Base/__Controller__.py
+++ b/OpenPNM/Base/__Controller__.py
@@ -174,8 +174,8 @@ class Controller(dict):
             else:
                 net = obj._net
             for item in net.geometries() + net.phases() + net.physics():
-                blank = self.pop(item, None)
-            del self[net.name]
+                self.pop(item, None)
+            self.pop(net.name, None)
         elif mode == 'single':
             name = obj.name
             for item in list(self.keys()):
@@ -183,14 +183,11 @@ class Controller(dict):
                 self[item].pop('pore.' + name, None)
                 self[item].pop('throat.' + name, None)
                 # Remove associations on other objects
-                self[item]._geometries[:] = \
-                    [x for x in self[item]._geometries if x is not obj]
-                self[item]._phases[:] = \
-                    [x for x in self[item]._phases if x is not obj]
-                self[item]._physics[:] = \
-                    [x for x in self[item]._physics if x is not obj]
+                self[item].geometries.pop(name, None)
+                self[item].physics.pop(name, None)
+                self[item].phases.pop(name, None)
             # Remove object from Controller dict
-            del self[name]
+            self.pop(name, None)
 
     def ghost_object(self, obj):
         r"""

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -230,6 +230,18 @@ class Core(dict):
                     objs.append(item.name)
             return objs
 
+    @property
+    def _geometries(self):
+        return list(self.geometries.values())
+
+    @property
+    def _phases(self):
+        return list(self.phases.values())
+
+    @property
+    def _physics(self):
+        return list(self.physics.values())
+
     # -------------------------------------------------------------------------
     """Model Manipulation Methods"""
     # -------------------------------------------------------------------------

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1592,22 +1592,22 @@ class Core(dict):
         if obj is None:
             query = False
             mro = [item.__name__ for item in self.__class__.__mro__]
-            if keyword in ['net', 'Network', 'GenericNetwork']:
+            if 'net' in keyword.lower():
                 if 'GenericNetwork' in mro:
                     query = True
-            elif keyword in ['geom', 'Geometry', 'GenericGeometry']:
+            elif 'geo' in keyword.lower():
                 if 'GenericGeometry' in mro:
                     query = True
-            elif keyword in ['phase', 'Phase', 'GenericPhase']:
+            elif 'phase' in keyword.lower():
                 if 'GenericPhase' in mro:
                     query = True
-            elif keyword in ['phys', 'Physics', 'GenericPhysics']:
+            elif 'phys' in keyword.lower():
                 if 'GenericPhysics' in mro:
                     query = True
-            elif keyword in ['alg', 'Algorithm', 'GenericAlgorithm']:
+            elif 'alg' in keyword.lower():
                 if 'GenericAlgorithm' in mro:
                     query = True
-            elif keyword in ['clone']:
+            elif 'clone' in keyword.lower():
                 if self._net is None:
                     if self._parent is not None:
                         query = True

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -215,6 +215,21 @@ class Core(dict):
         if 'models' in mode:
             self.models.clear()
 
+    def _find_object(self, obj_name='', obj_type=''):
+        all_dicts = {}
+        all_dicts.update(self.geometries)
+        all_dicts.update(self.physics)
+        all_dicts.update(self.phases)
+        all_dicts.update({self._net.name: self._net})
+        if obj_name != '':
+            return all_dicts.get(obj_name)
+        if obj_type != '':
+            objs = []
+            for item in all_dicts.values():
+                if item._isa(obj_type):
+                    objs.append(item.name)
+            return objs
+
     # -------------------------------------------------------------------------
     """Model Manipulation Methods"""
     # -------------------------------------------------------------------------

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -29,7 +29,6 @@ class Core(dict):
         obj.geometries = Tools.ObjectContainer()
         obj.physics = Tools.ObjectContainer()
         obj.network = Tools.ObjectContainer()
-        obj._net = None
         obj._parent = None
         # Initialize ordered dict for storing property models
         obj.models = ModelsDict()
@@ -241,6 +240,10 @@ class Core(dict):
     @property
     def _physics(self):
         return list(self.physics.values())
+
+    @property
+    def _net(self):
+        return list(self.network.values())[0]
 
     # -------------------------------------------------------------------------
     """Model Manipulation Methods"""

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -25,9 +25,10 @@ class Core(dict):
         obj.update({'throat.all': sp.array([], ndmin=1, dtype=bool)})
         # Initialize phase, physics, and geometry tracking lists
         obj._name = None
-        obj._phases = []
-        obj._geometries = []
-        obj._physics = []
+        obj.phases = Tools.ObjectContainer()
+        obj.geometries = Tools.ObjectContainer()
+        obj.physics = Tools.ObjectContainer()
+        obj.network = Tools.ObjectContainer()
         obj._net = None
         obj._parent = None
         # Initialize ordered dict for storing property models
@@ -231,162 +232,6 @@ class Core(dict):
         self.models.regenerate(props=props, mode=mode)
 
     regenerate.__doc__ = ModelsDict.regenerate.__doc__
-
-    # -------------------------------------------------------------------------
-    'Object lookup methods'
-    # -------------------------------------------------------------------------
-
-    def _find_object(self, obj_name='', obj_type=''):
-        r"""
-        Find objects associated with a given network model by name or type
-
-        Parameters
-        ----------
-        obj_name : string
-           Name of sought object
-
-        obj_type : string
-            The type of object beign sought.  Options are:
-
-            1. 'Network' or 'Networks'
-            2. 'Geometry' or 'Geometries'
-            3. 'Phase' or 'Phases'
-            4. 'Physics'
-
-        Returns
-        -------
-        OpenPNM object or list of objects
-
-        """
-        if obj_name != '':
-            obj = []
-            if obj_name in ctrl.keys():
-                obj = ctrl[obj_name]
-            return obj
-        elif obj_type != '':
-            if obj_type in ['Geometry', 'Geometries', 'geometry',
-                            'geometries']:
-                objs = ctrl.geometries()
-            elif obj_type in ['Phase', 'Phases', 'phase', 'phases']:
-                objs = ctrl.phases()
-            elif obj_type in ['Physics', 'physics']:
-                objs = ctrl.physics()
-            elif obj_type in ['Network', 'Networks', 'network', 'networks']:
-                objs = ctrl.networks()
-            return objs
-
-    def physics(self, phys_name=[]):
-        r"""
-        Retrieves Physics associated with the object
-
-        Parameters
-        ----------
-        name : string or list of strings, optional
-            The name(s) of the Physics object to retrieve
-
-        Returns
-        -------
-        If name is NOT provided, then a list of Physics names is returned.
-        If a name or list of names IS provided, then the Physics object(s)
-        with those name(s) is returned.
-        """
-        # If arg given as string, convert to list
-        if type(phys_name) == str:
-            phys_name = [phys_name]
-        if phys_name == []:  # If default argument received
-            phys = [item.name for item in self._physics]
-        else:  # If list of names received
-            phys = []
-            for item in self._physics:
-                if item.name in phys_name:
-                    phys.append(item)
-        return phys
-
-    def phases(self, phase_name=[]):
-        r"""
-        Retrieves Phases associated with the object
-
-        Parameters
-        ----------
-        name : string or list of strings, optional
-            The name(s) of the Phase object(s) to retrieve.
-
-        Returns
-        -------
-        If name is NOT provided, then a list of phase names is returned. If
-        a name are provided, then a list containing the requested objects
-        is returned.
-        """
-        # If arg given as string, convert to list
-        if type(phase_name) == str:
-            phase_name = [phase_name]
-        if phase_name == []:  # If default argument received
-            phase = [item.name for item in self._phases]
-        else:  # If list of names received
-            phase = []
-            for item in self._phases:
-                if item.name in phase_name:
-                    phase.append(item)
-        return phase
-
-    def geometries(self, geom_name=[]):
-        r"""
-        Retrieves Geometry object(s) associated with the object
-
-        Parameters
-        ----------
-        name : string or list of strings, optional
-            The name(s) of the Geometry object to retrieve.
-
-        Returns
-        -------
-        If name is NOT provided, then a list of Geometry names is returned.
-        If a name IS provided, then the Geometry object of that name is
-        returned.
-        """
-        # If arg given as string, convert to list
-        if type(geom_name) == str:
-            geom_name = [geom_name]
-        if geom_name == []:  # If default argument received
-            geom = [item.name for item in self._geometries]
-        else:  # If list of names received
-            geom = []
-            for item in self._geometries:
-                if item.name in geom_name:
-                    geom.append(item)
-        return geom
-
-    def network(self, name=''):
-        r"""
-        Retrieves the network associated with the object.  If the object is
-        a network, then it returns a handle to itself.
-
-        Parameters
-        ----------
-        name : string, optional
-            The name of the Network object to retrieve.
-
-        Returns
-        -------
-            If a name IS provided, then the parent netowrk object is returned.
-
-        Notes
-        -----
-        This doesn't quite work yet...we have to decide how to treat sub-nets
-        first
-        """
-        if name == '':
-            if self._net is None:
-                net = [self]
-            else:
-                net = [self._net]
-        else:
-            net = []
-            temp = self._find_object(obj_name=name)
-            if hasattr(temp, '_isa'):
-                if temp._isa('Network'):
-                    net = temp
-        return net
 
     # -------------------------------------------------------------------------
     """Data Query Methods"""

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -39,12 +39,18 @@ class ObjectContainer(dict):
             list_ = []
             for item in self.keys():
                 list_.append(item)
-            return list_
+            if len(list_) > 0:
+                if self[list_[0]]._isa('network'):
+                    return [self[list_[0]]]
+            return sorted(list_)
         else:
-            if self[name]._isa('network'):
-                return self[name]
+            if type(name) is not list:
+                name = [name]
+            objs = [self[item] for item in name]
+            if objs[0]._isa('network'):
+                return objs[0]
             else:
-                return [self[name]]
+                return objs
 
 
 class PrintableDict(_odict):

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -41,7 +41,10 @@ class ObjectContainer(dict):
                 list_.append(item)
             return list_
         else:
-            return list(self[name])
+            if self[name]._isa('network'):
+                return self[name]
+            else:
+                return [self[name]]
 
 
 class PrintableDict(_odict):

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -41,7 +41,7 @@ class ObjectContainer(dict):
                 list_.append(item)
             return list_
         else:
-            return self[name]
+            return list(self[name])
 
 
 class PrintableDict(_odict):

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -18,6 +18,32 @@ class PrintableList(list):
         return '\n'.join(lines)
 
 
+class ObjectContainer(dict):
+    r"""
+    This dict is a kludgy (but awesome!) fix for the current way object handles
+    are stored on other objects.  Currently ``net.geometries()`` returns a list
+    containing the names (i.e. strings) of all **Geometry** objects (OR if a
+    name is given it returns an actual handle to the object).  This behavior
+    must be maintained for backwards compatibility, but it's a pain since you
+    can't actually iterate over the list.  For instance, it would be nice if
+    you could do ``[item.regenerate() for item in pn.geometries]``; however,
+    the ``geometries`` attribute is a callable method and it returns a list of
+    strings, which is useless.  I've been wanting to replace this with a *dict*
+    for a while, but have finally figured out how to do it.  By making this
+    dict "callable" it can return the list of strings as it does now AND also
+    still be a regular dictionary. Eventually, we could remove the callable
+    aspect (i.e. in V2.0).
+    """
+    def __call__(self, name=None):
+        if name is None:
+            list_ = []
+            for item in self.keys():
+                list_.append(item)
+            return list_
+        else:
+            return self[name]
+
+
 class PrintableDict(_odict):
     def __init__(self, *args, **kwargs):
         self._header = 'value'

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -35,22 +35,19 @@ class ObjectContainer(dict):
     aspect (i.e. in V2.0).
     """
     def __call__(self, name=None):
+        if self == {}:
+            return []
         if name is None:
-            list_ = []
-            for item in self.keys():
-                list_.append(item)
-            if len(list_) > 0:
-                if self[list_[0]]._isa('network'):
-                    return [self[list_[0]]]
-            return list_
+            objs = [item for item in self.keys()]
+            if self[objs[0]]._isa('network'):
+                objs = [self[objs[0]]]
         else:
             if type(name) is not list:
                 name = [name]
             objs = [self[item] for item in name]
             if objs[0]._isa('network'):
-                return objs[0]
-            else:
-                return objs
+                objs = objs[0]
+        return objs
 
 
 class PrintableDict(_odict):

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -42,7 +42,7 @@ class ObjectContainer(dict):
             if len(list_) > 0:
                 if self[list_[0]]._isa('network'):
                     return [self[list_[0]]]
-            return sorted(list_)
+            return list_
         else:
             if type(name) is not list:
                 name = [name]

--- a/OpenPNM/Geometry/__GenericGeometry__.py
+++ b/OpenPNM/Geometry/__GenericGeometry__.py
@@ -50,7 +50,7 @@ class GenericGeometry(Core):
         else:
             self._net = network  # Attach network to self
             # Register self with network.geometries
-            self._net._geometries.append(self)
+            self._net.geometries.update({self.name: self})
 
         # Initialize a label dictionary in the associated network
         self._net['pore.'+self.name] = False

--- a/OpenPNM/Geometry/__GenericGeometry__.py
+++ b/OpenPNM/Geometry/__GenericGeometry__.py
@@ -46,11 +46,10 @@ class GenericGeometry(Core):
         logger.name = self.name
 
         if network is None:
-            self._net = GenericNetwork()
-        else:
-            self._net = network  # Attach network to self
-            # Register self with network.geometries
-            self._net.geometries.update({self.name: self})
+            network = GenericNetwork()
+        self.network.update({network.name: network})  # Attach network to self
+        # Register self with network.geometries
+        self._net.geometries.update({self.name: self})
 
         # Initialize a label dictionary in the associated network
         self._net['pore.'+self.name] = False

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -30,6 +30,7 @@ class GenericNetwork(Core):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         logger.name = self.name
+        self.network.update({self.name: self})
 
         # Initialize adjacency and incidence matrix dictionaries
         self._incidence_matrix = {}

--- a/OpenPNM/Phases/__GenericPhase__.py
+++ b/OpenPNM/Phases/__GenericPhase__.py
@@ -41,9 +41,8 @@ class GenericPhase(Core):
         logger.name = self.name
 
         if network is None:
-            self._net = GenericNetwork()
-        else:
-            self._net = network
+            network = GenericNetwork()
+        self.network.update({network.name: network})
 
         # Initialize label 'all' in the object's own info dictionaries
         self['pore.all'] = self._net['pore.all']

--- a/OpenPNM/Phases/__GenericPhase__.py
+++ b/OpenPNM/Phases/__GenericPhase__.py
@@ -60,7 +60,7 @@ class GenericPhase(Core):
         if components != []:
             for comp in components:
                 self.set_component(phase=comp)
-        self._net._phases.append(self)  # Append this Phase to the Network
+        self._net.phases.update({self.name: self})  # Connect Phase to Network
 
     def __setitem__(self, prop, value):
         for phys in self._physics:
@@ -111,8 +111,8 @@ class GenericPhase(Core):
                 logger.error('Phase already present')
                 pass
             else:
-                self._phases.append(phase)  # Associate any sub-phases with self
-                phase._phases.append(self)  # Associate self with sub-phases
+                self.phases.update({phase.name: phase})  # Associate any sub-phases with self
+                phase.phases.update({self.name: self})  # Associate self with sub-phases
                 # Add models for components to inherit mixture T and P
                 phase.models.add(propname='pore.temperature',
                                  model=OpenPNM.Phases.models.misc.mixture_value)
@@ -122,8 +122,7 @@ class GenericPhase(Core):
                 phase.models.reorder({'pore.temperature': 0, 'pore.pressure': 1})
         elif mode == 'remove':
             if phase.name in self.phases():
-                self._phases.remove(phase)
-                phase._phases = []
+                self.phases.pop(phase.name)
             else:
                 logger.error('Phase not found')
                 pass

--- a/OpenPNM/Phases/__GenericPhase__.py
+++ b/OpenPNM/Phases/__GenericPhase__.py
@@ -110,8 +110,10 @@ class GenericPhase(Core):
                 logger.error('Phase already present')
                 pass
             else:
-                self.phases.update({phase.name: phase})  # Associate any sub-phases with self
-                phase.phases.update({self.name: self})  # Associate self with sub-phases
+                # Associate components with self
+                self.phases.update({phase.name: phase})
+                # Associate self with components
+                phase.phases.update({self.name: self})
                 # Add models for components to inherit mixture T and P
                 phase.models.add(propname='pore.temperature',
                                  model=OpenPNM.Phases.models.misc.mixture_value)

--- a/OpenPNM/Physics/__GenericPhysics__.py
+++ b/OpenPNM/Physics/__GenericPhysics__.py
@@ -53,13 +53,13 @@ class GenericPhysics(OpenPNM.Base.Core):
             self._net = GenericNetwork()
         else:
             self._net = network  # Attach network to self
-            self._net._physics.append(self)  # Register self with network
+            self._net.physics.update({self.name: self})  # Register self with network
 
         # Associate with Phase
         if phase is None:
             phase = GenericPhase(network=self._net)
-        phase._physics.append(self)  # Register self with phase
-        self._phases.append(phase)  # Register phase with self
+        phase.physics.update({self.name: self})  # Register self with phase
+        self.phases.update({phase.name: phase})  # Register phase with self
 
         if geometry is not None:
             if (sp.size(pores) > 0) or (sp.size(throats) > 0):

--- a/OpenPNM/Physics/__GenericPhysics__.py
+++ b/OpenPNM/Physics/__GenericPhysics__.py
@@ -97,10 +97,11 @@ class GenericPhysics(OpenPNM.Base.Core):
         phase['pore.'+self.name] = pore_label
         phase['throat.'+self.name] = throat_label
         # Replace phase reference on self
-        self._phases[0] = phase
+        self.phases.clear()
+        self.phases.update({phase.name: phase})
         # Remove physics reference on current phase
-        current_phase._physics.remove(self)
-        phase._physics.append(self)
+        current_phase.physics.pop(self.name)
+        phase.physics.update({self.name: self})
 
     def _get_phase(self):
         return self._phases[0]

--- a/OpenPNM/Physics/__GenericPhysics__.py
+++ b/OpenPNM/Physics/__GenericPhysics__.py
@@ -50,10 +50,9 @@ class GenericPhysics(OpenPNM.Base.Core):
 
         # Associate with Network
         if network is None:
-            self._net = GenericNetwork()
-        else:
-            self._net = network  # Attach network to self
-            self._net.physics.update({self.name: self})  # Register self with network
+            network = GenericNetwork()
+        self.network.update({network.name: network})  # Attach network to self
+        self._net.physics.update({self.name: self})  # Register self with network
 
         # Associate with Phase
         if phase is None:

--- a/test/unit/Base/CoreTest.py
+++ b/test/unit/Base/CoreTest.py
@@ -442,9 +442,11 @@ class CoreTest:
 
     def test_object_rename(self):
         assert self.geo1 in ctrl.values()
+        old_name = self.geo1.name
         self.geo1.name = 'new_name'
         assert self.geo1.name == 'new_name'
         assert self.geo1 in ctrl.values()
+        self.geo1.name = old_name
 
     def test_object_duplicate_name(self):
         temp = self.geo1.name
@@ -603,8 +605,8 @@ class CoreTest:
         del ctrl[geo.name]
 
     def test_find_all_physics(self):
-        a = self.net1.physics()
-        b = [self.phys1.name, self.phys2.name]
+        a = set(self.net1.physics())
+        b = {self.phys1.name, self.phys2.name}
         assert a == b
 
     def test_find_physics_by_name(self):

--- a/test/unit/Base/CoreTest.py
+++ b/test/unit/Base/CoreTest.py
@@ -618,8 +618,8 @@ class CoreTest:
         assert self.phys2 in a
 
     def test_find_all_phases(self):
-        a = self.net1.phases()
-        b = [self.phase1.name, self.phase2.name]
+        a = set(self.net1.phases())
+        b = {self.phase1.name, self.phase2.name}
         assert a == b
 
     def test_find_phases_by_name(self):
@@ -631,8 +631,8 @@ class CoreTest:
         assert self.phase2 in a
 
     def test_find_all_geometries(self):
-        a = self.net1.geometries()
-        b = [self.geo1.name]
+        a = set(self.net1.geometries())
+        b = {self.geo1.name}
         assert a == b
 
     def test_find_geometries_by_name(self):

--- a/test/unit/Geometry/GenericGeometryTest.py
+++ b/test/unit/Geometry/GenericGeometryTest.py
@@ -1,5 +1,6 @@
 import OpenPNM
 import scipy as sp
+import pytest
 
 
 class GenericGeometryTest:
@@ -55,19 +56,14 @@ class GenericGeometryTest:
         assert sp.sum(a) == self.geo.Np
 
     def test_initialize_with_overlapping_locations(self):
-        flag = False
-        try:
-            OpenPNM.Geometry.GenericGeometry(network=self.net,
-                                             pores=[0])
-        except:
-            flag = True
-        assert flag
+        with pytest.raises(Exception):
+            OpenPNM.Geometry.GenericGeometry(network=self.net, pores=[0])
 
-    def test_plot_histogram(self):
-        self.geo['pore.diameter'] = 1
-        self.geo['throat.diameter'] = 1
-        self.geo['throat.length'] = 1
-        self.geo.plot_histograms()
+#    def test_plot_histogram(self):
+#        self.geo['pore.diameter'] = 1
+#        self.geo['throat.diameter'] = 1
+#        self.geo['throat.length'] = 1
+#        self.geo.plot_histograms()
 
     def test_clear(self):
         self.geo2.clear(mode='complete')


### PR DESCRIPTION
At present, related objects are stored on each other via hidden attribute (i.e. ```_geometries```).  These are accessed using a method ```geometries()``` which returns a list of object names.  This list is useless, and there are MANY places in the code where we iterate over the hidden list of actual objects.  SO, it seems that what we really want is for ```geometries``` to be an actual iterable.  I have used some really cool Python to:

(a) create a dict that stores our objects in the expected location (```geometries```) that we can now iterate over
(b) this dict has an added ```__call__``` method so that ```geometries()``` returns the expected list of strings AND ```geometries('some_name')``` returns the actual handle to the object.  The maintains backward compatibility
(c) the hidden ```_geometries``` list is also still present, but it is now a property method that returns a list which it gets from the ```geometries``` dict.  This also maintains backward compatiblity with the MANY instances of ```_geometries[0]``` throughout the code. 

The bottom line is that we can now do this:

    [item.regenerate() for item in pn.geometries.values()]

Instead of:

    [pn.geometries(item).regenerate() for item in pn.geometries()]

The change is subtle but makes the code MUCH more pythonic and sensible.  