### PR TITLE
Use Cantera to calculate physical properties.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install --file conda_requirements.txt
+  - conda install -c cantera cantera
   - pip install -r test_requirements.txt
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install --file conda_requirements.txt
-  - conda install -c cantera cantera
+  - conda install -c cantera/label/dev cantera  # Dev version uses numpy 14
   - pip install -r test_requirements.txt
   - python setup.py install
 

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -3,3 +3,4 @@ scipy
 matplotlib
 pandas
 scikit-image
+cantera

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -3,4 +3,3 @@ scipy
 matplotlib
 pandas
 scikit-image
-cantera

--- a/example_cantera.py
+++ b/example_cantera.py
@@ -3,23 +3,23 @@ import cantera as ct
 from openpnm.utils.misc import tic, toc
 ws = op.core.Workspace()
 
-net  = op.network.Cubic(shape = [10,10,10], spacing = 1e-6, name = 'test_net')
+net = op.network.Cubic(shape=[10, 10, 10], spacing=1e-6, name='test_net')
 proj = net.project
-geom = op.geometry.GenericGeometry(network = net, pores = net.Ps, throats = net.Ts)
+geom = op.geometry.GenericGeometry(network=net, pores=net.Ps, throats=net.Ts)
 
-air = op.phases.Air(network = net)
-phys_air = op.physics.GenericPhysics(network = net, phase = air, geometry = geom)
+air = op.phases.Air(network=net)
+phys_air = op.physics.GenericPhysics(network=net, phase=air, geometry=geom)
 
 cantera = op.models.phase.thermal_conductivity.cantera
 
 print('Calculating thermal conductivity with Cantera')
 tic()
-air.add_model(propname='pore.thermal_conductivity', model=cantera,
+air.add_model(propname='pore.thermal_conductivity',
+              model=cantera,
               cantera_phase_obj=ct.Solution('air.xml'))
 air.regenerate_models(propnames='pore.thermal_conductivity')
 toc()
 
-print()
 
 print('Calculating thermal conductivity directly')
 tic()

--- a/example_cantera.py
+++ b/example_cantera.py
@@ -1,0 +1,29 @@
+import openpnm as op
+import cantera as ct
+from openpnm.utils.misc import tic, toc
+ws = op.core.Workspace()
+
+net  = op.network.Cubic(shape = [10,10,10], spacing = 1e-6, name = 'test_net')
+proj = net.project
+geom = op.geometry.GenericGeometry(network = net, pores = net.Ps, throats = net.Ts)
+
+air = op.phases.Air(network = net)
+phys_air = op.physics.GenericPhysics(network = net, phase = air, geometry = geom)
+
+cantera = op.models.phase.thermal_conductivity.cantera
+
+print('Calculating thermal conductivity with Cantera')
+tic()
+air.add_model(propname='pore.thermal_conductivity', model=cantera,
+              cantera_phase_obj=ct.Solution('air.xml'))
+air.regenerate_models(propnames='pore.thermal_conductivity')
+toc()
+
+print()
+
+print('Calculating thermal conductivity directly')
+tic()
+water_conductivity = op.models.phase.thermal_conductivity.water
+air.add_model(propname='pore.thermal_conductivity', model=water_conductivity)
+air.regenerate_models(propnames='pore.thermal_conductivity')
+toc()

--- a/openpnm/models/phase/thermal_conductivity.py
+++ b/openpnm/models/phase/thermal_conductivity.py
@@ -6,7 +6,6 @@ Submodule -- thermal_conductance
 
 """
 import scipy as sp
-import cantera as ct
 
 
 def water(target, temperature='pore.temperature', salinity='pore.salinity'):
@@ -176,6 +175,12 @@ def cantera(target, cantera_phase_obj, temperature='pore.temperature',
         The dictionary key containing the pressure values (Pa)
 
     """
+    try:
+        import cantera as ct
+    except ModuleNotFoundError:
+        raise Exception('Cantera is not installed. Visit https://www.canter' +
+                        'a.org/docs/sphinx/html/install.html for more info.')
+
     T = target[temperature]
     p = target[pressure]
     states = ct.SolutionArray(phase=cantera_phase_obj, shape=T.size)

--- a/openpnm/models/phase/thermal_conductivity.py
+++ b/openpnm/models/phase/thermal_conductivity.py
@@ -6,7 +6,7 @@ Submodule -- thermal_conductance
 
 """
 import scipy as sp
-
+import cantera as ct
 
 def water(target, temperature='pore.temperature', salinity='pore.salinity'):
     r"""
@@ -151,3 +151,32 @@ def sato(target, mol_weight='pore.molecular_weight',
     Tr = T/Tc
     value = (1.11/((MW*1e3)**0.5))*(3+20*(1-Tr)**(2/3))/(3+20*(1-Tbr)**(2/3))
     return value
+
+
+def cantera(target, cantera_phase_obj, temperature='pore.temperature',
+            pressure='pore.pressure'):
+    r"""
+    Uses Cantera module to calculate thermal conductivity.
+    
+    Parameters
+    ----------
+    target : OpenPNM Object
+        The object for which these values are being calculated.  This
+        controls the length of the calculated array, and also provides
+        access to other necessary thermofluid properties.
+    
+    cantera_phase_obj : Cantera Solution instance
+        The object which contains the model to calculate thermal conductivity
+
+    temperature : string
+        The dictionary key containing the temperature values (K)
+
+    pressure : string
+        The dictionary key containing the pressure values (Pa)
+ 
+    """
+    T = target[temperature]
+    p = target[pressure]
+    states = ct.SolutionArray(phase=cantera_phase_obj, shape=T.size)
+    states.TP = T, p
+    return states.thermal_conductivity

--- a/openpnm/models/phase/thermal_conductivity.py
+++ b/openpnm/models/phase/thermal_conductivity.py
@@ -8,6 +8,7 @@ Submodule -- thermal_conductance
 import scipy as sp
 import cantera as ct
 
+
 def water(target, temperature='pore.temperature', salinity='pore.salinity'):
     r"""
     Calculates thermal conductivity of pure water or seawater at atmospheric
@@ -157,14 +158,14 @@ def cantera(target, cantera_phase_obj, temperature='pore.temperature',
             pressure='pore.pressure'):
     r"""
     Uses Cantera module to calculate thermal conductivity.
-    
+
     Parameters
     ----------
     target : OpenPNM Object
         The object for which these values are being calculated.  This
         controls the length of the calculated array, and also provides
         access to other necessary thermofluid properties.
-    
+
     cantera_phase_obj : Cantera Solution instance
         The object which contains the model to calculate thermal conductivity
 
@@ -173,7 +174,7 @@ def cantera(target, cantera_phase_obj, temperature='pore.temperature',
 
     pressure : string
         The dictionary key containing the pressure values (Pa)
- 
+
     """
     T = target[temperature]
     p = target[pressure]


### PR DESCRIPTION
Following the discussion we had a few weeks ago, this purpose of this pull request is to add `Cantera` as a dependency to `openpnm` for calculating physical properties such as thermal conductivity, diffusivity, etc.

So far, the major downside that prevented us to do this is that it takes `cantera` roughly 10 times compared to directly calculating properties with our current pore-scale models. The reason is probably that `cantera` updates all the physical properties attached to a phase even when you only need one.