### PR TITLE
Allowing for hidden or private dictionary entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ script:
 
 after_success:
   - codecov
+
+notifications:
+  email: false

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -126,7 +126,7 @@ class Core(dict):
             name = ''.join(random.choice(string.ascii_uppercase +
                                          string.ascii_lowercase +
                                          string.digits) for _ in range(5))
-            name = self.__class__.__name__ + '_' + name
+            name = '_' + self.__class__.__name__ + '_' + name
         elif self._name is not None:
             logger.info('Changing the name of '+self.name+' to '+name)
             # Check if name collides with any arrays in the simulation
@@ -1589,8 +1589,8 @@ class Core(dict):
                                                                          prop,
                                                                          defined,
                                                                          required))
-            elif prop.startswith('pore._') or prop.startswith('throat._'):
-                pass
+            elif '._' in prop:
+                tmp = 0  # dummy assignment
             else:
                 a = sp.isnan(self[item])
                 defined = sp.shape(self[item])[0] \
@@ -1610,8 +1610,8 @@ class Core(dict):
             prop = item
             if len(prop) > 35:
                 prop = prop[0:32] + '...'
-            if prop.startswith('pore._') or prop.startswith('throat._'):
-                pass
+            if '._' in prop:
+                tmp = 0  # dummy assignment
             else:
                 lines.append("{0:<5d} {1:<35s} {2:<10d}".format(i + 1,
                                                                 prop,

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1589,9 +1589,7 @@ class Core(dict):
                                                                          prop,
                                                                          defined,
                                                                          required))
-            elif prop.startswith('pore._') or prop.startswith('throat._'):
-                pass
-            else:
+            elif ~prop.startswith('pore._') or ~prop.startswith('throat._'):
                 a = sp.isnan(self[item])
                 defined = sp.shape(self[item])[0] \
                     - a.sum(axis=0, keepdims=(a.ndim-1) == 0)[0]
@@ -1610,9 +1608,7 @@ class Core(dict):
             prop = item
             if len(prop) > 35:
                 prop = prop[0:32] + '...'
-            if prop.startswith('pore._') or prop.startswith('throat._'):
-                pass
-            else:
+            if ~prop.startswith('pore._') or ~prop.startswith('throat._'):
                 lines.append("{0:<5d} {1:<35s} {2:<10d}".format(i + 1,
                                                                 prop,
                                                                 sp.sum(self[item])))

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1589,7 +1589,9 @@ class Core(dict):
                                                                          prop,
                                                                          defined,
                                                                          required))
-            elif ~prop.startswith('pore._') or ~prop.startswith('throat._'):
+            elif prop.startswith('pore._') or prop.startswith('throat._'):
+                pass
+            else:
                 a = sp.isnan(self[item])
                 defined = sp.shape(self[item])[0] \
                     - a.sum(axis=0, keepdims=(a.ndim-1) == 0)[0]
@@ -1608,7 +1610,9 @@ class Core(dict):
             prop = item
             if len(prop) > 35:
                 prop = prop[0:32] + '...'
-            if ~prop.startswith('pore._') or ~prop.startswith('throat._'):
+            if prop.startswith('pore._') or prop.startswith('throat._'):
+                pass
+            else:
                 lines.append("{0:<5d} {1:<35s} {2:<10d}".format(i + 1,
                                                                 prop,
                                                                 sp.sum(self[item])))

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -126,7 +126,7 @@ class Core(dict):
             name = ''.join(random.choice(string.ascii_uppercase +
                                          string.ascii_lowercase +
                                          string.digits) for _ in range(5))
-            name = '_' + self.__class__.__name__ + '_' + name
+            name = self.__class__.__name__ + '_' + name
         elif self._name is not None:
             logger.info('Changing the name of '+self.name+' to '+name)
             # Check if name collides with any arrays in the simulation

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1589,6 +1589,8 @@ class Core(dict):
                                                                          prop,
                                                                          defined,
                                                                          required))
+            elif prop.startswith('pore._') or prop.startswith('throat._'):
+                pass
             else:
                 a = sp.isnan(self[item])
                 defined = sp.shape(self[item])[0] \
