### PR TITLE
making interleave data public

### DIFF
--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -754,7 +754,7 @@ class Base(dict):
         indices = self._parse_indices(mask)
         return indices
 
-    def _interleave_data(self, prop, sources):
+    def interleave_data(self, prop):
         r"""
         Retrieves requested property from associated objects, to produce a full
         Np or Nt length array.
@@ -804,17 +804,15 @@ class Base(dict):
         N = self.project.network._count(element)
 
         # Fetch sources list depending on object type?
-        # proj = self.project
-        # if self._isa('network'):
-        #     sources = list(proj.geometries().values())
-        # elif self._isa('phase'):
-        #     sources = list(proj.phases().values())
-        # elif self._isa('physics')
-        #     sources = list(proj.physics().values())
-        # elif self._isa('physics'):
-        #     sources = list(proj.geometries().values())
-        # else:
-        #     pass
+        proj = self.project
+        if self._isa() in ['network', 'geometry']:
+            sources = list(proj.geometries().values())
+        elif self._isa() in ['phase', 'physics']:
+            sources = list(proj.find_physics(phase=self))
+        elif self._isa() in ['algorithm', 'base']:
+            sources = [self]
+        else:
+            raise Exception('Unrecognized object type, cannot find dependencies')
 
         # Attempt to 'get' the requested array from each object
         # Use 'get' so that missing keys return None, instead of KeyError

--- a/openpnm/network/GenericNetwork.py
+++ b/openpnm/network/GenericNetwork.py
@@ -58,8 +58,7 @@ class GenericNetwork(Base, ModelsMixin):
         # Now get values if present, or regenerate them
         vals = self.get(key)
         if vals is None:  # Invoke interleave data
-            geoms = self.project.geometries().values()
-            vals = self._interleave_data(key, geoms)
+            vals = self.interleave_data(key)
         return vals
 
     def _gen_ids(self):

--- a/openpnm/phases/GenericPhase.py
+++ b/openpnm/phases/GenericPhase.py
@@ -67,6 +67,5 @@ class GenericPhase(Base, ModelsMixin):
         # Now get values if present, or regenerate them
         vals = self.get(key)
         if vals is None:
-            physics = self.project.find_physics(phase=self)
-            vals = self._interleave_data(key, physics)
+            vals = self.interleave_data(key)
         return vals


### PR DESCRIPTION
Making interleave data a public method and removing the sources argument, which it can find itself now.