### PR TITLE
Dual cubic

### DIFF
--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -5,11 +5,8 @@ CubicDUal: Generate lattice-like networks with a
 ===============================================================================
 
 """
-import numpy as np
 import scipy as sp
-import scipy.spatial as sptl
 import OpenPNM.Utilities.misc as misc
-from OpenPNM.Network import tools
 from OpenPNM.Network import GenericNetwork
 from OpenPNM.Base import logging
 logger = logging.getLogger(__name__)

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""
+===============================================================================
+CubicDUal: Generate lattice-like networks with a
+===============================================================================
+
+"""
+import numpy as np
+import scipy as sp
+import scipy.spatial as sptl
+import OpenPNM.Utilities.misc as misc
+from OpenPNM.Network import tools
+from OpenPNM.Network import GenericNetwork
+from OpenPNM.Base import logging
+logger = logging.getLogger(__name__)
+
+
+class CubicDual(GenericNetwork):
+    r"""
+    Generates a cubic network of the specified size and shape.
+
+    Parameters
+    ----------
+    name : string
+        A unique name for the network
+
+    shape : list of ints
+        The size and shape of the network in terms of the number of pores in
+        each principal direction.  Solid nodes will be added at the center of
+        of each cube defined by 8 pores.
+
+    spacing : list of floats
+        The distance between pores in each of the principal directions
+
+    Examples
+    --------
+    >>>
+    """
+    def __init__(self, shape=None, spacing=[1, 1, 1], **kwargs):
+        super().__init__(**kwargs)
+        import OpenPNM as op
+        spacing = sp.array(spacing)
+        shape = sp.array(shape)
+        net = op.Network.Cubic(shape=shape, spacing=[1, 1, 1])
+        net['throat.cubic'] = True
+        net['pore.cubic'] = True
+        dual = op.Network.Cubic(shape=shape-1)
+        dual['pore.center'] = True
+        dual['throat.center'] = True
+        dual['pore.coords'] += 0.5
+        op.Network.tools.stitch(net, dual, P_network=net.Ps,
+                                P_donor=dual.Ps, len_max=1)
+        net['throat.interconnect'] = net['throat.stitched']
+        # Create center pores on each surface
+        offset = {'back': [0.5, 0, 0], 'front': [-0.5, 0, 0],
+                  'right': [0, 0.5, 0], 'left': [0, -0.5, 0],
+                  'top': [0, 0, 0.5], 'bottom': [0, 0, -0.5]}
+        for item in ['top', 'bottom', 'left', 'right', 'front', 'back']:
+            Ps = net.pores(labels=[item, 'center'], mode='intersection')
+            net.clone_pores(pores=Ps, apply_label=['surface', item])
+            Ps = net.pores(labels=['surface', item], mode='intersection')
+            net['pore.coords'][Ps] += offset[item]
+        del net['throat.stitched']
+        net['pore.coords'] *= spacing
+        [self.update({item: net[item]}) for item in net]
+        del self.workspace[net.name]
+
+    def add_boundary_pores(self, pores, offset, apply_label='boundary'):
+        r"""
+        This method uses ``clone_pores`` to clone the input pores, then shifts
+        them the specified amount and direction, then applies the given label.
+
+        Parameters
+        ----------
+        pores : array_like
+            List of pores to offset.  If no pores are specified, then it
+            assumes that all surface pores are to be cloned.
+
+        offset : 3 x 1 array
+            The distance in vector form which the cloned boundary pores should
+            be offset.  If no spacing is provided, then the spacing is inferred
+            from the Network.
+
+        apply_label : string
+            This label is applied to the boundary pores.  Default is
+            'boundary'.
+
+        Examples
+        --------
+        >>> import OpenPNM as op
+        >>> pn = op.Network.Cubic(shape=[5, 5, 5])
+        >>> print(pn.Np)  # Confirm initial Network size
+        125
+        >>> Ps = pn.pores('top')  # Select pores on top face
+        >>> pn.add_boundary_pores(pores=Ps, offset=[0, 0, 1])
+        >>> print(pn.Np)  # Confirm addition of 25 new pores
+        150
+        >>> 'pore.boundary' in pn.labels()  # Default label is created
+        True
+        """
+        # Parse the input pores
+        Ps = sp.array(pores, ndmin=1)
+        if Ps.dtype is bool:
+            Ps = self.toindices(Ps)
+        if sp.size(pores) == 0:  # Handle an empty array if given
+            return sp.array([], dtype=sp.int64)
+        # Clone the specifed pores
+        self.clone_pores(pores=Ps)
+        newPs = self.pores('pore.clone')
+        del self['pore.clone']
+        # Offset the cloned pores
+        self['pore.coords'][newPs] += offset
+        # Apply labels to boundary pores (trim leading 'pores' if present)
+        label = apply_label.split('.')[-1]
+        label = 'pore.' + label
+        logger.debug('The label \''+label+'\' has been applied')
+        self[label] = False
+        self[label][newPs] = True
+
+    def domain_length(self, face_1, face_2):
+        r"""
+        Calculate the distance between two faces of the network
+
+        Parameters
+        ----------
+        face_1 and face_2 : array_like
+            Lists of pores belonging to opposite faces of the network
+
+        Returns
+        -------
+        The length of the domain in the specified direction
+
+        Notes
+        -----
+        - Does not yet check if input faces are perpendicular to each other
+        """
+        # Ensure given points are coplanar before proceeding
+        if misc.iscoplanar(self['pore.coords'][face_1]) and \
+                misc.iscoplanar(self['pore.coords'][face_2]):
+            # Find distance between given faces
+            x = self['pore.coords'][face_1]
+            y = self['pore.coords'][face_2]
+            Ds = misc.dist(x, y)
+            L = sp.median(sp.amin(Ds, axis=0))
+        else:
+            logger.warning('The supplied pores are not coplanar. Length will be \
+                            approximate.')
+            f1 = self['pore.coords'][face_1]
+            f2 = self['pore.coords'][face_2]
+            distavg = [0, 0, 0]
+            distavg[0] = sp.absolute(sp.average(f1[:, 0]) - sp.average(f2[:, 0]))
+            distavg[1] = sp.absolute(sp.average(f1[:, 1]) - sp.average(f2[:, 1]))
+            distavg[2] = sp.absolute(sp.average(f1[:, 2]) - sp.average(f2[:, 2]))
+            L = max(distavg)
+        return L
+
+    def domain_area(self, face):
+        r"""
+        Calculate the area of a given network face
+
+        Parameters
+        ----------
+        face : array_like
+            List of pores of pore defining the face of interest
+
+        Returns
+        -------
+        The area of the specified face
+        """
+        coords = self['pore.coords'][face]
+        rads = self['pore.diameter'][face]/2.
+        # Calculate the area of the 3 principle faces of the bounding cuboid
+        dx = max(coords[:, 0]+rads) - min(coords[:, 0]-rads)
+        dy = max(coords[:, 1]+rads) - min(coords[:, 1]-rads)
+        dz = max(coords[:, 2]+rads) - min(coords[:, 2]-rads)
+        yz = dy*dz  # x normal
+        xz = dx*dz  # y normal
+        xy = dx*dy  # z normal
+        # Find the directions parallel to the plane
+        directions = sp.where([yz, xz, xy] != max([yz, xz, xy]))[0]
+        try:
+            # Use the whole network to do the area calculation
+            coords = self['pore.coords']
+            rads = self['pore.diameter']/2.
+            d0 = (max(coords[:, directions[0]]+rads) -
+                  min(coords[:, directions[0]]-rads))
+            d1 = (max(coords[:, directions[1]]+rads) -
+                  min(coords[:, directions[1]]-rads))
+            A = d0*d1
+        except:
+            # If that fails, use the max face area of the bounding cuboid
+            A = max([yz, xz, xy])
+        if not misc.iscoplanar(self['pore.coords'][face]):
+            logger.warning('The supplied pores are not coplanar. Area will be'
+                           'approximate')
+            pass
+        return A

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -15,9 +15,9 @@ logger = logging.getLogger(__name__)
 class CubicDual(GenericNetwork):
     r"""
     Generates a cubic network of the specified size and shape, then inserts
-    as second cubic network in the interstitial regions.  These two networks
-    are further connected by throats that allows material to be exchanged
-    between them.
+    as second cubic network to the corners of its lattice cells.  These two
+    networks are further connected by throats enabling material to be
+    exchanged between them.
 
     Parameters
     ----------
@@ -25,18 +25,18 @@ class CubicDual(GenericNetwork):
         A unique name for the network
 
     shape : list of ints
-        The size and shape of the principal cubic network in terms of the
+        The size and shape of the primary cubic network in terms of the
         number of pores in each direction.  Secondary nodes will be added at
-        the center of each unit cell defined by a cube 8 pores in the primary
-        network.
+        corners of each unit cell so the dual network will generaly have a
+        size of ''shape'' + 1.
 
     spacing : list of floats
-        The distance between pores in each of the principal directions
+        The distance between pores of the primary network in each of the
+        principal directions
 
     label_1 and label_2 : strings
-        The labels to apply to the main cubic lattice and the interpenetrating
-        cubic lattice (i.e. the dual network).  The defaults are 'corners' and
-        'centers', which refers to the position on the unit cell.
+        The labels to apply to the primary and secondary cubic lattices, which
+        defaults to 'primary' and 'secondary' respectively.
 
     Examples
     --------
@@ -46,15 +46,18 @@ class CubicDual(GenericNetwork):
                  label_2='centers', **kwargs):
         super().__init__(**kwargs)
         import OpenPNM as op
-        spacing = sp.array(spacing)
-        shape = sp.array(shape)
+        spacing = sp.array(1)
+        shape = sp.array([5, 5, 5])
+        label_1 = 'primary'
+        label_2 = 'secondary'
         net = op.Network.Cubic(shape=shape, spacing=[1, 1, 1])
+        net.add_boundaries()
         net['throat.'+label_1] = True
         net['pore.'+label_1] = True
-        dual = op.Network.Cubic(shape=shape-1)
+        dual = op.Network.Cubic(shape=shape+1)
         dual['pore.'+label_2] = True
         dual['throat.'+label_2] = True
-        dual['pore.coords'] += 0.5
+        dual['pore.coords'] -= 0.5
         op.Network.tools.stitch(net, dual, P_network=net.Ps,
                                 P_donor=dual.Ps, len_max=1)
         net['throat.interconnect'] = net['throat.stitched']

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -69,13 +69,19 @@ class CubicDual(GenericNetwork):
         for item in surface_labels:
             # Clone 'center' pores and shift to surface
             Ps = net.pores(labels=[item, label_2], mode='intersection')
-            net.clone_pores(pores=Ps, apply_label=[label_2, 'surface', item])
-            Ps = net.pores(labels=['surface', item], mode='intersection')
+            net['pore.'+item][Ps] = False
+            net['pore._clone'] = False
+            net['throat._clone'] = False
+            net.clone_pores(pores=Ps, apply_label=[label_2, '_clone'])
+            Ps = net.pores(labels=['_clone'])
             net['pore.coords'][Ps] += offset[item]
             Ts = net.find_neighbor_throats(pores=Ps)
             # Label pores and throats
             net['pore.surface'][Ps] = True
+            net['pore.'+item][Ps] = True
             net['throat.'+label_2][Ts] = True
+        del net['pore._clone']
+        del net['throat._clone']
         # Connect surface pores of both networks to each other
         for item in surface_labels:
             Ps1 = net.pores(labels=['surface', item], mode='intersection')
@@ -84,7 +90,8 @@ class CubicDual(GenericNetwork):
                 Ps3 = net.filter_by_label(pores=Ps2[row], labels=[item])
                 if Ps3.size:
                     conns = sp.array([list([Ps1[row]])*Ps3.size, Ps3]).T
-                    net.extend(throat_conns=conns, labels='surface')
+                    net.extend(throat_conns=conns,
+                               labels=['surface', 'interconnect'])
 
         Ps = net.pores(labels=surface_labels)
         net['pore.surface'][Ps] = True

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -93,8 +93,7 @@ class CubicDual(GenericNetwork):
 
         offset : 3 x 1 array
             The distance in vector form which the cloned boundary pores should
-            be offset.  If no spacing is provided, then the spacing is inferred
-            from the Network.
+            be offset.
 
         apply_label : string
             This label is applied to the boundary pores.  Default is
@@ -131,82 +130,3 @@ class CubicDual(GenericNetwork):
         logger.debug('The label \''+label+'\' has been applied')
         self[label] = False
         self[label][newPs] = True
-
-    def domain_length(self, face_1, face_2):
-        r"""
-        Calculate the distance between two faces of the network
-
-        Parameters
-        ----------
-        face_1 and face_2 : array_like
-            Lists of pores belonging to opposite faces of the network
-
-        Returns
-        -------
-        The length of the domain in the specified direction
-
-        Notes
-        -----
-        - Does not yet check if input faces are perpendicular to each other
-        """
-        # Ensure given points are coplanar before proceeding
-        if misc.iscoplanar(self['pore.coords'][face_1]) and \
-                misc.iscoplanar(self['pore.coords'][face_2]):
-            # Find distance between given faces
-            x = self['pore.coords'][face_1]
-            y = self['pore.coords'][face_2]
-            Ds = misc.dist(x, y)
-            L = sp.median(sp.amin(Ds, axis=0))
-        else:
-            logger.warning('The supplied pores are not coplanar. Length will be \
-                            approximate.')
-            f1 = self['pore.coords'][face_1]
-            f2 = self['pore.coords'][face_2]
-            distavg = [0, 0, 0]
-            distavg[0] = sp.absolute(sp.average(f1[:, 0]) - sp.average(f2[:, 0]))
-            distavg[1] = sp.absolute(sp.average(f1[:, 1]) - sp.average(f2[:, 1]))
-            distavg[2] = sp.absolute(sp.average(f1[:, 2]) - sp.average(f2[:, 2]))
-            L = max(distavg)
-        return L
-
-    def domain_area(self, face):
-        r"""
-        Calculate the area of a given network face
-
-        Parameters
-        ----------
-        face : array_like
-            List of pores of pore defining the face of interest
-
-        Returns
-        -------
-        The area of the specified face
-        """
-        coords = self['pore.coords'][face]
-        rads = self['pore.diameter'][face]/2.
-        # Calculate the area of the 3 principle faces of the bounding cuboid
-        dx = max(coords[:, 0]+rads) - min(coords[:, 0]-rads)
-        dy = max(coords[:, 1]+rads) - min(coords[:, 1]-rads)
-        dz = max(coords[:, 2]+rads) - min(coords[:, 2]-rads)
-        yz = dy*dz  # x normal
-        xz = dx*dz  # y normal
-        xy = dx*dy  # z normal
-        # Find the directions parallel to the plane
-        directions = sp.where([yz, xz, xy] != max([yz, xz, xy]))[0]
-        try:
-            # Use the whole network to do the area calculation
-            coords = self['pore.coords']
-            rads = self['pore.diameter']/2.
-            d0 = (max(coords[:, directions[0]]+rads) -
-                  min(coords[:, directions[0]]-rads))
-            d1 = (max(coords[:, directions[1]]+rads) -
-                  min(coords[:, directions[1]]-rads))
-            A = d0*d1
-        except:
-            # If that fails, use the max face area of the bounding cuboid
-            A = max([yz, xz, xy])
-        if not misc.iscoplanar(self['pore.coords'][face]):
-            logger.warning('The supplied pores are not coplanar. Area will be'
-                           'approximate')
-            pass
-        return A

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 ===============================================================================
-CubicDUal: Generate lattice-like networks with a
+CubicDual: Generate a cubic lattice with an interpentrating dual network
 ===============================================================================
 
 """
