### PR TITLE
Minor tweak to use 64 bit integers in A matrix

### DIFF
--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -435,7 +435,10 @@ class GenericTransport(GenericAlgorithm):
             del(ls)  # Clean
         else:
             solver = getattr(sprs.linalg, self.settings['solver'])
-            x = solver(A=A.tocsr(), b=b)
+            A = A.tocsr()
+            A.indices = A.indices.astype(np.int64)
+            A.indptr = A.indptr.astype(np.int64)
+            x = solver(A=A, b=b)
         return x
 
     def results(self):

--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -435,21 +435,19 @@ class GenericTransport(GenericAlgorithm):
             x = sls.solve(ls)
             del(ls)  # Clean
         else:
-            solver = getattr(sprs.linalg, self.settings['solver'])
-            func = inspect.getargspec(solver)[0]
-            if 'tol' in func:
-                norm_A = sprs.linalg.norm(self._A)
-                norm_b = np.linalg.norm(self._b)
-                tol = min(norm_A, norm_b)*1e-06
-                x = solver(A=A.tocsr(), b=b, tol=tol)
-            else:
-                x = solver(A=A.tocsr(), b=b)
-        if type(x) == tuple:
-            x = x[0]
             A = A.tocsr()
             A.indices = A.indices.astype(np.int64)
             A.indptr = A.indptr.astype(np.int64)
-            x = solver(A=A, b=b)
+            solver = getattr(sprs.linalg, self.settings['solver'])
+            if 'tol' in inspect.getargspec(solver)[0]:
+                norm_A = sprs.linalg.norm(self._A)
+                norm_b = np.linalg.norm(self._b)
+                tol = min(norm_A, norm_b)*1e-06
+                x = solver(A=A, b=b, tol=tol)
+            else:
+                x = solver(A=A, b=b)
+        if type(x) == tuple:
+            x = x[0]
         return x
 
     def results(self):

--- a/openpnm/algorithms/ReactiveTransport.py
+++ b/openpnm/algorithms/ReactiveTransport.py
@@ -94,7 +94,7 @@ class ReactiveTransport(GenericTransport):
         self._update_physics()
 
         x = self._run_reactive(x=x)
-        return x
+        self[self.settings['quantity']] = x
 
     def _run_reactive(self, x):
         if x is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ h5py
 porespy
 transforms3d
 flatdict
+scikit-umfpack

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
         'h5py',
         'porespy',
         'transforms3d',
-        'flatdict'],
+        'flatdict',
+        'scikit-umfpack'],
 
     author='OpenPNM Team',
     author_email='jgostick@uwaterloo.ca',

--- a/tests/unit/algorithms/GenericTransportTest.py
+++ b/tests/unit/algorithms/GenericTransportTest.py
@@ -55,6 +55,19 @@ class GenericTransportTest:
         y = sp.unique(sp.around(alg['pore.mole_fraction'], decimals=3))
         assert sp.all(x == y)
 
+    def test_two_value_conditions_cg(self):
+        alg = op.algorithms.GenericTransport(network=self.net,
+                                             phase=self.phase)
+        alg.settings['conductance'] = 'throat.diffusive_conductance'
+        alg.settings['quantity'] = 'pore.mole_fraction'
+        alg.set_value_BC(pores=self.net.pores('top'), values=1)
+        alg.set_value_BC(pores=self.net.pores('bottom'), values=0)
+        alg.settings['solver'] = 'cg'
+        alg.run()
+        x = [0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1.0]
+        y = sp.unique(sp.around(alg['pore.mole_fraction'], decimals=3))
+        assert sp.all(x == y)
+
     def test_one_value_one_rate(self):
         alg = op.algorithms.GenericTransport(network=self.net,
                                              phase=self.phase)


### PR DESCRIPTION
This was added to force scipy to use the 64 bit version of umfpack and hence increase the allowed memory.  It works! 