### PR TITLE
Add element to num neighbors

### DIFF
--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -498,9 +498,9 @@ class GenericNetwork(Core):
         Notes
         -----
         This method literally just counts the number of elements in the array
-        returned by ``find_neighbor_pores`` and uses the same logic.  Explore
-        that method and its returned values if uncertain about the meaning of
-        the ``mode`` argument.
+        returned by ``find_neighbor_pores`` or ``find_neighbor_throats`` and
+        uses the same logic.  Explore those methods if uncertain about the
+        meaning of the ``mode`` argument here.
 
         See Also
         --------
@@ -520,17 +520,15 @@ class GenericNetwork(Core):
         """
         pores = self._parse_locations(pores)
         # Count number of neighbors
+        neighbors = self._find_neighbors(pores, element=element,
+                                         flatten=flatten, mode=mode,
+                                         excl_self=True)
         if flatten:
-            neighborPs = self.find_neighbor_pores(pores,
-                                                  flatten=True,
-                                                  mode=mode,
-                                                  excl_self=True)
-            num = sp.shape(neighborPs)[0]
+            num = sp.shape(neighbors)[0]
         else:
-            neighborPs = self.find_neighbor_pores(pores, flatten=False)
-            num = sp.zeros(sp.shape(neighborPs)[0], dtype=int)
+            num = sp.zeros(sp.shape(neighbors)[0], dtype=int)
             for i in range(0, sp.shape(num)[0]):
-                num[i] = sp.size(neighborPs[i])
+                num[i] = sp.size(neighbors[i])
         return num
 
     def find_interface_throats(self, labels=[]):

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -413,7 +413,7 @@ class GenericNetwork(Core):
         """
         neighbors = self._find_neighbors(pores=pores, mode=mode,
                                          element='throat', flatten=flatten,
-                                         excl_self=True)
+                                         excl_self=False)
         return neighbors
 
     def _find_neighbors(self, pores, element, mode, flatten, excl_self):
@@ -454,7 +454,7 @@ class GenericNetwork(Core):
                 neighbors = sp.unique(neighbors)
             elif mode == 'intersection':
                 neighbors = sp.unique(sp.where(sp.bincount(neighbors) > 1)[0])
-            if excl_self is True:
+            if excl_self is True and element == 'pores':
                 neighbors = neighbors[~sp.in1d(neighbors, pores)]
             return sp.array(neighbors, ndmin=1, dtype=int)
         else:
@@ -530,10 +530,8 @@ class GenericNetwork(Core):
                                    mode=mode, excl_self=True)
         num = sp.array([sp.size(i) for i in num], dtype=int)
         if flatten:
-#            num = sp.array([sp.size(i) for i in num], dtype=int)
             num = sp.sum(num)
-        else:
-            pass
+            num = int(num)
         return num
 
     def find_interface_throats(self, labels=[]):

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -418,6 +418,43 @@ class GenericNetwork(Core):
 
     def _find_neighbors(self, pores, element, mode, flatten, excl_self):
         r"""
+        Private method for finding the neighboring pores or throats connected
+        directly to given set of pores.
+
+        Parameters
+        ----------
+        pores : array_like
+            The list of pores whose neighbors are sought
+        element : string, either 'pore' or 'throat'
+            Whether to find neighboring pores or throats
+        mode : string
+            Controls how the neighbors are filtered.  Options are:
+
+            **'union'** : All neighbors of the input pores
+
+            **'intersection'** : Only neighbors shared by all input pores
+
+            **'not_intersection'** : Only neighbors not shared by any input
+            pores
+
+        flatten : boolean
+            If flatten is True (default) a 1D array of unique neighbors is
+            returned. If flatten is False the returned array contains arrays
+            of neighboring throat ID numbers for each input pore, in the order
+            they were sent.
+        excl_self : bool
+            When True the input pores are not included in the returned list of
+            neighboring pores.  This option only applies when input pores are
+            in fact neighbors to each other, otherwise they are not part of the
+            returned list anyway.  This is ignored with the element is
+            'throats'.
+
+        See Also
+        --------
+        find_neighbor_pores
+        find_neighbor_throats
+        num_neighors
+
         """
         element = self._parse_element(element=element, single=True)
         pores = self._parse_locations(pores)
@@ -522,6 +559,7 @@ class GenericNetwork(Core):
         6
         >>> pn.num_neighbors(pores=[0, 1], element='throat', mode='union',
         ...                  flatten=True)
+        6
         """
         pores = self._parse_locations(pores)
         # Count number of neighbors

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -526,12 +526,14 @@ class GenericNetwork(Core):
         """
         pores = self._parse_locations(pores)
         # Count number of neighbors
-        neighbors = self._find_neighbors(pores, element=element,
-                                         flatten=False, mode=mode,
-                                         excl_self=True)
-        num = sp.array([sp.size(i) for i in neighbors], dtype=int)
+        num = self._find_neighbors(pores, element=element, flatten=flatten,
+                                   mode=mode, excl_self=True)
+        num = sp.array([sp.size(i) for i in num], dtype=int)
         if flatten:
+#            num = sp.array([sp.size(i) for i in num], dtype=int)
             num = sp.sum(num)
+        else:
+            pass
         return num
 
     def find_interface_throats(self, labels=[]):

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -443,8 +443,7 @@ class GenericNetwork(Core):
         if flatten:
             # Convert rows of lil into single flat list
             neighbors = itertools.chain.from_iterable(neighbors)