@@ -1608,8 +1610,11 @@ class Core(dict):
             prop = item
             if len(prop) > 35:
                 prop = prop[0:32] + '...'
-            lines.append("{0:<5d} {1:<35s} {2:<10d}".format(i + 1,
-                                                            prop,
-                                                            sp.sum(self[item])))
+            if prop.startswith('pore._') or prop.startswith('throat._'):
+                pass
+            else:
+                lines.append("{0:<5d} {1:<35s} {2:<10d}".format(i + 1,
+                                                                prop,
+                                                                sp.sum(self[item])))
         lines.append(horizonal_rule)
         return '\n'.join(lines)

--- a/OpenPNM/Base/__Core__.py
+++ b/OpenPNM/Base/__Core__.py
@@ -1589,9 +1589,7 @@ class Core(dict):
                                                                          prop,
                                                                          defined,
                                                                          required))
-            elif '._' in prop:
-                tmp = 0  # dummy assignment
-            else:
+            elif '._' not in prop:
                 a = sp.isnan(self[item])
                 defined = sp.shape(self[item])[0] \
                     - a.sum(axis=0, keepdims=(a.ndim-1) == 0)[0]
@@ -1610,9 +1608,7 @@ class Core(dict):
             prop = item
             if len(prop) > 35:
                 prop = prop[0:32] + '...'
-            if '._' in prop:
-                tmp = 0  # dummy assignment
-            else:
+            if '._' not in prop:
                 lines.append("{0:<5d} {1:<35s} {2:<10d}".format(i + 1,
                                                                 prop,
                                                                 sp.sum(self[item])))

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -13,8 +13,8 @@ class PrintableList(list):
         lines = [horizontal_rule]
         self.sort()
         for i, item in enumerate(self):
-            if item.startswith('pore._') or item.startswith('throat._'):
-                pass
+            if '._' in item:
+                tmp = 0  # dummy assignment
             else:
                 lines.append('{0}\t: {1}'.format(i + 1, item))
         lines.append(horizontal_rule)

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -13,7 +13,9 @@ class PrintableList(list):
         lines = [horizontal_rule]
         self.sort()
         for i, item in enumerate(self):
-            if ~item.startswith('pore._') or ~item.startswith('throat._'):
+            if item.startswith('pore._') or item.startswith('throat._'):
+                pass
+            else:
                 lines.append('{0}\t: {1}'.format(i + 1, item))
         lines.append(horizontal_rule)
         return '\n'.join(lines)

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -13,7 +13,10 @@ class PrintableList(list):
         lines = [horizontal_rule]
         self.sort()
         for i, item in enumerate(self):
-            lines.append('{0}\t: {1}'.format(i + 1, item))
+            if item.startswith('pore._') or item.startswith('throat._'):
+                pass
+            else:
+                lines.append('{0}\t: {1}'.format(i + 1, item))
         lines.append(horizontal_rule)
         return '\n'.join(lines)
 

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -13,9 +13,7 @@ class PrintableList(list):
         lines = [horizontal_rule]
         self.sort()
         for i, item in enumerate(self):
-            if item.startswith('pore._') or item.startswith('throat._'):
-                pass
-            else:
+            if ~item.startswith('pore._') or ~item.startswith('throat._'):
                 lines.append('{0}\t: {1}'.format(i + 1, item))
         lines.append(horizontal_rule)
         return '\n'.join(lines)

--- a/OpenPNM/Base/__Tools__.py
+++ b/OpenPNM/Base/__Tools__.py
@@ -13,9 +13,7 @@ class PrintableList(list):
         lines = [horizontal_rule]
         self.sort()
         for i, item in enumerate(self):
-            if '._' in item:
-                tmp = 0  # dummy assignment
-            else:
+            if '._' not in item:
                 lines.append('{0}\t: {1}'.format(i + 1, item))
         lines.append(horizontal_rule)
         return '\n'.join(lines)

