### PR TITLE
Fix 579 using deep mode

### DIFF
--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -288,10 +288,11 @@ class Core(dict):
             **'constants'** : Returns only properties that are set as constant
             values
 
-            **'deep'** : Returns all properties on the object and all sub-
-            objects.  For instance, all Geometry properties will be returned
+        deep : Boolean (default if False)
+            If True, all properties on the object and all sub-objects are
+            returned. For instance, all Geometry properties will be returned
             along with all Network properties, and all Physics properties will
-            be returned with all Phase properties.  This mode has not effect
+            be returned with all Phase properties.  This arg has no effect
             when this query is called from a Geometry or Phase object.
 
         Returns

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -73,12 +73,12 @@ class GenericNetwork(Core):
         return self
     _net = property(fset=_set_net, fget=_get_net)
 
-    def props(self, element=None, mode='all'):
+    def props(self, element=None, mode='all', deep=False):
         modes = ['all', 'deep', 'models', 'constants']
         mode = self._parse_mode(mode=mode, allowed=modes, single=False)
         prop_list = Tools.PrintableList()
-        if 'deep' in mode:
-            mode.remove('deep')
+            if mode.count('deep') > 0:
+                mode.remove('deep')
             for geom in self._geometries:
                 prop_list.extend(geom.props(element=element, mode=mode))
             # Get unique values

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -74,6 +74,8 @@ class GenericNetwork(Core):
     _net = property(fset=_set_net, fget=_get_net)
 
     def props(self, element=None, mode='all'):
+        modes = ['all', 'deep', 'models', 'constants']
+        mode = self._parse_mode(mode=mode, allowed=modes, single=False)
         prop_list = Tools.PrintableList()
         if 'deep' in mode:
             mode.remove('deep')

--- a/OpenPNM/Network/__GenericNetwork__.py
+++ b/OpenPNM/Network/__GenericNetwork__.py
@@ -74,9 +74,12 @@ class GenericNetwork(Core):
     _net = property(fset=_set_net, fget=_get_net)
 
     def props(self, element=None, mode='all', deep=False):
+        # TODO: The mode 'deep' is deprecated in favor of the deep argument
+        # and should be removed in a future version
         modes = ['all', 'deep', 'models', 'constants']
         mode = self._parse_mode(mode=mode, allowed=modes, single=False)
         prop_list = Tools.PrintableList()
+        if ('deep' in mode) or (deep is True):
             if mode.count('deep') > 0:
                 mode.remove('deep')
             for geom in self._geometries:

--- a/OpenPNM/Phases/__GenericPhase__.py
+++ b/OpenPNM/Phases/__GenericPhase__.py
@@ -80,6 +80,8 @@ class GenericPhase(Core):
             return super().__getitem__(key)
 
     def props(self, element=None, mode='all', deep=False):
+        # TODO: The mode 'deep' is deprecated in favor of the deep argument
+        # and should be removed in a future version
         modes = ['all', 'deep', 'models', 'constants']
         mode = self._parse_mode(mode=mode, allowed=modes, single=False)
         prop_list = []

--- a/OpenPNM/Phases/__GenericPhase__.py
+++ b/OpenPNM/Phases/__GenericPhase__.py
@@ -79,12 +79,13 @@ class GenericPhase(Core):
         else:
             return super().__getitem__(key)
 
-    def props(self, element=None, mode='all'):
+    def props(self, element=None, mode='all', deep=False):
         modes = ['all', 'deep', 'models', 'constants']
         mode = self._parse_mode(mode=mode, allowed=modes, single=False)
         prop_list = []
-        if 'deep' in mode:
-            mode.remove('deep')
+        if ('deep' in mode) or (deep is True):
+            if mode.count('deep') > 0:
+                mode.remove('deep')
             for phys in self._physics:
                 prop_list.extend(phys.props(element=element, mode=mode))
             # Get unique values

--- a/OpenPNM/Phases/__GenericPhase__.py
+++ b/OpenPNM/Phases/__GenericPhase__.py
@@ -80,6 +80,8 @@ class GenericPhase(Core):
             return super().__getitem__(key)
 
     def props(self, element=None, mode='all'):
+        modes = ['all', 'deep', 'models', 'constants']
+        mode = self._parse_mode(mode=mode, allowed=modes, single=False)
         prop_list = []
         if 'deep' in mode:
             mode.remove('deep')


### PR DESCRIPTION
This PR fixes issue #579 pertaining to the mode deep in the ```props``` method.  I've actually changed the code a bit so that deep is now an argument not a mode, but have tried to maintain backwards compatibility.