-            # Add input pores to list
-            if element == 'pore':
+            if element == 'pore':  # Add input pores to list
                 neighbors = itertools.chain.from_iterable([neighbors, pores])
             # Convert list to numpy array
             neighbors = sp.fromiter(neighbors, dtype=int)
@@ -454,7 +453,7 @@ class GenericNetwork(Core):
                 neighbors = sp.unique(neighbors)
             elif mode == 'intersection':
                 neighbors = sp.unique(sp.where(sp.bincount(neighbors) > 1)[0])
-            if excl_self is True and element == 'pores':
+            if excl_self and element == 'pore':  # Remove input pores from list
                 neighbors = neighbors[~sp.in1d(neighbors, pores)]
             return sp.array(neighbors, ndmin=1, dtype=int)
         else:

--- a/test/unit/Network/GenericNetworkTest.py
+++ b/test/unit/Network/GenericNetworkTest.py
@@ -95,28 +95,80 @@ class GenericNetworkTest:
         assert sp.all(a == [0, 1, 2, 900, 902, 1800, 1802])
 
     def test_num_neighbors_empty(self):
-        a = self.net.num_neighbors(pores=[])
+        a = self.net.num_neighbors(pores=[], element='pores')
+        assert sp.size(a) == 0
+        a = self.net.num_neighbors(pores=[], element='throats')
         assert sp.size(a) == 0
 
-    def test_num_neighbors_boolean(self):
-        Pind = sp.zeros((self.net.Np,), dtype=bool)
-        Pind[0] = True
-        a = self.net.num_neighbors(pores=Pind)
+    def test_num_neighbors_pores_flattened(self):
+        a = self.net.num_neighbors(pores=0, element='pores', flatten=True)
         assert a == 3
-
-    def test_num_neighbors_numeric_flattened(self):
-        a = self.net.num_neighbors(pores=[0, 2], flatten=True)
+        assert isinstance(a, int)
+        a = self.net.num_neighbors(pores=[0, 2], element='pores', flatten=True)
         assert a == 6
         assert isinstance(a, int)
 
-    def test_num_neighbors_numeric_notflattened(self):
+    def test_num_neighbors_pores_with_modes(self):
+        a = self.net.num_neighbors(pores=[0, 2], element='pores', mode='union',
+                                   flatten=True)
+        assert a == 6
+        a = self.net.num_neighbors(pores=[0, 2], element='pores',
+                                   mode='intersection', flatten=True)
+        assert a == 1
+        a = self.net.num_neighbors(pores=[0, 2], element='pores',
+                                   mode='not_intersection', flatten=True)
+        assert a == 5
+
+    def test_num_neighbors_pores_notflattened(self):
         a = self.net.num_neighbors(pores=[0, 2], flatten=False)
         assert sp.all(a == [3, 4])
-
-    def test_num_neighbors_single_pore_notflattened(self):
         a = self.net.num_neighbors(pores=0, flatten=False)
         assert sp.all(a == [3])
         assert isinstance(a, sp.ndarray)
+
+    def test_num_neighbors_throats_flattened(self):
+        a = self.net.num_neighbors(pores=0, element='throats', flatten=True)
+        assert a == 3
+        a = self.net.num_neighbors(pores=[0, 1], element='throats',
+                                   flatten=True)
+        assert a == 6
+        self.net.extend(throat_conns=[[0, 1], [0, 2]])
+        a = self.net.num_neighbors(pores=0, element='throats', flatten=True)
+        assert a == 5
+        a = self.net.num_neighbors(pores=[0, 1], element='throats',
+                                   flatten=True)
+        assert a == 8
+        self.net.trim(throats=self.net.Ts[-2:])
+
+    def test_num_neighbors_throats_with_modes(self):
+        a = self.net.num_neighbors(pores=[0, 1], element='throats',
+                                   mode='union', flatten=True)
+        assert a == 6
+        self.net.extend(throat_conns=[[0, 1], [0, 2]])
+        a = self.net.num_neighbors(pores=[0, 1], element='throats',
+                                   mode='union', flatten=True)
+        assert a == 8
+        a = self.net.num_neighbors(pores=[0, 1], element='throats',
+                                   mode='intersection', flatten=True)
+        assert a == 2
+        a = self.net.num_neighbors(pores=[0, 1], element='throats',
+                                   mode='not_intersection', flatten=True)
+        assert a == 6
+        self.net.trim(throats=self.net.Ts[-2:])
+
+    def test_num_neighbors_throats_not_flattened(self):
+        a = self.net.num_neighbors(pores=0, element='throats', flatten=False)
+        assert sp.all(a == [3])
+        a = self.net.num_neighbors(pores=[0, 1, 2, 3], element='throats',
+                                   flatten=False)
+        assert sp.all(a == [3, 4, 4, 4])
+        self.net.extend(throat_conns=[[0, 1], [0, 2]])
+        a = self.net.num_neighbors(pores=0, element='throats', flatten=False)
+        assert sp.all(a == [5])
+        a = self.net.num_neighbors(pores=[0, 1, 2, 3], element='throats',
+                                   flatten=False)
+        assert sp.all(a == [5, 5, 5, 4])
+        self.net.trim(throats=self.net.Ts[-2:])
 
     def test_find_interface_throats(self):
         self.net['pore.domain1'] = False


### PR DESCRIPTION
The PR adds two features to ```num_neighbors```.  The ability to specify the 'mode' of the count, and the ability to count neighbor pores and throats. In the backend this also abstracts ```find_neighbor_pores``` and ```find_neighbor_throats``` into a single private method ```_find_neighbors``` that both call.