--- a/test/unit/Base/CoreTest.py
+++ b/test/unit/Base/CoreTest.py
@@ -127,7 +127,7 @@ class CoreTest:
     def test_props_hidden_keys(self):
         self.net['pore._blah'] = 1.0
         assert 'pore._blah' not in self.net.__str__()
-        assert 'pore._blah' in self.keys()
+        assert 'pore._blah' in self.net.keys()
 
     def test_labels(self):
         a = self.net.labels()

--- a/test/unit/Base/CoreTest.py
+++ b/test/unit/Base/CoreTest.py
@@ -124,6 +124,11 @@ class CoreTest:
         b = ['pore.diameter']
         assert sorted(a) == sorted(b)
 
+    def test_props_hidden_keys(self):
+        self.net['pore._blah'] = 1.0
+        assert 'pore._blah' not in self.net.__str__()
+        assert 'pore._blah' in self.keys()
+
     def test_labels(self):
         a = self.net.labels()
         assert 'pore.top' in a
@@ -208,6 +213,11 @@ class CoreTest:
     def test_labels_pores_mode_foo(self):
         with pytest.raises(Exception):
             self.net.labels(pores=[0, 1], mode='foo')
+
+    def test_labels_hidden_key(self):
+        self.net['pore._foo'] = True
+        assert 'pore._foo' not in self.net.__str__()
+        assert 'pore._foo' in self.net.keys()
 
     def test_pores(self):
         a = self.net.pores()

--- a/test/unit/Base/ToolsTest.py
+++ b/test/unit/Base/ToolsTest.py
@@ -17,8 +17,9 @@ class ToolsTest:
 
         def test_hidden_items(self):
             list_ = Tools.PrintableList(['pore.first', 'pore._second'])
-            assert 'first' in list_.__str__()
-            assert 'pore._second' not in list_.__str__()
+            s = list_.__str__()
+            assert 'pore.first' in s
+            assert 'pore._second' not in s
 
     class PrintableDictTest:
         def setup_class(self):

--- a/test/unit/Base/ToolsTest.py
+++ b/test/unit/Base/ToolsTest.py
@@ -3,10 +3,11 @@ from OpenPNM.Base import Tools
 
 class PrintableListTest:
     def setup_class(self):
-        self.list = Tools.PrintableList(['first', 'second'])
+        pass
 
     def test_str(self):
-        actual_string = self.list.__str__()
+        list_ = Tools.PrintableList(['first', 'second'])
+        actual_string = list_.__str__()
         expected_string = \
             '------------------------------------------------------------\n' + \
             '1\t: first\n' + \
@@ -16,11 +17,11 @@ class PrintableListTest:
 
     def test_hidden_items(self):
         list_ = Tools.PrintableList(['pore.first', 'pore._second'])
-        s = list_.__str__()
-        assert 'pore.first' in s
-        assert 'pore._second' not in s
+        actual_string = list_.__str__()
+        assert 'pore.first' in actual_string
+        assert 'pore._second' not in actual_string
 
-.
+
 class PrintableDictTest:
     def setup_class(self):
         self.dict = Tools.PrintableDict()

--- a/test/unit/Base/ToolsTest.py
+++ b/test/unit/Base/ToolsTest.py
@@ -16,9 +16,9 @@ class ToolsTest:
             assert actual_string == expected_string
 
         def test_hidden_items(self):
-            list_ = Tools.PrintableList(['first', '_second'])
+            list_ = Tools.PrintableList(['pore.first', 'pore._second'])
             assert 'first' in list_.__str__()
-            assert '_second' not in list_.__str__()
+            assert 'pore._second' not in list_.__str__()
 
     class PrintableDictTest:
         def setup_class(self):

--- a/test/unit/Base/ToolsTest.py
+++ b/test/unit/Base/ToolsTest.py
@@ -1,43 +1,43 @@
 from OpenPNM.Base import Tools
 
 
-class ToolsTest:
-    class PrintableListTest:
-        def setup_class(self):
-            self.list = Tools.PrintableList(['first', 'second'])
 
