### PR TITLE
Missing dep message

### DIFF
--- a/openpnm/core/ModelsMixin.py
+++ b/openpnm/core/ModelsMixin.py
@@ -284,7 +284,17 @@ class ModelsMixin():
             try:
                 self[prop] = model(target=self, **kwargs)
             except KeyError:
-                logger.warning(prop+' was not run due to missing dependencies')
+                missing_deps = []
+                for key in kwargs.values():
+                    if type(key) == str and key.split('.')[0] in ['pore', 'throat']:
+                        try:
+                            self[key]
+                        except KeyError:
+                            missing_deps.append(key)
+
+                        logger.warning(prop+' was not run since the following'
+                                       + ' properties are missing: '
+                                       + str(missing_deps))
                 self.models[prop]['regen_mode'] = 'deferred'
 
     def remove_model(self, propname=None, mode=['model', 'data']):

--- a/openpnm/core/ModelsMixin.py
+++ b/openpnm/core/ModelsMixin.py
@@ -292,9 +292,8 @@ class ModelsMixin():
                         except KeyError:
                             missing_deps.append(key)
 
-                logger.warning(prop+' was not run since the following'
-                               + ' properties are missing: '
-                               + str(missing_deps))
+                logger.warning(prop + ' was not run since the following ' +
+                               'properties are missing: ' + str(missing_deps))
                 self.models[prop]['regen_mode'] = 'deferred'
 
     def remove_model(self, propname=None, mode=['model', 'data']):

--- a/openpnm/core/ModelsMixin.py
+++ b/openpnm/core/ModelsMixin.py
@@ -292,9 +292,9 @@ class ModelsMixin():
                         except KeyError:
                             missing_deps.append(key)
 
-                        logger.warning(prop+' was not run since the following'
-                                       + ' properties are missing: '
-                                       + str(missing_deps))
+                logger.warning(prop+' was not run since the following'
+                               + ' properties are missing: '
+                               + str(missing_deps))
                 self.models[prop]['regen_mode'] = 'deferred'
 
     def remove_model(self, propname=None, mode=['model', 'data']):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ pandas
 scikit-image
 sympy
 numba
-testfixtures
 networkx

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cache
 pytest-cov
 pytest-pep8
+testfixtures

--- a/tests/unit/core/ModelsTest.py
+++ b/tests/unit/core/ModelsTest.py
@@ -33,7 +33,7 @@ class ModelsTest:
         assert a == 17
 
     def test_dependency_list(self):
-        prj=self.net.project
+        prj = self.net.project
         prj.purge_object(self.geo)
         geom = op.geometry.GenericGeometry(network=self.net,
                                            pores=self.net.Ps)
@@ -57,10 +57,10 @@ class ModelsTest:
                        num_range=[0, 0.1],
                        seed=None)
         tree = np.asarray(geom.models.dependency_list())
-        pos_v = np.argwhere(tree=='pore.volume').flatten()[0]
-        pos_d = np.argwhere(tree=='pore.diameter').flatten()[0]
-        pos_a = np.argwhere(tree=='pore.area').flatten()[0]
-        pos_s = np.argwhere(tree=='pore.seed').flatten()[0]
+        pos_v = np.argwhere(tree == 'pore.volume').flatten()[0]
+        pos_d = np.argwhere(tree == 'pore.diameter').flatten()[0]
+        pos_a = np.argwhere(tree == 'pore.area').flatten()[0]
+        pos_s = np.argwhere(tree == 'pore.seed').flatten()[0]
         assert pos_v > pos_d
         assert pos_d > pos_s
         assert pos_a > pos_d
@@ -101,6 +101,16 @@ class ModelsTest:
 
         with pytest.raises(Exception):
             pn.models.dependency_list()
+
+    def test_missing_dependencies_message(self):
+        pn = op.network.Cubic(shape=[5, 5, 5])
+        geo = op.geometry.StickAndBall(network=pn, pores=pn.Ps, throats=pn.Ts)
+        geo.clear()
+        with LogCapture() as log:
+            geo.regenerate_models(propnames=['pore.diameter'])
+        log.check(('root', 'WARNING', "pore.diameter was not run since the " +
+                   "following properties are missing: ['pore.max_size', " +
+                   "'pore.seed']"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes a minor issue, making it easier to see which dependencies have not been run.  It does NOT show the entire tree of missing deps, only those missing for the current model being regenerated.  Still better than before.