### PR TITLE
Fixed a bug in (rate) function

### DIFF
--- a/OpenPNM/Algorithms/__GenericLinearTransport__.py
+++ b/OpenPNM/Algorithms/__GenericLinearTransport__.py
@@ -861,7 +861,7 @@ class GenericLinearTransport(GenericAlgorithm):
         elif mode == 'single':
             t = network.find_neighbor_throats(pores, flatten=False,
                                               mode='not_intersection')
-            throat_group_num = sp.size(t)
+            throat_group_num = sp.shape(t)[0]
         for i in sp.r_[0: throat_group_num]:
             if mode == 'group':
                 throats = t

--- a/test/integration/script_test.py
+++ b/test/integration/script_test.py
@@ -73,7 +73,11 @@ def test_linear_solvers():
         round(sp.absolute(alg_3.rate(BC2_pores))[0], 14)
     assert round(sp.absolute(sp.sum(alg_4.rate(BC2_pores, mode='single'))), 14) ==\
         round(sp.absolute(alg_4.rate(BC2_pores))[0], 14)
-
+    BC5_pores = [37,57]
+    assert round(sp.absolute(sp.sum(alg_3.rate(BC5_pores, mode='single'))), 14) ==\
+        round(sp.absolute(alg_3.rate(BC5_pores))[0], 14)
+    assert round(sp.absolute(sp.sum(alg_4.rate(BC5_pores, mode='single'))), 14) ==\
+        round(sp.absolute(alg_4.rate(BC5_pores))[0], 14)
 
 def test_add_boundary():
     pn = OpenPNM.Network.Cubic(shape=[5, 5, 5])

--- a/test/integration/script_test.py
+++ b/test/integration/script_test.py
@@ -79,6 +79,7 @@ def test_linear_solvers():
     assert round(sp.absolute(sp.sum(alg_4.rate(BC5_pores, mode='single'))), 14) ==\
         round(sp.absolute(alg_4.rate(BC5_pores))[0], 14)
 
+
 def test_add_boundary():
     pn = OpenPNM.Network.Cubic(shape=[5, 5, 5])
     pn.add_boundaries()


### PR DESCRIPTION
There was a bug in the 'single' mode of the 'rate' function. Apparently, at some point, 'len' has been replaced by 'size'. I changed it to 'shape'.