### PR TITLE
Rename_save_to_save_workspace

### DIFF
--- a/OpenPNM/Base/__Workspace__.py
+++ b/OpenPNM/Base/__Workspace__.py
@@ -302,7 +302,7 @@ class Workspace(dict):
         for item in temp_dict.values():
             item.workspace = self
 
-    def save(self, filename=''):
+    def save_workspace(self, filename=''):
         r"""
         Save the entire state of the Workspace to a 'pnm' file.
 
@@ -342,7 +342,14 @@ class Workspace(dict):
         # Save nested dictionary pickle
         _pickle.dump(self, open(filename + '.pnm', 'wb'))
 
-    def load(self, filename):
+    def save(self, **kwargs):
+        r"""
+        This method is deprecated, use ``save_workspace`` instead.
+        """
+        logger.warning("This method is deprecated, use \'save_workspace\'.")
+        self.save_workspace(**kwargs)
+
+    def load_workspace(self, filename):
         r"""
         Load an entire Workspace from a 'pnm' file.
 
@@ -374,6 +381,13 @@ class Workspace(dict):
                                    '\n' +
                                    '--> Current version: ' +
                                    str(OpenPNM.__version__))
+
+    def load(self, **kwargs):
+        r"""
+        This method is deprecated, use ``load_workspace`` instead.
+        """
+        logger.warning("This method is deprecated, use \'load_workspace\'.")
+        self.load_workspace(**kwargs)
 
     def export(self, network=None, filename='', fileformat='VTK'):
         logger.warning("This method is deprecated, use \'export_data\'.")

--- a/OpenPNM/__init__.py
+++ b/OpenPNM/__init__.py
@@ -58,8 +58,8 @@ from .Base import Workspace as mgr
 
 _workspace = mgr()
 del mgr
-save = _workspace.save
-load = _workspace.load
+save_workspace = _workspace.save_workspace
+load_workspace = _workspace.load_workspace
 export_data = _workspace.export_data
 import_data = _workspace.import_data
 clear = _workspace.clear

--- a/test/unit/Base/ControllerTest.py
+++ b/test/unit/Base/ControllerTest.py
@@ -21,25 +21,25 @@ class WorkspaceTest:
         assert self.workspace.loglevel == 'Log level is currently set to: 50'
 
     def test_save_and_load(self):
-        self.workspace.save(join(TEMP_DIR, 'test_workspace'))
+        self.workspace.save_workspace(filename=join(TEMP_DIR, 'test_workspace'))
         self.workspace.clear()
         assert self.workspace == {}
-        self.workspace.load(join(TEMP_DIR, 'test_workspace'))
+        self.workspace.load_workspace(filename=join(TEMP_DIR, 'test_workspace'))
         assert self.net.name in self.workspace.keys()
 
     def test_load_overwrite_existing(self):
         temp = self.workspace.copy()
-        self.workspace.save(join(TEMP_DIR, 'test_workspace'))
-        self.workspace.load(join(TEMP_DIR, 'test_workspace'))
+        self.workspace.save_workspace(filename=join(TEMP_DIR, 'test_workspace'))
+        self.workspace.load_workspace(filename=join(TEMP_DIR, 'test_workspace'))
         flag = [i for i in temp.keys() if i not in self.workspace.keys()]
 
     def test_save_no_name(self):
-        self.workspace.save()
+        self.workspace.save_workspace()
 
     def test_load_v120_pnm(self):
         temp = self.workspace.copy()
         self.workspace.clear()
-        self.workspace.load(join(FIXTURE_DIR, 'test_v120.pnm'))
+        self.workspace.load_workspace(filename=join(FIXTURE_DIR, 'test_v120.pnm'))
         a = [
             'Boundary_hy4Ey',
             'FickianDiffusion_LjxxQ',


### PR DESCRIPTION
Renamed save and load to save_workspace and load_workspace to be more descriptive.  Change is backward compatible, except that the helper methods at the package level were also updated, but not made backward compatible.