### PR TITLE
Fix cubic dual

### DIFF
--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -47,6 +47,8 @@ class CubicDual(GenericNetwork):
         super().__init__(**kwargs)
         spacing = sp.array(spacing)
         shape = sp.array(shape)
+        # Deal with non-3D shape arguments
+        shape = sp.pad(shape, [0, 3-shape.size], mode='constant', constant_values=1)
         net = Cubic(shape=shape, spacing=[1, 1, 1])
         net['throat.'+label_1] = True
         net['pore.'+label_1] = True

--- a/OpenPNM/Network/__CubicDual__.py
+++ b/OpenPNM/Network/__CubicDual__.py
@@ -6,8 +6,8 @@ CubicDual: Generate a cubic lattice with an interpentrating dual network
 
 """
 import scipy as sp
-import OpenPNM.Utilities.misc as misc
-from OpenPNM.Network import GenericNetwork
+from OpenPNM.Network.tools import stitch
+from OpenPNM.Network import GenericNetwork, Cubic
 from OpenPNM.Base import logging
 logger = logging.getLogger(__name__)
 
@@ -45,23 +45,17 @@ class CubicDual(GenericNetwork):
     def __init__(self, shape=None, spacing=[1, 1, 1], label_1='primary',
                  label_2='secondary', **kwargs):
         super().__init__(**kwargs)
-        import OpenPNM as op
-        spacing = sp.array(1)
-        shape = sp.array([5, 5, 5])
-        label_1 = 'primary'
-        label_2 = 'secondary'
         spacing = sp.array(spacing)
         shape = sp.array(shape)
-        net = op.Network.Cubic(shape=shape, spacing=[1, 1, 1])
-        net.add_boundaries()
+        net = Cubic(shape=shape, spacing=[1, 1, 1])
         net['throat.'+label_1] = True
         net['pore.'+label_1] = True
-        dual = op.Network.Cubic(shape=shape+1)
+        dual = Cubic(shape=shape-1, spacing=[1, 1, 1])
+        dual.add_boundaries()
         dual['pore.'+label_2] = True
         dual['throat.'+label_2] = True
-        dual['pore.coords'] -= 0.5
-        op.Network.tools.stitch(net, dual, P_network=net.Ps, P_donor=dual.Ps,
-                                len_max=1)
+        dual['pore.coords'] += 0.5
+        stitch(net, dual, P_network=net.Ps, P_donor=dual.Ps, len_max=1)
         net['throat.interconnect'] = net['throat.stitched']
         net['pore.coords'] *= spacing
 

--- a/OpenPNM/Network/tools.py
+++ b/OpenPNM/Network/tools.py
@@ -345,6 +345,7 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
     # Ensure Networks have no associated objects yet
     if (len(network._simulation()) > 1) or (len(donor._simulation()) > 1):
         raise Exception('Cannot stitch a Network with active sibling objects')
+    network['throat.stitched'] = False
     # Get the initial number of pores and throats
     N_init = {}
     N_init['pore'] = network.Np

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -50,12 +50,12 @@ class CubicDualTest:
                                    label_2='secondary')
         assert net.Np == 57
         assert net.Nt == 176
-        assert net.num_pores('left') == 9
-        assert net.num_pores('right') == 9
+        assert net.num_pores('left') == 41
+        assert net.num_pores('right') == 41
         assert net.num_pores('front') == 9
         assert net.num_pores('back') == 9
-        assert net.num_pores('top') == 41
-        assert net.num_pores('bottom') == 41
+        assert net.num_pores('top') == 9
+        assert net.num_pores('bottom') == 9
         net.num_throats('interconnect') == 96
 
         net = op.Network.CubicDual(shape=[1, 5, 5], label_1='primary',
@@ -64,8 +64,8 @@ class CubicDualTest:
         assert net.Nt == 176
         assert net.num_pores('left') == 9
         assert net.num_pores('right') == 9
-        assert net.num_pores('front') == 9
-        assert net.num_pores('back') == 9
-        assert net.num_pores('top') == 41
-        assert net.num_pores('bottom') == 41
+        assert net.num_pores('front') == 41
+        assert net.num_pores('back') == 41
+        assert net.num_pores('top') == 9
+        assert net.num_pores('bottom') == 9
         net.num_throats('interconnect') == 96

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -10,9 +10,9 @@ class CubicDualTest:
         assert net.Np == 285
         assert net.Nt == 1436
         assert net.num_pores('all') == 285
-        assert net.num_pores('back') == 21
-        assert net.num_pores('bottom') == 21
-        assert net.num_pores('front') == 21
+        assert net.num_pores('back') == 41
+        assert net.num_pores('bottom') == 41
+        assert net.num_pores('front') == 41
         assert net.num_pores('internal') == 91
         assert net.num_pores('left') == 41
         assert net.num_pores('primary') == 125

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -33,7 +33,7 @@ class CubicDualTest:
         assert net.num_throats('front') == 104
         assert net.num_throats('back') == 104
 
-    def test_generation_2D(self):
+    def test_generation_2D_XY(self):
         net = op.Network.CubicDual(shape=[5, 5, 1], label_1='primary',
                                    label_2='secondary')
         assert net.Np == 57
@@ -46,6 +46,7 @@ class CubicDualTest:
         assert net.num_pores('bottom') == 41
         net.num_throats('interconnect') == 96
 
+    def test_generation_2D_XZ(self):
         net = op.Network.CubicDual(shape=[5, 1, 5], label_1='primary',
                                    label_2='secondary')
         assert net.Np == 57
@@ -58,6 +59,7 @@ class CubicDualTest:
         assert net.num_pores('bottom') == 9
         net.num_throats('interconnect') == 96
 
+    def test_generation_2D_YZ(self):
         net = op.Network.CubicDual(shape=[1, 5, 5], label_1='primary',
                                    label_2='secondary')
         assert net.Np == 57
@@ -68,4 +70,17 @@ class CubicDualTest:
         assert net.num_pores('back') == 41
         assert net.num_pores('top') == 9
         assert net.num_pores('bottom') == 9
+        net.num_throats('interconnect') == 96
+
+    def test_generation_2D_2_dims(self):
+        net = op.Network.CubicDual(shape=[5, 5], label_1='primary',
+                                   label_2='secondary')
+        assert net.Np == 57
+        assert net.Nt == 176
+        assert net.num_pores('left') == 9
+        assert net.num_pores('right') == 9
+        assert net.num_pores('front') == 9
+        assert net.num_pores('back') == 9
+        assert net.num_pores('top') == 41
+        assert net.num_pores('bottom') == 41
         net.num_throats('interconnect') == 96

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -4,7 +4,7 @@ import scipy as sp
 
 class CubicDualTest:
 
-    def test_generation(self):
+    def test_generation_3D(self):
         net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',
                                    label_2='secondary')
         assert net.Np == 285
@@ -32,3 +32,40 @@ class CubicDualTest:
         assert net.num_throats('right') == 104
         assert net.num_throats('front') == 104
         assert net.num_throats('back') == 104
+
+    def test_generation_2D(self):
+        net = op.Network.CubicDual(shape=[5, 5, 1], label_1='primary',
+                                   label_2='secondary')
+        assert net.Np == 57
+        assert net.Nt == 176
+        assert net.num_pores('left') == 9
+        assert net.num_pores('right') == 9
+        assert net.num_pores('front') == 9
+        assert net.num_pores('back') == 9
+        assert net.num_pores('top') == 41
+        assert net.num_pores('bottom') == 41
+        net.num_throats('interconnect') == 96
+
+        net = op.Network.CubicDual(shape=[5, 1, 5], label_1='primary',
+                                   label_2='secondary')
+        assert net.Np == 57
+        assert net.Nt == 176
+        assert net.num_pores('left') == 9
+        assert net.num_pores('right') == 9
+        assert net.num_pores('front') == 9
+        assert net.num_pores('back') == 9
+        assert net.num_pores('top') == 41
+        assert net.num_pores('bottom') == 41
+        net.num_throats('interconnect') == 96
+
+        net = op.Network.CubicDual(shape=[1, 5, 5], label_1='primary',
+                                   label_2='secondary')
+        assert net.Np == 57
+        assert net.Nt == 176
+        assert net.num_pores('left') == 9
+        assert net.num_pores('right') == 9
+        assert net.num_pores('front') == 9
+        assert net.num_pores('back') == 9
+        assert net.num_pores('top') == 41
+        assert net.num_pores('bottom') == 41
+        net.num_throats('interconnect') == 96

--- a/test/unit/Network/CubicDualTest.py
+++ b/test/unit/Network/CubicDualTest.py
@@ -7,22 +7,28 @@ class CubicDualTest:
     def test_generation(self):
         net = op.Network.CubicDual(shape=[5, 5, 5], label_1='primary',
                                    label_2='secondary')
-        assert net.Np == 491
-        assert net.Nt == 2590
-        assert net.num_pores('all') == 491
-        assert net.num_pores('back') == 61
-        assert net.num_pores('bottom') == 61
-        assert net.num_pores('front') == 61
-        assert net.num_pores('internal') == 189
-        assert net.num_pores('left') == 61
-        assert net.num_pores('primary') == 275
-        assert net.num_pores('right') == 61
-        assert net.num_pores('secondary') == 216
-        assert net.num_pores('surface') == 302
-        assert net.num_pores('top') == 61
-        assert net.num_throats('all') == 2590
-        assert net.num_throats('interconnect') == 1600
-        assert net.num_throats('internal') == 1690
-        assert net.num_throats('primary') == 450
-        assert net.num_throats('secondary') == 540
-        assert net.num_throats('surface') == 900
+        assert net.Np == 285
+        assert net.Nt == 1436
+        assert net.num_pores('all') == 285
+        assert net.num_pores('back') == 21
+        assert net.num_pores('bottom') == 21
+        assert net.num_pores('front') == 21
+        assert net.num_pores('internal') == 91
+        assert net.num_pores('left') == 41
+        assert net.num_pores('primary') == 125
+        assert net.num_pores('right') == 41
+        assert net.num_pores('secondary') == 160
+        assert net.num_pores('surface') == 194
+        assert net.num_pores('top') == 41
+        assert net.num_throats('all') == 1436
+        assert net.num_throats('interconnect') == 896
+        assert net.num_throats('internal') == 860
+        assert net.num_throats('primary') == 300
+        assert net.num_throats('secondary') == 240
+        assert net.num_throats('surface') == 576
+        assert net.num_throats('top') == 104
+        assert net.num_throats('bottom') == 104
+        assert net.num_throats('left') == 104
+        assert net.num_throats('right') == 104
+        assert net.num_throats('front') == 104
+        assert net.num_throats('back') == 104


### PR DESCRIPTION
There was a major bug in this class (the network size was being hard coded, presumably due to some left over debugging lines).  This could have been avoided it we'd done proper team-based code review before merging.  Also, I took the opportunity to adjust how the duals were generated, so now requesting a shape of [4,4,4] returns a [4,4,4].  It was previously being padded to [5,5,5], which was not very logical.