-        def test_str(self):
-            actual_string = self.list.__str__()
-            expected_string = \
-                '------------------------------------------------------------\n' + \
-                '1\t: first\n' + \
-                '2\t: second\n' + \
-                '------------------------------------------------------------'
-            assert actual_string == expected_string
+class PrintableListTest:
+    def setup_class(self):
+        self.list = Tools.PrintableList(['first', 'second'])
 
-        def test_hidden_items(self):
-            list_ = Tools.PrintableList(['pore.first', 'pore._second'])
-            s = list_.__str__()
-            assert 'pore.first' in s
-            assert 'pore._second' not in s
+    def test_str(self):
+        actual_string = self.list.__str__()
+        expected_string = \
+            '------------------------------------------------------------\n' + \
+            '1\t: first\n' + \
+            '2\t: second\n' + \
+            '------------------------------------------------------------'
+        assert actual_string == expected_string
 
-    class PrintableDictTest:
-        def setup_class(self):
-            self.dict = Tools.PrintableDict()
-            self.dict['first_key'] = 'first_value'
-            self.dict['second_key'] = 'second_value'
+    def test_hidden_items(self):
+        list_ = Tools.PrintableList(['pore.first', 'pore._second'])
+        s = list_.__str__()
+        assert 'pore.first' in s
+        assert 'pore._second' not in s
 
-        def test_str(self):
-            actual_string = self.dict.__str__()
-            expected_string = \
-                '------------------------------------------------------------\n' + \
-                'key                       value\n' + \
-                '------------------------------------------------------------\n' + \
-                'first_key                 first_value\n' + \
-                'second_key                second_value\n' + \
-                '------------------------------------------------------------'
-            assert actual_string == expected_string
+class PrintableDictTest:
+    def setup_class(self):
+        self.dict = Tools.PrintableDict()
+        self.dict['first_key'] = 'first_value'
+        self.dict['second_key'] = 'second_value'
 
-        def test_representation(self):
-            a = self.dict.__repr__()
-            assert type(a) is str
+    def test_str(self):
+        actual_string = self.dict.__str__()
+        expected_string = \
+            '------------------------------------------------------------\n' + \
+            'key                       value\n' + \
+            '------------------------------------------------------------\n' + \
+            'first_key                 first_value\n' + \
+            'second_key                second_value\n' + \
+            '------------------------------------------------------------'
+        assert actual_string == expected_string
+
+    def test_representation(self):
+        a = self.dict.__repr__()
+        assert type(a) is str

--- a/test/unit/Base/ToolsTest.py
+++ b/test/unit/Base/ToolsTest.py
@@ -20,7 +20,7 @@ class PrintableListTest:
         assert 'pore.first' in s
         assert 'pore._second' not in s
 
-
+.
 class PrintableDictTest:
     def setup_class(self):
         self.dict = Tools.PrintableDict()

--- a/test/unit/Base/ToolsTest.py
+++ b/test/unit/Base/ToolsTest.py
@@ -1,7 +1,6 @@
 from OpenPNM.Base import Tools
 
 
-
 class PrintableListTest:
     def setup_class(self):
         self.list = Tools.PrintableList(['first', 'second'])
@@ -20,6 +19,7 @@ class PrintableListTest:
         s = list_.__str__()
         assert 'pore.first' in s
         assert 'pore._second' not in s
+
 
 class PrintableDictTest:
     def setup_class(self):

--- a/test/unit/Base/ToolsTest.py
+++ b/test/unit/Base/ToolsTest.py
@@ -15,6 +15,11 @@ class ToolsTest:
                 '------------------------------------------------------------'
             assert actual_string == expected_string
 
+        def test_hidden_items(self):
+            list_ = Tools.PrintableList(['first', '_second'])
+            assert 'first' in list_.__str__()
+            assert '_second' not in list_.__str__()
+
     class PrintableDictTest:
         def setup_class(self):
             self.dict = Tools.PrintableDict()


### PR DESCRIPTION
Adjusted the __str__ function on Core to not show any dict keys starting with 'pore._' or throat._'.  Also adjust the PrintableList to do the same.  This way print(pn), print(pn.props()), and print(pn.labels()) will all exclude the hidden or private arrays.

Actually implementing this throughout the code will be a pain, but at least the framework is ready.