### PR TITLE
change A.dtype to np.int64

### DIFF
--- a/OpenPNM/Algorithms/__GenericLinearTransport__.py
+++ b/OpenPNM/Algorithms/__GenericLinearTransport__.py
@@ -6,6 +6,7 @@ module __GenericLinearTransport__: Class for solving linear transport processes
 
 """
 import scipy as sp
+import  numpy as np
 import scipy.sparse as sprs
 import scipy.sparse.linalg as sprslin
 from OpenPNM.Algorithms import GenericAlgorithm

--- a/OpenPNM/Algorithms/__GenericLinearTransport__.py
+++ b/OpenPNM/Algorithms/__GenericLinearTransport__.py
@@ -560,6 +560,8 @@ class GenericLinearTransport(GenericAlgorithm):
 
         if A is None:
             A = self.A
+            A.indices = A.indices.astype(np.int64)
+            A.indptr = A.indptr.astype(np.int64)
         if b is None:
             b = self.b
         if self._iterative_solver is None:


### PR DESCRIPTION
Fix Memory limit for scipy.sparse.linalg.spsolve with scikit-umfpack. 
When using umfpack to solve Ax=b, which have 10X speedup in Ubuntu and MacOS, an int32 indices will hit a 32 bit memory limit (such as more than 180000 pores). This is because the 64-bit umfpack family solver is only called when the indices have dtype int64 (see more: https://github.com/scipy/scipy/issues/8278). 
An easy way to fix this bug is to change the dtype of A to np.int64