### PR TITLE
Model wrapper

### DIFF
--- a/openpnm/core/ModelsMixin.py
+++ b/openpnm/core/ModelsMixin.py
@@ -56,27 +56,6 @@ class ModelsDict(PrintableDict):
         [unique.append(item) for item in tree if item not in unique]
         return unique
 
-    def dependency_map(self):
-        r"""
-        Create a graph of the dependency graph in a decent format
-
-        See Also
-        --------
-        dependency_graph
-        dependency_list
-
-        """
-        dtree = self.dependency_graph()
-        fig = nx.draw_spectral(dtree,
-                               with_labels=True,
-                               arrowsize=50,
-                               node_size=2000,
-                               edge_color='lightgrey',
-                               width=3.0,
-                               font_size=32,
-                               font_weight='bold')
-        return fig
-
     def find_target(self):
         for proj in ws.values():
             for obj in proj:


### PR DESCRIPTION
This adds a ModelWrapper class which houses a model and all it's arguments.  It has the ability to find its own target, and to call itself, so you could do something like this:

```
mod = geom.models['pore.diameter']
mod.run()
```

I am not sure this is worth the complication of adding another level of classes, but it's something we can add at a later date.  

Of interest on this PR is the ability for the ModelsDict (the dictionary that houses the ModelWrapper) to look up it's own master...which may be worth cherry picking.