### PR TITLE
Critical bug in conduit_lengths and equivalent_area models

### DIFF
--- a/openpnm/models/geometry/throat_equivalent_area.py
+++ b/openpnm/models/geometry/throat_equivalent_area.py
@@ -24,14 +24,14 @@ def spherical_pores(target, throat_area='throat.area', pore_diameter='pore.diame
 
     """
     network = target.project.network
-    throats = target.map_throats(target['throat._id'])
+    throats = network.map_throats(target['throat._id'])
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]
-    L1 = target[throat_conduit_lengths+'.pore1'][throats]
-    L2 = target[throat_conduit_lengths+'.pore2'][throats]
+    L1 = target[throat_conduit_lengths+'.pore1']
+    L2 = target[throat_conduit_lengths+'.pore2']
     return {'pore1': d1*L1*_pi / (2*_np.arctanh(2*L1/d1)),
-            'throat': target[throat_area][throats],
+            'throat': target[throat_area],
             'pore2': d2*L2*_pi / (2*_np.arctanh(2*L2/d2))}
 
 
@@ -56,13 +56,13 @@ def truncated_pyramid(target, throat_area='throat.area', pore_diameter='pore.dia
 
     """
     network = target.project.network
-    throats = target.map_throats(target['throat._id'])
+    throats = network.map_throats(target['throat._id'])
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]
-    td = _np.sqrt(target[throat_area][throats])
+    td = _np.sqrt(target[throat_area])
     return {'pore1': d1*td,
-            'throat': target[throat_area][throats],
+            'throat': target[throat_area],
             'pore2': d2*td}
 
 
@@ -88,12 +88,12 @@ def circular_pores(target, throat_area='throat.area', pore_diameter='pore.diamet
 
     """
     network = target.project.network
-    throats = target.map_throats(target['throat._id'])
+    throats = network.map_throats(target['throat._id'])
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]
-    L1 = target[throat_conduit_lengths+'.pore1'][throats]
-    L2 = target[throat_conduit_lengths+'.pore2'][throats]
+    L1 = target[throat_conduit_lengths+'.pore1']
+    L2 = target[throat_conduit_lengths+'.pore2']
     return {'pore1': 2*L1 / (_np.arctan(2*L1/_np.sqrt(d1**2 - 4*L1**2))),
-            'throat': target[throat_area][throats],
+            'throat': target[throat_area],
             'pore2': 2*L2 / (_np.arctan(2*L2/_np.sqrt(d2**2 - 4*L2**2)))}

--- a/openpnm/models/geometry/throat_length.py
+++ b/openpnm/models/geometry/throat_length.py
@@ -20,7 +20,7 @@ def ctc(target, pore_diameter='pore.diameter'):
 
     """
     network = target.project.network
-    throats = target.map_throats(target['throat._id'])
+    throats = network.map_throats(target['throat._id'])
     cn = network['throat.conns'][throats]
     C1 = network['pore.coords'][cn[:, 0]]
     C2 = network['pore.coords'][cn[:, 1]]
@@ -48,7 +48,7 @@ def straight(target, pore_diameter='pore.diameter', L_negative=1e-12):
         ``None``.
     """
     network = target.project.network
-    throats = target.map_throats(target['throat._id'])
+    throats = network.map_throats(target['throat._id'])
     cn = network['throat.conns'][throats]
     E = ctc(target, pore_diameter=pore_diameter)
     D1 = network[pore_diameter][cn[:, 0]]
@@ -83,7 +83,7 @@ def spherical_pores(target, pore_diameter='pore.diameter',
 
     """
     network = target.project.network
-    throats = target.map_throats(target['throat._id'])
+    throats = network.map_throats(target['throat._id'])
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]

--- a/openpnm/models/physics/hydraulic_conductance.py
+++ b/openpnm/models/physics/hydraulic_conductance.py
@@ -47,13 +47,13 @@ def hagen_poiseuille(target,
     geom = target.project.find_geometry(target)
     cn = network['throat.conns'][throats]
     # Getting equivalent areas
-    A1 = geom[throat_equivalent_area+'.pore1'][throats]
-    At = geom[throat_equivalent_area+'.throat'][throats]
-    A2 = geom[throat_equivalent_area+'.pore2'][throats]
+    A1 = geom[throat_equivalent_area+'.pore1']
+    At = geom[throat_equivalent_area+'.throat']
+    A2 = geom[throat_equivalent_area+'.pore2']
     # Getting conduit lengths
-    L1 = geom[throat_conduit_lengths+'.pore1'][throats]
-    Lt = geom[throat_conduit_lengths+'.throat'][throats]
-    L2 = geom[throat_conduit_lengths+'.pore2'][throats]
+    L1 = geom[throat_conduit_lengths+'.pore1']
+    Lt = geom[throat_conduit_lengths+'.throat']
+    L2 = geom[throat_conduit_lengths+'.pore2']
     # Interpolate pore phase property values to throats
     try:
         mut = phase[throat_viscosity]

--- a/openpnm/models/physics/misc.py
+++ b/openpnm/models/physics/misc.py
@@ -42,13 +42,13 @@ def poisson_conductance(target, pore_diffusivity, throat_diffusivity,
     geom = target.project.find_geometry(target)
     cn = network['throat.conns'][throats]
     # Getting equivalent areas
-    A1 = geom[throat_equivalent_area+'.pore1'][throats]
-    At = geom[throat_equivalent_area+'.throat'][throats]
-    A2 = geom[throat_equivalent_area+'.pore2'][throats]
+    A1 = geom[throat_equivalent_area+'.pore1']
+    At = geom[throat_equivalent_area+'.throat']
+    A2 = geom[throat_equivalent_area+'.pore2']
     # Getting conduit lengths
-    L1 = geom[throat_conduit_lengths+'.pore1'][throats]
-    Lt = geom[throat_conduit_lengths+'.throat'][throats]
-    L2 = geom[throat_conduit_lengths+'.pore2'][throats]
+    L1 = geom[throat_conduit_lengths+'.pore1']
+    Lt = geom[throat_conduit_lengths+'.throat']
+    L2 = geom[throat_conduit_lengths+'.pore2']
     # Interpolate pore phase property values to throats
     try:
         Dt = phase[throat_diffusivity]
@@ -66,5 +66,5 @@ def poisson_conductance(target, pore_diffusivity, throat_diffusivity,
     gp2[_sp.isnan(gp2)] = _sp.inf
     # Find g for full throat
     gt = Dt[throats] * At / Lt
-    gt[gt<=0] = _sp.inf
+    gt[_sp.isnan(gt)] = _sp.inf
     return (1/gt + 1/gp1 + 1/gp2)**(-1)


### PR DESCRIPTION
There are two critical bugs in these models:

1. `map_throats` is incorrectly being called on `geometry`, rather than `network`.
2. Filtered data from geometry (for instance `dt = target['throat.diameter']` were being re-filtered by an incorrect map from map_throats (for instance `dt = target['throat.diameter'][throats]` where `throats = target.map_throats(target['throat._id'])`).