### PR TITLE
Read networkx graph object directly

### DIFF
--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -1023,7 +1023,7 @@ class NetworkX(GenericIO):
                     val = {i: phase[prop][i] for i in network.Ps}
                     _nx.set_node_attributes(G, prop[5:], val)
                 if 'throat.' in prop:
-                    val = {tuple(conn): phase[prop][i] for i, conn in \
+                    val = {tuple(conn): phase[prop][i] for i, conn in
                            enumerate(conns)}
                     _nx.set_edge_attributes(G, prop[7:], val)
         return G

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -838,7 +838,7 @@ class NetworkX(GenericIO):
 
     2. Since \'pore.coords\' is so central to OpenPNM it should be specified
     in the NetworkX object as \'coords\', and the [X, Y, Z] coordinates of
-    each node should be a 3x1 list.
+    each node should be a 1x3 list.
 
     3. Edges in a NetworkX object are accessed using the index numbers of the
     two nodes it connects, such as ``G.edge[2][3]['length'] = 0.1``
@@ -860,9 +860,9 @@ class NetworkX(GenericIO):
         Parameters
         ----------
         G : networkx.classes.graph.Graph Object
-            The NetworkX graph. G should be undirected. The numbering of nodes 
-            should be numeric (int's), zero-based and should not contain any 
-            gaps, i.e. ``G.nodes() = [0,1,3,4,5]`` is not allowed and should be 
+            The NetworkX graph. G should be undirected. The numbering of nodes
+            should be numeric (int's), zero-based and should not contain any
+            gaps, i.e. ``G.nodes() = [0,1,3,4,5]`` is not allowed and should be
             mapped to ``G.nodes() = [0,1,2,3,4]``.
 
         network : OpenPNM Network Object
@@ -889,7 +889,7 @@ class NetworkX(GenericIO):
         """
         net = {}
 
-        # Ensure G is an undirected networkX graph with numerically numbered 
+        # Ensure G is an undirected networkX graph with numerically numbered
         # nodes for which the numbering starts at 0 and does not contain any gaps
         if not isinstance(G, _nx.Graph):
             raise ('Provided object is not a NetworkX graph.')
@@ -905,7 +905,7 @@ class NetworkX(GenericIO):
         # Parsing node data
         Np = len(G)
         net.update({'pore.all': _sp.ones((Np,), dtype=bool)})
-        for n,props in G.nodes(data = True):
+        for n, props in G.nodes(data=True):
             for item in props.keys():
                 val = props[item]
                 dtype = type(val)
@@ -914,8 +914,8 @@ class NetworkX(GenericIO):
                     item = item.replace(b, '')
                 # Create arrays for subsequent indexing, if not present already
                 if 'pore.'+item not in net.keys():
-                    if dtype == str: # handle strings of arbitrary length
-                        net['pore.'+item] = _sp.ndarray((Np,), dtype='object') 
+                    if dtype == str:  # handle strings of arbitrary length
+                        net['pore.'+item] = _sp.ndarray((Np,), dtype='object')
                     elif dtype is list:
                         dtype = type(val[0])
                         if dtype == str:

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -971,15 +971,15 @@ class NetworkX(GenericIO):
     def save(cls, network, phases=[]):
         r"""
         Write Network to a NetworkX object.
-        
+    
         Parameters
         ----------
         network : OpenPNM Network Object
             The OpenPNM Network to be exported to a NetworkX object
-
+    
         phases : list of phase objects ([])
             Phases that have properties we want to write to NetworkX object
-            
+    
         Returns
         -------
         A NetworkX object with all pore/throat properties attached to it
@@ -1001,25 +1001,30 @@ class NetworkX(GenericIO):
         # Explicitly add nodes and connectivity matrix
         G.add_nodes_from(nodes)
         G.add_edges_from(conns)
-        
+    
         # Attach Network properties to G
         for prop in network.props(mode=['all', 'deep']) + network.labels():
             if 'pore.' in prop:
-                _nx.set_node_attributes(G, prop[5:], {i: network[prop][i] for i in nodes})
+                if len(network[prop].shape) > 1:
+                    val = {i: list(network[prop][i]) for i in network.Ps}
+                else:
+                    val = {i: network[prop][i] for i in network.Ps}
+                _nx.set_node_attributes(G, prop[5:], val)
             if 'throat.' in prop:
                 val = {tuple(conn): network[prop][i] for i, conn in enumerate(conns)}
                 _nx.set_edge_attributes(G, prop[7:], val)
-                
+    
         # Attach Phase properties to G
         for phase in phases:
             props = phase.props(mode=['all', 'deep']) + phase.labels()
             for prop in props:
                 if 'pore.' in prop:
-                    _nx.set_node_attributes(G, prop[5:], {i: phase[prop][i] for i in nodes})
+                    val = {i: phase[prop][i] for i in network.Ps}
+                    _nx.set_node_attributes(G, prop[5:], val)
                 if 'throat.' in prop:
                     val = {tuple(conn): phase[prop][i] for i, conn in enumerate(conns)}
                     _nx.set_edge_attributes(G, prop[7:], val)
-        return G    
+        return G
 
 
 class iMorph(GenericIO):

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -966,6 +966,61 @@ class NetworkX(GenericIO):
         network = cls._update_network(network=network, net=net,
                                       return_geometry=return_geometry)
         return network
+    
+    @classmethod
+    def save(cls, network, phases=[]):
+        r"""
+        Write Network to a NetworkX object.
+        
+        Parameters
+        ----------
+        network : OpenPNM Network Object
+            The OpenPNM Network to be exported to a NetworkX object
+    
+        phases : list of phase objects ([])
+            Phases that have properties we want to write to NetworkX object
+            
+        Returns
+        -------
+        A NetworkX object with all pore/throat properties attached to it
+         
+        """
+        # Ensure phases is a list
+        if type(phases) is not list:  
+            phases = [phases]
+        # Ensure network is an OpenPNM Network object.
+        if not isinstance(network, OpenPNM.Network.__GenericNetwork__.GenericNetwork):
+            raise('Provided network is not an OpenPNM Network.')
+    
+        G = _nx.Graph()
+    
+        # Extracting node list and connectivity matrix from Network
+        nodes = map(int, network.Ps)
+        conns = network['throat.conns']
+    
+        # Explicitly add nodes and connectivity matrix
+        G.add_nodes_from(nodes)
+        G.add_edges_from(conns)
+        
+        # Attach Network properties to G
+        for prop in network.props(mode=['all', 'deep']) + network.labels():
+            if 'pore.' in prop:
+                print(prop)
+                _nx.set_node_attributes(G, prop[5:], {i: network[prop][i] for i in nodes})
+            if 'throat.' in prop:
+                val = {tuple(conn): network[prop][i] for i, conn in enumerate(conns)}
+                _nx.set_edge_attributes(G, prop[7:], val)
+                
+        # Attach Phase properties to G
+        for phase in phases:
+            props = phase.props(mode=['all', 'deep']) + phase.labels()
+            for prop in props:
+                if 'pore.' in prop:
+                    _nx.set_node_attributes(G, prop[5:], {i: phase[prop][i] for i in nodes})
+                if 'throat.' in prop:
+                    val = {tuple(conn): phase[prop][i] for i, conn in enumerate(conns)}
+                    _nx.set_edge_attributes(G, prop[7:], val)
+        return G    
 
 
 class iMorph(GenericIO):

--- a/OpenPNM/Utilities/IO.py
+++ b/OpenPNM/Utilities/IO.py
@@ -966,42 +966,43 @@ class NetworkX(GenericIO):
         network = cls._update_network(network=network, net=net,
                                       return_geometry=return_geometry)
         return network
-    
+
     @classmethod
     def save(cls, network, phases=[]):
         r"""
         Write Network to a NetworkX object.
-    
+
         Parameters
         ----------
         network : OpenPNM Network Object
             The OpenPNM Network to be exported to a NetworkX object
-    
+
         phases : list of phase objects ([])
             Phases that have properties we want to write to NetworkX object
-    
+
         Returns
         -------
         A NetworkX object with all pore/throat properties attached to it
-         
+
         """
         # Ensure phases is a list
-        if type(phases) is not list:  
+        if type(phases) is not list:
             phases = [phases]
         # Ensure network is an OpenPNM Network object.
-        if not isinstance(network, OpenPNM.Network.__GenericNetwork__.GenericNetwork):
+        if not isinstance(network,
+                          OpenPNM.Network.__GenericNetwork__.GenericNetwork):
             raise('Provided network is not an OpenPNM Network.')
-    
+
         G = _nx.Graph()
-    
+
         # Extracting node list and connectivity matrix from Network
         nodes = map(int, network.Ps)
         conns = network['throat.conns']
-    
+
         # Explicitly add nodes and connectivity matrix
         G.add_nodes_from(nodes)
         G.add_edges_from(conns)
-    
+
         # Attach Network properties to G
         for prop in network.props(mode=['all', 'deep']) + network.labels():
             if 'pore.' in prop:
@@ -1013,7 +1014,7 @@ class NetworkX(GenericIO):
             if 'throat.' in prop:
                 val = {tuple(conn): network[prop][i] for i, conn in enumerate(conns)}
                 _nx.set_edge_attributes(G, prop[7:], val)
-    
+
         # Attach Phase properties to G
         for phase in phases:
             props = phase.props(mode=['all', 'deep']) + phase.labels()
@@ -1022,7 +1023,8 @@ class NetworkX(GenericIO):
                     val = {i: phase[prop][i] for i in network.Ps}
                     _nx.set_node_attributes(G, prop[5:], val)
                 if 'throat.' in prop:
-                    val = {tuple(conn): phase[prop][i] for i, conn in enumerate(conns)}
+                    val = {tuple(conn): phase[prop][i] for i, conn in \
+                           enumerate(conns)}
                     _nx.set_edge_attributes(G, prop[7:], val)
         return G
 

--- a/test/unit/Utilities/IOTest.py
+++ b/test/unit/Utilities/IOTest.py
@@ -146,13 +146,13 @@ class IOTest:
 
     def test_load_networkx(self):
         G = nx.complete_graph(10)
-        pos = nx.random_layout(G, dim = 3)
+        pos = nx.random_layout(G, dim=3)
         nx.set_node_attributes(G, 'coords', {n: list(pos[n]) for n in pos})
         nx.set_node_attributes(G, 'area', 1.123)
         nx.set_node_attributes(G, 'diameter', 1.123)
         nx.set_edge_attributes(G, 'length', 1.123)
         nx.set_edge_attributes(G, 'perimeter', 1.123)
-        net = opnm.Utilities.IO.NetworkX.load(G=G)
+        net = io.NetworkX.load(G=G)
         num_nodes = len(G.nodes())
         num_edges = len(G.edges())
         assert net.Np == num_nodes

--- a/test/unit/Utilities/IOTest.py
+++ b/test/unit/Utilities/IOTest.py
@@ -1,5 +1,6 @@
 import OpenPNM as op
 import scipy as sp
+import networkx as nx
 import os
 import OpenPNM.Utilities.IO as io
 import pytest
@@ -144,12 +145,20 @@ class IOTest:
         assert [True for item in net.keys() if 'diffusive_conductance' in item]
 
     def test_load_networkx(self):
-        fname = os.path.join(FIXTURE_DIR, 'test_load_yaml.yaml')
-        net = io.NetworkX.load(filename=fname)
-        assert net.Np == 9
-        assert net.Nt == 12
-        assert sp.shape(net['pore.coords']) == (9, 3)
-        assert sp.shape(net['throat.conns']) == (12, 2)
+        G = nx.complete_graph(10)
+        pos = nx.random_layout(G, dim = 3)
+        nx.set_node_attributes(G, 'coords', {n: list(pos[n]) for n in pos})
+        nx.set_node_attributes(G, 'area', 1.123)
+        nx.set_node_attributes(G, 'diameter', 1.123)
+        nx.set_edge_attributes(G, 'length', 1.123)
+        nx.set_edge_attributes(G, 'perimeter', 1.123)
+        net = opnm.Utilities.IO.NetworkX.load(G=G)
+        num_nodes = len(G.nodes())
+        num_edges = len(G.edges())
+        assert net.Np == num_nodes
+        assert net.Nt == num_edges
+        assert sp.shape(net['pore.coords']) == (num_nodes, 3)
+        assert sp.shape(net['throat.conns']) == (num_edges, 2)
         a = {'pore.area', 'pore.diameter', 'throat.length', 'throat.perimeter'}
         assert a.issubset(net.props())
 

--- a/test/unit/Utilities/IOTest.py
+++ b/test/unit/Utilities/IOTest.py
@@ -161,7 +161,25 @@ class IOTest:
         assert sp.shape(net['throat.conns']) == (num_edges, 2)
         a = {'pore.area', 'pore.diameter', 'throat.length', 'throat.perimeter'}
         assert a.issubset(net.props())
-
+        
+    def test_save_and_load_networkx_no_phases(self):
+        G = io.NetworkX.save(network=self.net)
+        net = io.NetworkX.load(G)
+        assert net.Np == 27
+        assert net.Nt == 54
+        assert sp.shape(net['pore.coords']) == (27, 3)
+        assert sp.shape(net['throat.conns']) == (54, 2)
+    
+    def test_save_and_load_networkx_w_phases(self):
+        G = io.NetworkX.save(network=self.net, phases=self.phase)
+        net = io.NetworkX.load(G)
+        assert net.Np == 27
+        assert net.Nt == 54
+        assert sp.shape(net['pore.coords']) == (27, 3)
+        assert sp.shape(net['throat.conns']) == (54, 2)
+        assert [True for item in net.keys() if 'temperature' in item]
+        assert [True for item in net.keys() if 'diffusive_conductance' in item]
+    
     def test_load_imorph(self):
         path = os.path.join(FIXTURE_DIR, 'iMorph-Sandstone')
         net = io.iMorph.load(path)

--- a/test/unit/Utilities/IOTest.py
+++ b/test/unit/Utilities/IOTest.py
@@ -161,7 +161,7 @@ class IOTest:
         assert sp.shape(net['throat.conns']) == (num_edges, 2)
         a = {'pore.area', 'pore.diameter', 'throat.length', 'throat.perimeter'}
         assert a.issubset(net.props())
-        
+
     def test_save_and_load_networkx_no_phases(self):
         G = io.NetworkX.save(network=self.net)
         net = io.NetworkX.load(G)
@@ -169,7 +169,7 @@ class IOTest:
         assert net.Nt == 54
         assert sp.shape(net['pore.coords']) == (27, 3)
         assert sp.shape(net['throat.conns']) == (54, 2)
-    
+
     def test_save_and_load_networkx_w_phases(self):
         G = io.NetworkX.save(network=self.net, phases=self.phase)
         net = io.NetworkX.load(G)
@@ -179,7 +179,7 @@ class IOTest:
         assert sp.shape(net['throat.conns']) == (54, 2)
         assert [True for item in net.keys() if 'temperature' in item]
         assert [True for item in net.keys() if 'diffusive_conductance' in item]
-        
+
     def test_load_imorph(self):
         path = os.path.join(FIXTURE_DIR, 'iMorph-Sandstone')
         net = io.iMorph.load(path)


### PR DESCRIPTION
As per personal communication with @jgostick , `NetworkX.load()` is replaced by a function that accepts a `networkX` graph directly, instead of using an intermediate YAML file.

Checks on the input graph:
- Checking if supplied object is networkX graph
- Checking if supplied graph is undirected
- Checking if numbering of G.nodes() contains any gaps
- Checking if numbering of G.nodes() starts at 0

The implementation is very similar to the original YAML approach. There was no need to remove duplicates from `conns` anymore, but it's still sorting because I could not determine if `G.edges()` returns a sorted list.

I didn't manage to fill an `ndarray` of strings, such as `_sp.ndarray((N,M), dtype=str)`, correctly. hence there are a few checks to see if `dtype` is `str`. Without these checks and the use of `dtype='object'`, the `ndarray` would contain only empty strings. Perhaps there is a more elegant way to handle this?

Lastly, `test_load_networkx` in `IOTest.py` will need to be updated.