### PR TITLE
Debugged subdivide method

### DIFF
--- a/OpenPNM/Network/tools.py
+++ b/OpenPNM/Network/tools.py
@@ -529,13 +529,14 @@ def subdivide(network, pores, shape, labels=[]):
     pores = _sp.array(pores, ndmin=1)
 
     # Checks to find boundary pores in the selected pores
-    try:
-        b = network.pores('boundary')
-        if (_sp.in1d(pores, b)).any():
+    if 'pore.boundary' in network.labels():
+        if (_sp.in1d(pores, network.pores('boundary'))).any():
             raise Exception('boundary pores cannot be subdivided!')
-    except KeyError:
-        pass
-
+    if not hasattr(network, '_subdivide_flag'):
+        network._subdivide_flag = True
+    else:
+        raise Exception('The network has subdivided pores, so the method ' +
+                        'does not support another subdivision.')
     # Assigning right shape and division
     if _sp.size(shape) != 2 and _sp.size(shape) != 3:
         raise Exception('Subdivide not implemented for Networks other than 2D \

--- a/test/integration/test_topological_manipulations.py
+++ b/test/integration/test_topological_manipulations.py
@@ -1,6 +1,7 @@
 import OpenPNM
 from os.path import join
 import scipy as sp
+import pytest
 from OpenPNM.Utilities import topology
 mgr = OpenPNM.Base.Workspace()
 topo = topology()
@@ -23,10 +24,8 @@ def test_subdivide_boundary():
     pn.add_boundaries()
     pn['pore.micro'] = True
     nano_pores = [2, 13, 126, 15]
-    try:
+    with pytest.raises(Exception):
         pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
-    except Exception:
-        pass
     nano_pores = [2, 13, 14, 15]
     pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
     assert pn.Np == (275+4*64-4)
@@ -42,10 +41,8 @@ def test_subdivide_consecutive():
     assert pn.Np == (125+4*64-4)
     assert pn.Nt == (300+(4*144)-16+15*16+16)
     nano_pores = [7, 11]
-    try:
+    with pytest.raises(Exception):
         pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
-    except Exception:
-        pass
     assert (pn._subdivide_flag)
 
 

--- a/test/integration/test_topological_manipulations.py
+++ b/test/integration/test_topological_manipulations.py
@@ -16,6 +16,39 @@ def test_subdivide():
     assert pn.Np == (125+4*64-4)
     assert pn.Nt == (300+(4*144)-16+15*16+16)
 
+
+def test_subdivide_boundary():
+    pn = OpenPNM.Network.Cubic(shape=[5, 5, 5],
+                               spacing=0.001)
+    pn.add_boundaries()
+    pn['pore.micro'] = True
+    nano_pores = [2, 13, 126, 15]
+    try:
+        pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
+    except Exception:
+        pass
+    nano_pores = [2, 13, 14, 15]
+    pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
+    assert pn.Np == (275+4*64-4)
+    assert pn.Nt == (450+(4*144)-16+24*16-16-(2+3+2))
+
+
+def test_subdivide_consecutive():
+    pn = OpenPNM.Network.Cubic(shape=[5, 5, 5],
+                               spacing=0.001)
+    pn['pore.micro'] = True
+    nano_pores = [2, 13, 14, 15]
+    pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
+    assert pn.Np == (125+4*64-4)
+    assert pn.Nt == (300+(4*144)-16+15*16+16)
+    nano_pores = [7, 11]
+    try:
+        pn.subdivide(pores=nano_pores, shape=[4, 4, 4], labels='nano')
+    except Exception:
+        pass
+    assert (pn._subdivide_flag)
+
+
 def test_clone_and_trim():
     mgr.clear()
     pn = OpenPNM.Network.Cubic(shape=[5, 5, 5], name='net')


### PR DESCRIPTION
This PR addresses the issue  #617 and is just a quick fix for the problem that some users might have had. Before, it was allowing user to run the subdivide method consecutively, but right now, it raises an Exception. Because creating the proper connections is really complicated when it comes to the different spacing and scales.