### PR TITLE
Fix issue 566

### DIFF
--- a/OpenPNM/Physics/models/hydraulic_conductance.py
+++ b/OpenPNM/Physics/models/hydraulic_conductance.py
@@ -9,10 +9,13 @@ import scipy as _sp
 import OpenPNM.Utilities.misc as misc
 
 
-def hagen_poiseuille(physics, phase, network, pore_diameter='pore.diameter',
-                     pore_viscosity='pore.viscosity', throat_length='throat.length',
-                     throat_diameter='throat.diameter', calc_pore_len=True,
+def hagen_poiseuille(physics, phase, network,
+                     pore_diameter='pore.diameter',
+                     pore_viscosity='pore.viscosity',
+                     throat_length='throat.length',
+                     throat_diameter='throat.diameter',
                      shape_factor='throat.shape_factor',
+                     calc_pore_len=False,
                      **kwargs):
     r"""
     Calculates the hydraulic conductivity of throat assuming cylindrical
@@ -26,11 +29,8 @@ def hagen_poiseuille(physics, phase, network, pore_diameter='pore.diameter',
 
     Notes
     -----
-    (1) This function requires that all the necessary phase properties already
-    be calculated.
-
-    (2) This function calculates the specified property for the *entire*
-    network then extracts the values for the appropriate throats at the end.
+    This function calculates the specified property for the *entire* network
+    then extracts the values for the appropriate throats at the end.
 
     """
     # Get Nt-by-2 list of pores connected to each throat

--- a/OpenPNM/Utilities/misc.py
+++ b/OpenPNM/Utilities/misc.py
@@ -242,19 +242,10 @@ def amalgamate_data(objs=[], delimiter='_'):
 
 def conduit_lengths(network, throats=None, mode='pore'):
     r"""
-    Return the respective lengths of the conduit components including part of
-    pore A, part of pore B, and the throat connecting pores Aand B.
-
-    Parameters
-    ----------
-    throats : array_like
-        The list of throats for who's conduit lengths are sought
-    mode : string
-        Controls how the pore length is determined.  Options are:
-
-        **'pore'**: Uses pore coordinates
-        **'centroid'**: Uses pore and throat centroids
-
+    Return the respective lengths of the conduit components defined by the throat
+    conns P1 T P2
+    mode = 'pore' - uses pore coordinates
+    mode = 'centroid' uses pore and throat centroids
     """
     if throats is None:
         throats = network.throats()
@@ -280,13 +271,13 @@ def conduit_lengths(network, throats=None, mode='pore'):
         # Find the pore-to-pore distance, minus the throat length
         lengths = _sp.sqrt(_sp.sum(_sp.square(pcoords[Ps[:, 0]] -
                                    pcoords[Ps[:, 1]]), 1)) - network['throat.length']
-        lengths[lengths <= 0.0] = 2e-9
+        lengths[lengths < 0.0] = 2e-9
         # Calculate the fraction of that distance from the first pore
         try:
             fractions = pdia[Ps[:, 0]]/(pdia[Ps[:, 0]] + pdia[Ps[:, 1]])
             # Don't allow zero lengths
-            fractions[fractions == 0.0] = 0.5
-            fractions[fractions == 1.0] = 0.5
+#            fractions[fractions == 0.0] = 0.5
+#            fractions[fractions == 1.0] = 0.5
         except:
             fractions = 0.5
         plen1 = lengths*fractions

--- a/OpenPNM/Utilities/misc.py
+++ b/OpenPNM/Utilities/misc.py
@@ -242,10 +242,19 @@ def amalgamate_data(objs=[], delimiter='_'):
 
 def conduit_lengths(network, throats=None, mode='pore'):
     r"""
-    Return the respective lengths of the conduit components defined by the throat
-    conns P1 T P2
-    mode = 'pore' - uses pore coordinates
-    mode = 'centroid' uses pore and throat centroids
+    Return the respective lengths of the conduit components including part of
+    pore A, part of pore B, and the throat connecting pores Aand B.
+
+    Parameters
+    ----------
+    throats : array_like
+        The list of throats for who's conduit lengths are sought
+    mode : string
+        Controls how the pore length is determined.  Options are:
+
+        **'pore'**: Uses pore coordinates
+        **'centroid'**: Uses pore and throat centroids
+
     """
     if throats is None:
         throats = network.throats()

--- a/run_script.py
+++ b/run_script.py
@@ -5,7 +5,7 @@ from OpenPNM.Geometry import models as gm
 #==============================================================================
 '''Build Topological Network'''
 #==============================================================================
-pn = op.Network.Cubic(shape=[5,6,7],spacing=0.0001,name='net')
+pn = op.Network.Cubic(shape=[5,5,5],spacing=1,name='net')
 pn.add_boundaries()
 
 #==============================================================================
@@ -13,8 +13,12 @@ pn.add_boundaries()
 #==============================================================================
 Ps = pn.pores('boundary',mode='not')
 Ts = pn.find_neighbor_throats(pores=Ps,mode='intersection',flatten=True)
-geom = op.Geometry.Toray090(network=pn,pores=Ps,throats=Ts)
-geom.models.add(propname='throat.length',model=gm.throat_length.straight)
+geom = op.Geometry.GenericGeometry(network=pn,pores=Ps,throats=Ts)
+geom['throat.length'] = 0
+geom['throat.diameter'] = 1
+geom['pore.diameter'] = 1
+geom['pore.area'] = 1
+geom['throat.area'] = 1
 Ps = pn.pores('boundary')
 Ts = pn.find_neighbor_throats(pores=Ps,mode='not_intersection')
 boun = op.Geometry.Boundary(network=pn,pores=Ps,throats=Ts)
@@ -67,27 +71,18 @@ alg.set_boundary_conditions(bctype='Dirichlet', bcvalue=0.6, pores=BC1_pores)
 BC2_pores = pn.pores('left_boundary')
 alg.set_boundary_conditions(bctype='Dirichlet', bcvalue=0.4, pores=BC2_pores)
 #Add new model to air's physics that accounts for water occupancy
-phys_air.models.add(model=op.Physics.models.multiphase.conduit_conductance,
-                    propname='throat.conduit_diffusive_conductance',
-                    throat_conductance='throat.diffusive_conductance',
-                    throat_occupancy='throat.occupancy',
-                    pore_occupancy='pore.occupancy',
-                    mode='strict',
-                    factor=0)
+#phys_air.models.add(model=op.Physics.models.multiphase.conduit_conductance,
+#                    propname='throat.conduit_diffusive_conductance',
+#                    throat_conductance='throat.diffusive_conductance',
+#                    throat_occupancy='throat.occupancy',
+#                    pore_occupancy='pore.occupancy',
+#                    mode='strict',
+#                    factor=0)
 #Use desired diffusive_conductance in the diffusion calculation (conductance for the dry network or water-filled network)
 alg.run(conductance='throat.diffusive_conductance')
 alg.return_results()
 Deff = alg.calc_eff_diffusivity()
-
-try:
-    # this creates a time step x num_pores, which is what the animated object needs
-    inv_seq = water['pore.IP_inv_seq'].squeeze()
-    history = []
-    for i in sorted(set(inv_seq)):
-      history.append( (inv_seq != 0) & (inv_seq < i) )
-
-except Exception as e:
-    pass
+print(Deff/air['pore.diffusivity'][0])
 
 #------------------------------------------------------------------------------
 '''Export to VTK'''

--- a/test/unit/Physics/models/DiffusiveConductanceTest.py
+++ b/test/unit/Physics/models/DiffusiveConductanceTest.py
@@ -22,11 +22,11 @@ class DiffusiveConductanceTest:
         mod = OpenPNM.Physics.models.diffusive_conductance.bulk_diffusion
         self.phys.models.add(propname='throat.conductance1',
                              model=mod)
-        assert sp.allclose(a = self.phys['throat.conductance1'][0],
-                           b = 0.00084552)
+        assert sp.allclose(a=self.phys['throat.conductance1'][0],
+                           b=0.00084552)
 
         self.phys.models.add(propname='throat.conductance2',
                              model=mod,
                              calc_pore_len=True)
-        assert sp.allclose(a = self.phys['throat.conductance2'][0],
-                           b = 0.00084552)
+        assert sp.allclose(a=self.phys['throat.conductance2'][0],
+                           b=0.00084552)

--- a/test/unit/Physics/models/DiffusiveConductanceTest.py
+++ b/test/unit/Physics/models/DiffusiveConductanceTest.py
@@ -2,6 +2,7 @@ import OpenPNM
 import pytest
 import scipy as sp
 
+
 class DiffusiveConductanceTest:
     def setup_class(self):
         self.net = OpenPNM.Network.Cubic(shape=[5, 5, 5], spacing=1.0)

--- a/test/unit/Physics/models/HydraulicConductance.py
+++ b/test/unit/Physics/models/HydraulicConductance.py
@@ -20,11 +20,11 @@ class HydraulicConductanceTest:
         mod = OpenPNM.Physics.models.hydraulic_conductance.hagen_poiseuille
         self.phys.models.add(propname='throat.conductance1',
                              model=mod)
-        assert sp.allclose(a = self.phys['throat.conductance1'][0],
-                           b = 1330.68207684)
+        assert sp.allclose(a=self.phys['throat.conductance1'][0],
+                           b=1330.68207684)
 
         self.phys.models.add(propname='throat.conductance2',
                              model=mod,
                              calc_pore_len=True)
-        assert sp.allclose(a = self.phys['throat.conductance2'][0],
-                           b = 1330.68207684)
+        assert sp.allclose(a=self.phys['throat.conductance2'][0],
+                           b=1330.68207684)

--- a/test/unit/Physics/models/HydraulicConductance.py
+++ b/test/unit/Physics/models/HydraulicConductance.py
@@ -2,31 +2,29 @@ import OpenPNM
 import pytest
 import scipy as sp
 
-class DiffusiveConductanceTest:
+class HydraulicConductanceTest:
     def setup_class(self):
         self.net = OpenPNM.Network.Cubic(shape=[5, 5, 5], spacing=1.0)
         self.geo = OpenPNM.Geometry.GenericGeometry(network=self.net,
                                                     pores=self.net.Ps,
                                                     throats=self.net.Ts)
         self.geo['pore.diameter'] = 1.0
-        self.geo['pore.area'] = 1.0
         self.geo['throat.diameter'] = 1.0
-        self.geo['throat.length'] = 1e-9
-        self.geo['throat.area'] = 1
+        self.geo['throat.length'] = 1.0e-9
         self.air = OpenPNM.Phases.Air(network=self.net)
         self.phys = OpenPNM.Physics.GenericPhysics(network=self.net,
                                                    phase=self.air,
                                                    geometry=self.geo)
 
-    def test_bulk_diffusion(self):
-        mod = OpenPNM.Physics.models.diffusive_conductance.bulk_diffusion
+    def test_hagen_poiseuille(self):
+        mod = OpenPNM.Physics.models.hydraulic_conductance.hagen_poiseuille
         self.phys.models.add(propname='throat.conductance1',
                              model=mod)
         assert sp.allclose(a = self.phys['throat.conductance1'][0],
-                           b = 0.00084552)
+                           b = 1330.68207684)
 
         self.phys.models.add(propname='throat.conductance2',
                              model=mod,
                              calc_pore_len=True)
         assert sp.allclose(a = self.phys['throat.conductance2'][0],
-                           b = 0.00084552)
+                           b = 1330.68207684)

--- a/test/unit/Physics/models/HydraulicConductance.py
+++ b/test/unit/Physics/models/HydraulicConductance.py
@@ -2,6 +2,7 @@ import OpenPNM
 import pytest
 import scipy as sp
 
+
 class HydraulicConductanceTest:
     def setup_class(self):
         self.net = OpenPNM.Network.Cubic(shape=[5, 5, 5], spacing=1.0)


### PR DESCRIPTION
There is a bug in the Utilities.misc.conduit_length code that calculates longer lengths when boundary pores are present...this PR comments out 2 lines that fix the problem, but we need to come up with a complete solution...

Also, should this conduit length calculator be a pore-scale model?  