### PR TITLE
Improved models for calculating equivalent area for conduits

### DIFF
--- a/openpnm/models/geometry/throat_area.py
+++ b/openpnm/models/geometry/throat_area.py
@@ -1,4 +1,5 @@
 from numpy import pi as _pi
+import numpy as _np
 
 
 def cylinder(target, throat_diameter='throat.diameter'):
@@ -39,3 +40,44 @@ def cuboid(target, throat_diameter='throat.diameter'):
     diams = target[throat_diameter]
     value = (diams)**2
     return value
+
+
+def equivalent_area_spherical_pores(target, throat_diameter='throat.diameter',
+                                    throat_area='throat.area',
+                                    pore_diameter='pore.diameter'):
+    r"""
+    Calculate equivalent cross-sectional area for a conduit consisting of two
+    spherical pores and a constant cross-section throat. This area can be later
+    used to calculate hydraulic or diffusive conductance of the conduit.
+
+    Parameters
+    ----------
+    target : OpenPNM Object
+        The object which this model is associated with. This controls the
+        length of the calculated array, and also provides access to other
+        necessary properties.
+
+    throat_diameter : string
+        Dictionary key of the throat diameter values
+
+    throat_area : string
+        Dictionary key of the throat area values
+
+    pore_diameter : string
+        Dictionary key of the pore diameter values
+
+    """
+    network = target.project.network
+    cn = network['throat.conns']
+    dp = target[pore_diameter]
+    d1 = dp[cn[:, 0]]
+    d2 = dp[cn[:, 1]]
+    dt = target[throat_diameter]
+    L1 = _np.sqrt(d1**2 - dt**2) / 4            # Effective length of pore 1
+    L2 = _np.sqrt(d2**2 - dt**2) / 4            # Effective length of pore 2
+    C1 = network['pore.coords'][cn[:, 0]]
+    C2 = network['pore.coords'][cn[:, 1]]
+    L = _np.sqrt(_np.sum((C1-C2)**2, axis=1))   # c2c distance of pores
+    Lt = L - (L1+L2)                            # Effective length of throat
+    return L / (2 / (d1*_pi) * _np.arctanh(2*L1/d1) + Lt / target[throat_area] +
+                2 / (d2*_pi) * _np.arctanh(2*L2/d2))

--- a/openpnm/models/geometry/throat_area.py
+++ b/openpnm/models/geometry/throat_area.py
@@ -7,10 +7,10 @@ def cylinder(target, throat_diameter='throat.diameter'):
 
     Parameters
     ----------
-    geometry : OpenPNM Geometry Object
-        The Geometry object which this model is associated with. This controls
-        the length of the calculated array, and also provides access to other
-        necessary geometric properties.
+    target : OpenPNM Object
+        The object which this model is associated with. This controls the
+        length of the calculated array, and also provides access to other
+        necessary properties.
 
     throat_diameter : string
         Dictionary key of the throat diameter values
@@ -27,10 +27,10 @@ def cuboid(target, throat_diameter='throat.diameter'):
 
     Parameters
     ----------
-    geometry : OpenPNM Geometry Object
-        The Geometry object which this model is associated with. This controls
-        the length of the calculated array, and also provides access to other
-        necessary geometric properties.
+    target : OpenPNM Object
+        The object which this model is associated with. This controls the
+        length of the calculated array, and also provides access to other
+        necessary properties.
 
     throat_diameter : string
         Dictionary key of the throat diameter values

--- a/tests/unit/models/geometry/ThroatAreaTest.py
+++ b/tests/unit/models/geometry/ThroatAreaTest.py
@@ -33,6 +33,16 @@ class ThroatSurfaceAreaTest:
         b = np.unique(self.geo['throat.area'])
         assert_approx_equal(a, b)
 
+    def test_equivalent_area_spherical_pores(self):
+        self.geo['pore.diameter'] = 0.2
+        self.geo['throat.area'] = np.pi * self.geo['throat.diameter']**2 / 4
+        self.geo.add_model(propname='throat.equivalent_area',
+                           model=mods.equivalent_area_spherical_pores,
+                           regen_mode='normal')
+        a = np.array([0.008385833])
+        b = np.unique(self.geo['throat.equivalent_area'])
+        assert_approx_equal(a, b)
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Previously, we used to use the whole pore area for calculating the transport conductance for a conduit, whereas only part of the area contributes to the total conductance. This PR addresses this issue by introducing a new parameter, i.e. equivalent area, defined for individual conduits such that it encapsulates the variation of cross-section area of the two pores and possibly throats (not yet implemented), which can later be used by conductance models to give more accurate conductance values.