### PR TITLE
Find surface pores

### DIFF
--- a/OpenPNM/Network/tools.py
+++ b/OpenPNM/Network/tools.py
@@ -800,20 +800,3 @@ def find_surface_pores(network, im_max=1e7):
     surface = _sp.unique(labels[inds])-1
     network['pore.surface'] = False
     network['pore.surface'][surface] = True
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/OpenPNM/Network/tools.py
+++ b/OpenPNM/Network/tools.py
@@ -734,7 +734,16 @@ def template_sphere_shell(outer_radius=None, inner_radius=0):
 def find_surface_pores(network):
     import scipy.ndimage as spim
     from skimage.morphology import watershed
-    im = _sp.zeros([50, 50, 50], dtype=_sp.uint16)
+    P1 = network['throat.conns'][:, 0]
+    P2 = network['throat.conns'][:, 1]
+    C1 = network['pore.coords'][P1]
+    C2 = network['pore.coords'][P2]
+    E = _sp.sqrt(_sp.sum((C1-C2)**2, axis=1))  # Distance between pores
+    dmin = _sp.amin(network['pore.coords'], axis=0)
+    dmax = _sp.amax(network['pore.coords'], axis=0)
+    spacing = _sp.amin(E)
+    shape = 5*(dmax - dmin)/spacing
+    im = _sp.zeros(shape, dtype=_sp.uint16)
     pts = _sp.array(network['pore.coords']*8, dtype=_sp.uint16)
     val = 1
     for row in pts:

--- a/OpenPNM/Network/tools.py
+++ b/OpenPNM/Network/tools.py
@@ -792,8 +792,7 @@ def find_surface_pores(network, markers=None, label='surface'):
                    [xave, ymin - yave, zave],
                    [xave, yave, zmax + zave],
                    [xave, yave, zmin - zave]]
-    else:
-        markers = _sp.atleast_3d(markers)
+    markers = _sp.atleast_3d(markers)
     for row in range(0, markers.shape[0]):
         tri = sptl.Delaunay(network['pore.coords'], incremental=True)
         tri.add_points(markers[row].T)

--- a/OpenPNM/Network/tools.py
+++ b/OpenPNM/Network/tools.py
@@ -729,3 +729,39 @@ def template_sphere_shell(outer_radius=None, inner_radius=0):
         img_min = x ** 2 + y ** 2 + z ** 2 > _np.unique(rmin) ** 2
         img = img * img_min
     return (img)
+
+
+def find_surface_pores(network):
+    import scipy.ndimage as spim
+    from skimage.morphology import watershed
+    im = _sp.zeros([50, 50, 50], dtype=_sp.uint16)
+    pts = _sp.array(network['pore.coords']*8, dtype=_sp.uint16)
+    val = 1
+    for row in pts:
+        im[row[0], row[1], row[2]] = val
+        val += 1
+    distance = spim.distance_transform_edt(im == 0)
+    labels = watershed(distance, im)
+    box = -_sp.ones(_sp.array(_sp.shape(im))-2)
+    box = _sp.pad(box, pad_width=1, mode='constant', constant_values=1)
+    inds = _sp.where((labels*box) > 0)
+    surface = _sp.unique(labels[inds])-1
+    network['pore.surface'] = False
+    network['pore.surface'][surface] = True
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Added a function to Network.tools that finds pores on the surface of any network and labels them as 'pore.surface', to address issue #527.  This method uses a watershed transport to segment the space around each pore center, then labels all pores whose watershed basin touches the edge of the image as a surface pore.  Because it uses image analysis tricks, it can be slow in some cases: particularly subdivided networks.  