### PR TITLE
Bugfix for #628 Utilities.IO.Statoil breaking for large networks

### DIFF
--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -302,19 +302,12 @@ class Statoil():
         for item in ['node1']:
             filename = _os.path.join(path, prefix+'_'+item+'.dat')
             with _read_file(filename=filename, ext='dat') as f:
-                row_0 = f.readline().split(' ')
-                while '' in row_0:
-                    row_0.remove('')
+                row_0 = f.readline().split()
                 num_lines = int(row_0[0])
                 array = _sp.ndarray([num_lines, 6])
                 for i in range(num_lines):
-                    row = f.readline().split(' ')
-                    while '' in row:
-                        row.remove('')
-                    try:
-                        row.remove('\n')
-                    except:
-                        pass
+                    row = f.readline()\
+                           .replace('\t',' ').replace('\n',' ').split()
                     array[i, :] = row[0:6]
         node1 = _pd.DataFrame(array[:, [1, 2, 3, 4]])
         node1.columns = ['pore.x_coord', 'pore.y_coord', 'pore.z_coord',

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -307,7 +307,7 @@ class Statoil():
                 array = _sp.ndarray([num_lines, 6])
                 for i in range(num_lines):
                     row = f.readline()\
-                           .replace('\t',' ').replace('\n',' ').split()
+                           .replace('\t', ' ').replace('\n', ' ').split()
                     array[i, :] = row[0:6]
         node1 = _pd.DataFrame(array[:, [1, 2, 3, 4]])
         node1.columns = ['pore.x_coord', 'pore.y_coord', 'pore.z_coord',


### PR DESCRIPTION
as discussed in #628 the following changes were made:

1. replace '\t' and '\n' in row string by ' ', and then split - will consider subsequent whitespace as just one whitespace
replace('\t',' ').replace('\n',' ').split()
2. clean up those parts of the code that did manual splitting for just one whitespace using spit(' ') by just using split without argument as split()