@@ -14,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 class CubicDual(GenericNetwork):
     r"""
-    Generates a cubic network of the specified size and shape.
+    Generates a cubic network of the specified size and shape, then inserts
+    as second cubic network in the interstitial regions.  These two networks
+    are further connected by throats that allows material to be exchanged
+    between them.
 
     Parameters
     ----------
@@ -73,6 +76,16 @@ class CubicDual(GenericNetwork):
             # Label pores and throats
             net['pore.surface'][Ps] = True
             net['throat.'+label_2][Ts] = True
+        # Connect surface pores of both networks to each other
+        for item in surface_labels:
+            Ps1 = net.pores(labels=['surface', item], mode='intersection')
+            Ps2 = net.find_nearby_pores(pores=Ps1, distance=0.7072)
+            for row in range(len(Ps1)):
+                Ps3 = net.filter_by_label(pores=Ps2[row], labels=[item])
+                if Ps3.size:
+                    conns = sp.array([list([Ps1[row]])*Ps3.size, Ps3]).T
+                    net.extend(throat_conns=conns, labels='surface')
+
         Ps = net.pores(labels=surface_labels)
         net['pore.surface'][Ps] = True
 

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -64,35 +64,7 @@ class CubicDual(GenericNetwork):
         del net['throat.stitched']
         net['pore.surface'] = False
         net['throat.surface'] = False
-        # Create center pores on each surface
-        offset = {'back': [0.5, 0, 0], 'front': [-0.5, 0, 0],
-                  'right': [0, 0.5, 0], 'left': [0, -0.5, 0],
-                  'top': [0, 0, 0.5], 'bottom': [0, 0, -0.5]}
-        surface_labels = ['top', 'bottom', 'left', 'right', 'front', 'back']
-        for item in surface_labels:
-            # Clone 'center' pores and shift to surface
-            Ps = net.pores(labels=[item, label_2], mode='intersection')
-            net['pore.'+item][Ps] = False
-            net['pore._clone'] = False
-            net['throat._clone'] = False
-            net.clone_pores(pores=Ps, apply_label=[label_2, '_clone'])
-            Ps = net.pores(labels=['_clone'])
-            net['pore.coords'][Ps] += offset[item]
-            Ts = net.find_neighbor_throats(pores=Ps)
-            # Label pores and throats
-            net['pore.surface'][Ps] = True
-            net['pore.'+item][Ps] = True
-            net['throat.'+label_2][Ts] = True
-        # Connect surface pores of both networks to each other
-        for item in surface_labels:
-            Ps1 = net.pores(labels=['surface', item], mode='intersection')
-            Ps2 = net.find_nearby_pores(pores=Ps1, distance=0.7072)
-            for row in range(len(Ps1)):
-                Ps3 = net.filter_by_label(pores=Ps2[row], labels=[item])
-                if Ps3.size:
-                    conns = sp.array([list([Ps1[row]])*Ps3.size, Ps3]).T
-                    net.extend(throat_conns=conns,
-                               labels=['surface', 'interconnect'])
+
 
         # Clean-ups
         net['pore.coords'] *= spacing

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -80,8 +80,6 @@ class CubicDual(GenericNetwork):
             net['pore.surface'][Ps] = True
             net['pore.'+item][Ps] = True
             net['throat.'+label_2][Ts] = True
-        del net['pore._clone']
-        del net['throat._clone']
         # Connect surface pores of both networks to each other
         for item in surface_labels:
             Ps1 = net.pores(labels=['surface', item], mode='intersection')
@@ -93,10 +91,16 @@ class CubicDual(GenericNetwork):
                     net.extend(throat_conns=conns,
                                labels=['surface', 'interconnect'])
 
+        # Clean-ups
+        net['pore.coords'] *= spacing
         Ps = net.pores(labels=surface_labels)
         net['pore.surface'][Ps] = True
-
-        net['pore.coords'] *= spacing
+        net['pore.internal'] = ~net['pore.surface']
+        Ts = net.find_neighbor_throats(pores=net['pore.internal'])
+        net['throat.internal'] = False
+        net['throat.internal'][Ts] = True
+        del net['pore._clone']
+        del net['throat._clone']
         [self.update({item: net[item]}) for item in net]
         del self.workspace[net.name]
 

--- a/OpenPNM/Network/__init__.py
+++ b/OpenPNM/Network/__init__.py
@@ -34,6 +34,7 @@ Classes
 from . import tools
 from .__GenericNetwork__ import GenericNetwork
 from .__Cubic__ import Cubic
+from .__CubicDual__ import CubicDual
 from .__Delaunay__ import Delaunay
 from .__DelaunayCubic__ import DelaunayCubic
 from .__MatFile__ import MatFile

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -1,4 +1,5 @@
 import OpenPNM as op
+import scipy as sp
 
 
 class CubicDualTest:
@@ -15,3 +16,12 @@ class CubicDualTest:
         assert net.num_throats('secondary') == 240
         assert net.num_throats('surface') == 96
         assert net.num_throats('interconnect') == 512
+
+    def test_add_boundary_pores(self):
+        net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',
+                                   label_2='secondary')
+        Ps = net.pores(labels=['surface', 'bottom'], mode='intersection')
+        net.add_boundary_pores(pores=Ps, offset=[0, 0, -0.5])
+        Ps2 = net.pores(labels=['boundary'], mode='intersection')
+        assert Ps.size == Ps2.size
+        assert sp.any(sp.in1d(Ps, Ps2)) == False

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -10,7 +10,7 @@ class CubicDualTest:
         assert net.Np == 285
         assert net.Nt == 1052
         assert net.num_pores('primary') == 125
-        assert net.num_pores('secondary') == 125
+        assert net.num_pores('secondary') == 160
         assert net.num_pores('surface') == 250
         assert net.num_throats('primary') == 300
         assert net.num_throats('secondary') == 240
@@ -24,4 +24,4 @@ class CubicDualTest:
         net.add_boundary_pores(pores=Ps, offset=[0, 0, -0.5])
         Ps2 = net.pores(labels=['boundary'], mode='intersection')
         assert Ps.size == Ps2.size
-        assert sp.any(sp.in1d(Ps, Ps2)) == False
+        assert ~sp.any(sp.in1d(Ps, Ps2))

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -7,8 +7,8 @@ class CubicDualTest:
     def test_generation(self):
         net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',
                                    label_2='secondary')
-        assert net.Np == 285
-        assert net.Nt == 1436
+        assert net.Np == 491
+        assert net.Nt == 2590
         assert net.num_pores('all') == 491
         assert net.num_pores('back') == 61
         assert net.num_pores('bottom') == 61

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -8,14 +8,14 @@ class CubicDualTest:
         net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',
                                    label_2='secondary')
         assert net.Np == 285
-        assert net.Nt == 1052
+        assert net.Nt == 1436
         assert net.num_pores('primary') == 125
         assert net.num_pores('secondary') == 160
-        assert net.num_pores('surface') == 250
+        assert net.num_pores('surface') == 194
         assert net.num_throats('primary') == 300
         assert net.num_throats('secondary') == 240
-        assert net.num_throats('surface') == 96
-        assert net.num_throats('interconnect') == 512
+        assert net.num_throats('surface') == 384
+        assert net.num_throats('interconnect') == 896
 
     def test_add_boundary_pores(self):
         net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -1,0 +1,17 @@
+import OpenPNM as op
+
+
+class CubicDualTest:
+
+    def test_generation(self):
+        net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',
+                                   label_2='secondary')
+        assert net.Np == 285
+        assert net.Nt == 1052
+        assert net.num_pores('primary') == 125
+        assert net.num_pores('secondary') == 125
+        assert net.num_pores('surface') == 250
+        assert net.num_throats('primary') == 300
+        assert net.num_throats('secondary') == 240
+        assert net.num_throats('surface') == 96
+        assert net.num_throats('interconnect') == 512

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -9,13 +9,23 @@ class CubicDualTest:
                                    label_2='secondary')
         assert net.Np == 285
         assert net.Nt == 1436
-        assert net.num_pores('primary') == 125
-        assert net.num_pores('secondary') == 160
-        assert net.num_pores('surface') == 194
-        assert net.num_throats('primary') == 300
-        assert net.num_throats('secondary') == 240
-        assert net.num_throats('surface') == 384
-        assert net.num_throats('interconnect') == 896
+        assert net.num_pores('all') == 491
+        assert net.num_pores('back') == 61
+        assert net.num_pores('bottom') == 61
+        assert net.num_pores('front') == 61
+        assert net.num_pores('internal') == 189
+        assert net.num_pores('left') == 61
+        assert net.num_pores('primary') == 275
+        assert net.num_pores('right') == 61
+        assert net.num_pores('secondary') == 216
+        assert net.num_pores('surface') == 302
+        assert net.num_pores('top') == 61
+        assert net.num_throats('all') == 2590
+        assert net.num_throats('interconnect') == 1600
+        assert net.num_throats('internal') == 1690
+        assert net.num_throats('primary') == 450
+        assert net.num_throats('secondary') == 540
+        assert net.num_throats('surface') == 900
 
     def test_add_boundary_pores(self):
         net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',


### PR DESCRIPTION
This PR adds a CubicDual class to the suite of Network generators.  This class creates a standard cubic, but with an another cubic network interpenetrating it offset by half a lattice cell.  These two dual networks are also connected to each other, which allows exchange of material between them such as heat transfer, or perhaps to model mass transfer from pores centers to walls.  This class is added as the cubic counter part to the DelaunayVoronoiDual class added in PR #604 .