### PR TITLE
removed_dummy_subdivided_network

### DIFF
--- a/OpenPNM/Network/tools.py
+++ b/OpenPNM/Network/tools.py
@@ -609,6 +609,7 @@ def subdivide(network, pores, shape, labels=[]):
     for l in main_labels:
         del network['pore.surface_'+l]
     trim(network=network, pores=pores)
+    _mgr.purge_object(obj=new_net, mode='complete')
 
 
 def trim_occluded_throats(network, mask='all'):


### PR DESCRIPTION
There was a dummy network in the subdivided method, which would appear
in the workspace. Now the object will be purged after running the
method. This PR addresses the issue  #587.