### PR TITLE
Changing the API for the mapping functions

### DIFF
--- a/example_script.py
+++ b/example_script.py
@@ -41,4 +41,5 @@ rxn.set_value_BC(pores=pn.pores('top'), values=1)
 rxn.run()
 air.update(rxn.results())
 
-proj.export_data(network=pn, phases=[hg, air, water], filename='output.vtp')
+# Output network and phases to a VTP file for visualization in Paraview
+# proj.export_data(network=pn, phases=[hg, air, water], filename='output.vtp')

--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -757,37 +757,62 @@ class Base(dict):
             t = namedtuple('index_map', ('indices', 'mask'))
             return t(ind, mask)
 
-    def map_pores(self, ids, filtered=True):
+    def map_pores(self, pores, target, filtered=True):
         r"""
-        Translates pore ids to indices on the calling object
+        Given a list of pore on a target object, finds indices of
+        those pores on the calling object
 
         Parameters
         ----------
-        ids : array_like
-            The ids of the pores whose indices are sought
+        pores : array_like
+            The indices of the pores on the target object
+
+        target : OpenPNM Base object
+            The object corresponding to the indices given in ``pores``
 
         filtered : boolean (default is ``True``)
             If ``True`` then a ND-array of indices is returned with missing
             indices removed, otherwise a named-tuple containing both the
             ``indices`` and a boolean ``mask`` with ``False`` indicating
-            which ``ids`` were not found.
+            which locations were not found.
+
+        Returns
+        -------
+        Pore indices on the calling object corresponding to the same pores
+        on the target object.  Can be an array or a tuple containing an array
+        and a mask, depending on the value of ``filtered``.
 
         """
+        ids = target['pore._id'][pores]
         return self._map(element='pore', ids=ids, filtered=filtered)
 
-    def map_throats(self, ids, filtered=True):
+    def map_throats(self, throats, target, filtered=True):
         r"""
-        Translates throat ids to indices on the calling object
+        Given a list of throats on a target object, finds indices of
+        those throats on the calling object
 
         Parameters
         ----------
-        ids : array_like
-             The ids of the throats whose indices are sought
+        throats : array_like
+            The indices of the throats on the target object
+
+        target : OpenPNM Base object
+            The object corresponding to the indices given in ``throats``
 
         filtered : boolean (default is ``True``)
-            If ``True`` then a ND-array of indices is returned, otherwise
-            a named-tuple containing the ``indices`` and the ???
+            If ``True`` then a ND-array of indices is returned with missing
+            indices removed, otherwise a named-tuple containing both the
+            ``indices`` and a boolean ``mask`` with ``False`` indicating
+            which locations were not found.
+
+        Returns
+        -------
+        Throat indices on the calling object corresponding to the same throats
+        on the target object.  Can be an array or a tuple containing an array
+        and a mask, depending on the value of ``filtered``.
+
         """
+        ids = target['throat._id'][throats]
         return self._map(element='throat', ids=ids, filtered=filtered)
 
     def _tomask(self, indices, element):

--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -757,7 +757,7 @@ class Base(dict):
             t = namedtuple('index_map', ('indices', 'mask'))
             return t(ind, mask)
 
-    def map_pores(self, pores, target, filtered=True):
+    def map_pores(self, pores, origin, filtered=True):
         r"""
         Given a list of pore on a target object, finds indices of
         those pores on the calling object
@@ -767,7 +767,7 @@ class Base(dict):
         pores : array_like
             The indices of the pores on the target object
 
-        target : OpenPNM Base object
+        origin : OpenPNM Base object
             The object corresponding to the indices given in ``pores``
 
         filtered : boolean (default is ``True``)
@@ -783,10 +783,10 @@ class Base(dict):
         and a mask, depending on the value of ``filtered``.
 
         """
-        ids = target['pore._id'][pores]
+        ids = origin['pore._id'][pores]
         return self._map(element='pore', ids=ids, filtered=filtered)
 
-    def map_throats(self, throats, target, filtered=True):
+    def map_throats(self, throats, origin, filtered=True):
         r"""
         Given a list of throats on a target object, finds indices of
         those throats on the calling object
@@ -796,7 +796,7 @@ class Base(dict):
         throats : array_like
             The indices of the throats on the target object
 
-        target : OpenPNM Base object
+        origin : OpenPNM Base object
             The object corresponding to the indices given in ``throats``
 
         filtered : boolean (default is ``True``)
@@ -812,7 +812,7 @@ class Base(dict):
         and a mask, depending on the value of ``filtered``.
 
         """
-        ids = target['throat._id'][throats]
+        ids = origin['throat._id'][throats]
         return self._map(element='throat', ids=ids, filtered=filtered)
 
     def _tomask(self, indices, element):

--- a/openpnm/models/geometry/throat_equivalent_area.py
+++ b/openpnm/models/geometry/throat_equivalent_area.py
@@ -25,7 +25,7 @@ def spherical_pores(target, throat_area='throat.area',
 
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]
@@ -59,7 +59,7 @@ def truncated_pyramid(target, throat_area='throat.area',
 
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]
@@ -92,7 +92,7 @@ def circular_pores(target, throat_area='throat.area',
 
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]

--- a/openpnm/models/geometry/throat_equivalent_area.py
+++ b/openpnm/models/geometry/throat_equivalent_area.py
@@ -2,7 +2,8 @@ from numpy import pi as _pi
 import numpy as _np
 
 
-def spherical_pores(target, throat_area='throat.area', pore_diameter='pore.diameter',
+def spherical_pores(target, throat_area='throat.area',
+                    pore_diameter='pore.diameter',
                     throat_conduit_lengths='throat.conduit_lengths'):
     r"""
     Calculate equivalent cross-sectional area for a conduit consisting of two
@@ -24,7 +25,7 @@ def spherical_pores(target, throat_area='throat.area', pore_diameter='pore.diame
 
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]
@@ -35,11 +36,13 @@ def spherical_pores(target, throat_area='throat.area', pore_diameter='pore.diame
             'pore2': d2*L2*_pi / (2*_np.arctanh(2*L2/d2))}
 
 
-def truncated_pyramid(target, throat_area='throat.area', pore_diameter='pore.diameter'):
+def truncated_pyramid(target, throat_area='throat.area',
+                      pore_diameter='pore.diameter'):
     r"""
     Calculate equivalent cross-sectional area for a conduit consisting of two
-    truncated pyramid pores and a constant cross-section throat. This area can be later
-    used to calculate hydraulic or diffusive conductance of the conduit.
+    truncated pyramid pores and a constant cross-section throat. This area can
+    be later used to calculate hydraulic or diffusive conductance of the
+    conduit.
 
     Parameters
     ----------
@@ -56,7 +59,7 @@ def truncated_pyramid(target, throat_area='throat.area', pore_diameter='pore.dia
 
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]
@@ -66,7 +69,8 @@ def truncated_pyramid(target, throat_area='throat.area', pore_diameter='pore.dia
             'pore2': d2*td}
 
 
-def circular_pores(target, throat_area='throat.area', pore_diameter='pore.diameter',
+def circular_pores(target, throat_area='throat.area',
+                   pore_diameter='pore.diameter',
                    throat_conduit_lengths='throat.conduit_lengths'):
     r"""
     Calculate equivalent cross-sectional area for a conduit consisting of two
@@ -88,7 +92,7 @@ def circular_pores(target, throat_area='throat.area', pore_diameter='pore.diamet
 
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]

--- a/openpnm/models/geometry/throat_length.py
+++ b/openpnm/models/geometry/throat_length.py
@@ -20,7 +20,7 @@ def ctc(target, pore_diameter='pore.diameter'):
 
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     cn = network['throat.conns'][throats]
     C1 = network['pore.coords'][cn[:, 0]]
     C2 = network['pore.coords'][cn[:, 1]]
@@ -106,7 +106,7 @@ def spherical_pores(target, pore_diameter='pore.diameter',
     L2[mask_overlap] = L2temp[mask_overlap]
     Lt[mask_overlap] = L_negative
     # Removing negative lengths
-    if _sp.any([L1<0, L2<0, Lt<0]) and L_negative is not None:
+    if _sp.any([L1 < 0, L2 < 0, Lt < 0]) and L_negative is not None:
         _logger.warn('Negative pore/throat lengths are calculated. Arbitrary' +
                      ' positive length assigned: ' + str(L_negative))
         L1[L1 < 0] = L_negative
@@ -140,7 +140,7 @@ def truncated_pyramid(target, pore_diameter='pore.diameter',
 
 
 def circular_pores(target, pore_diameter='pore.diameter',
-                    throat_diameter='throat.diameter'):
+                   throat_diameter='throat.diameter'):
     r"""
     Calculate conduit lengths, i.e. pore 1 length, throat length,
     and pore 2 length, assuming that pores are circles.

--- a/openpnm/models/geometry/throat_length.py
+++ b/openpnm/models/geometry/throat_length.py
@@ -48,7 +48,7 @@ def straight(target, pore_diameter='pore.diameter', L_negative=1e-12):
         ``None``.
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     cn = network['throat.conns'][throats]
     E = ctc(target, pore_diameter=pore_diameter)
     D1 = network[pore_diameter][cn[:, 0]]
@@ -83,7 +83,7 @@ def spherical_pores(target, pore_diameter='pore.diameter',
 
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]

--- a/openpnm/models/geometry/throat_length.py
+++ b/openpnm/models/geometry/throat_length.py
@@ -20,7 +20,7 @@ def ctc(target, pore_diameter='pore.diameter'):
 
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
     C1 = network['pore.coords'][cn[:, 0]]
     C2 = network['pore.coords'][cn[:, 1]]
@@ -48,7 +48,7 @@ def straight(target, pore_diameter='pore.diameter', L_negative=1e-12):
         ``None``.
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
     E = ctc(target, pore_diameter=pore_diameter)
     D1 = network[pore_diameter][cn[:, 0]]
@@ -83,7 +83,7 @@ def spherical_pores(target, pore_diameter='pore.diameter',
 
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
     d1 = network[pore_diameter][cn[:, 0]]
     d2 = network[pore_diameter][cn[:, 1]]

--- a/openpnm/models/physics/hydraulic_conductance.py
+++ b/openpnm/models/physics/hydraulic_conductance.py
@@ -42,7 +42,7 @@ def hagen_poiseuille(target,
 
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     phase = target.project.find_phase(target)
     geom = target.project.find_geometry(target)
     cn = network['throat.conns'][throats]

--- a/openpnm/models/physics/hydraulic_conductance.py
+++ b/openpnm/models/physics/hydraulic_conductance.py
@@ -42,7 +42,7 @@ def hagen_poiseuille(target,
 
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     phase = target.project.find_phase(target)
     geom = target.project.find_geometry(target)
     cn = network['throat.conns'][throats]

--- a/openpnm/models/physics/misc.py
+++ b/openpnm/models/physics/misc.py
@@ -37,7 +37,7 @@ def poisson_conductance(target, pore_diffusivity, throat_diffusivity,
 
     """
     network = target.project.network
-    throats = network.map_throats(target['throat._id'])
+    throats = network.map_throats(throats=target.Ts, target=target)
     phase = target.project.find_phase(target)
     geom = target.project.find_geometry(target)
     cn = network['throat.conns'][throats]

--- a/openpnm/models/physics/misc.py
+++ b/openpnm/models/physics/misc.py
@@ -37,7 +37,7 @@ def poisson_conductance(target, pore_diffusivity, throat_diffusivity,
 
     """
     network = target.project.network
-    throats = network.map_throats(throats=target.Ts, target=target)
+    throats = network.map_throats(throats=target.Ts, origin=target)
     phase = target.project.find_phase(target)
     geom = target.project.find_geometry(target)
     cn = network['throat.conns'][throats]

--- a/openpnm/models/physics/multiphase.py
+++ b/openpnm/models/physics/multiphase.py
@@ -62,7 +62,7 @@ def conduit_conductance(target, throat_conductance,
     value = phase[throat_conductance].copy()
     value[mask] = value[mask]*factor
     # Now map throats onto target object
-    Ts = phase.map_throats(ids=target['throat._id'])
+    Ts = network.map_throats(throats=target.Ts, target=target)
     return value[Ts]
 
 

--- a/openpnm/models/physics/multiphase.py
+++ b/openpnm/models/physics/multiphase.py
@@ -62,7 +62,7 @@ def conduit_conductance(target, throat_conductance,
     value = phase[throat_conductance].copy()
     value[mask] = value[mask]*factor
     # Now map throats onto target object
-    Ts = network.map_throats(throats=target.Ts, target=target)
+    Ts = network.map_throats(throats=target.Ts, origin=target)
     return value[Ts]
 
 

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -669,8 +669,6 @@ def trim(network, pores=[], throats=[]):
     Pkeep_inds = sp.where(Pkeep)[0]
     Tkeep_inds = sp.where(Tkeep)[0]
     Pmap = sp.ones((network.Np,), dtype=int)*-1
-    Pid = network['pore._id']
-    Tid = network['throat._id']
     tpore1 = network['throat.conns'][:, 0]
     tpore2 = network['throat.conns'][:, 1]
 
@@ -680,8 +678,8 @@ def trim(network, pores=[], throats=[]):
             Ps = Pkeep_inds
             Ts = Tkeep_inds
         else:
-            Ps = obj.map_pores(ids=Pid[Pkeep])
-            Ts = obj.map_throats(ids=Tid[Tkeep])
+            Ps = obj.map_pores(pores=Pkeep, target=network)
+            Ts = obj.map_throats(throats=Tkeep, target=network)
         for key in list(obj.keys()):
             temp = obj.pop(key)
             if key.split('.')[0] == 'throat':

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -678,8 +678,8 @@ def trim(network, pores=[], throats=[]):
             Ps = Pkeep_inds
             Ts = Tkeep_inds
         else:
-            Ps = obj.map_pores(pores=Pkeep, target=network)
-            Ts = obj.map_throats(throats=Tkeep, target=network)
+            Ps = obj.map_pores(pores=Pkeep, origin=network)
+            Ts = obj.map_throats(throats=Tkeep, origin=network)
         for key in list(obj.keys()):
             temp = obj.pop(key)
             if key.split('.')[0] == 'throat':

--- a/openpnm/utils/Project.py
+++ b/openpnm/utils/Project.py
@@ -341,9 +341,9 @@ class Project(list):
                 physics = self.find_physics(phase=phase)
                 temp = None
                 for phys in physics:
-                    Ps = phase.map_pores(phys['pore._id'])
+                    Ps = phase.map_pores(pores=phys.Ps, target=phys)
                     physPs = phase.tomask(pores=Ps)
-                    Ts = phase.map_throats(phys['throat._id'])
+                    Ts = phase.map_throats(throats=phys.Ts, target=phys)
                     physTs = phase.tomask(throats=Ts)
                     if np.all(geoPs == physPs) and np.all(geoTs == physTs):
                         temp = phys

--- a/openpnm/utils/Project.py
+++ b/openpnm/utils/Project.py
@@ -341,9 +341,9 @@ class Project(list):
                 physics = self.find_physics(phase=phase)
                 temp = None
                 for phys in physics:
-                    Ps = phase.map_pores(pores=phys.Ps, target=phys)
+                    Ps = phase.map_pores(pores=phys.Ps, origin=phys)
                     physPs = phase.tomask(pores=Ps)
-                    Ts = phase.map_throats(throats=phys.Ts, target=phys)
+                    Ts = phase.map_throats(throats=phys.Ts, origin=phys)
                     physTs = phase.tomask(throats=Ts)
                     if np.all(geoPs == physPs) and np.all(geoTs == physTs):
                         temp = phys

--- a/openpnm/utils/vertexops.py
+++ b/openpnm/utils/vertexops.py
@@ -407,11 +407,11 @@ def plot_pore(geometry, pores, fig=None, axis_bounds=None,
     from mpl_toolkits.mplot3d.art3d import Poly3DCollection
     if len(pores) > 0:
         net = geometry.network
-        net_pores = net.map_pores(pores=pores, target=geometry)
+        net_pores = net.map_pores(pores=pores, origin=geometry)
         centroids = geometry['pore.centroid'][pores]
         coords = net['pore.coords'][net_pores]
         net_throats = net.find_neighbor_throats(pores=net_pores)
-        throats = geometry.map_throats(throats=net_throats, target=net)
+        throats = geometry.map_throats(throats=net_throats, origin=net)
         tcentroids = geometry["throat.centroid"][throats]
         # Can't create volume from one throat
         if 1 <= len(throats):

--- a/openpnm/utils/vertexops.py
+++ b/openpnm/utils/vertexops.py
@@ -282,9 +282,8 @@ def pore2centroid(network):
     for geom_name in network.geometries():
         geometry = network.geometries(geom_name)[0]
         if 'pore.centroid' in geometry.props():
-            net_pores, geom_pores = geometry.map_pores(network,
-                                                       geometry.pores(),
-                                                       True).values()
+            net_pores = network.pores(geometry.name)
+            geom_pores = network.map_pors(poress=geometry.Ts, target=geometry)
             for i in range(len(geom_pores)):
                 network['pore.coords'][net_pores[i]] = \
                     geometry['pore.centroid'][geom_pores[i]]
@@ -408,11 +407,11 @@ def plot_pore(geometry, pores, fig=None, axis_bounds=None,
     from mpl_toolkits.mplot3d.art3d import Poly3DCollection
     if len(pores) > 0:
         net = geometry.network
-        net_pores = net.map_pores(geometry['pore._id'][pores])
+        net_pores = net.map_pores(pores=pores, target=geometry)
         centroids = geometry['pore.centroid'][pores]
         coords = net['pore.coords'][net_pores]
         net_throats = net.find_neighbor_throats(pores=net_pores)
-        throats = geometry.map_throats(net['throat._id'][net_throats])
+        throats = geometry.map_throats(throats=net_throats, target=net)
         tcentroids = geometry["throat.centroid"][throats]
         # Can't create volume from one throat
         if 1 <= len(throats):

--- a/tests/unit/core/BaseTest.py
+++ b/tests/unit/core/BaseTest.py
@@ -578,39 +578,39 @@ class BaseTest:
         assert a.size == self.geo21.Np
         assert b.size == self.geo22.Np
         assert ~sp.any(sp.in1d(a, b))
-        Pgeo21 = self.net2.map_pores(pores=self.geo21.Ps, target=self.geo21)
+        Pgeo21 = self.net2.map_pores(pores=self.geo21.Ps, origin=self.geo21)
         assert sp.all(Pgeo21 == self.net2.pores(self.geo21.name))
-        Pgeo22 = self.net2.map_pores(pores=self.geo22.Ps, target=self.geo22)
+        Pgeo22 = self.net2.map_pores(pores=self.geo22.Ps, origin=self.geo22)
         assert sp.all(Pgeo22 == self.net2.pores(self.geo22.name))
 
     def test_map_throats(self):
         a = self.geo21['throat._id']
         assert a.size == self.geo21.Nt
-        Tgeo21 = self.net2.map_throats(throats=self.geo21.Ts, target=self.geo21)
+        Tgeo21 = self.net2.map_throats(throats=self.geo21.Ts, origin=self.geo21)
         assert sp.all(Tgeo21 == self.net2.throats(self.geo21.name))
 
     def test_map_pores_unfiltered(self):
-        b = self.net.map_pores(pores=self.geo.Ps, target=self.geo, filtered=False)
+        b = self.net.map_pores(pores=self.geo.Ps, origin=self.geo, filtered=False)
         assert sp.all(b.indices == self.net.pores(self.geo.name))
         assert b.mask.size == self.geo.Np
 
     def test_map_pores_unfiltered_missing(self):
         Ps = self.net2.Ps[15:20]
-        b = self.geo22.map_pores(pores=Ps, target=self.net2, filtered=False)
+        b = self.geo22.map_pores(pores=Ps, origin=self.net2, filtered=False)
         assert sum(b.mask) == 2
         assert len(b.mask) == 5
 
     def test_map_pores_reverse(self):
         Ps = self.net2.Ps[:5]
-        b = self.geo21.map_pores(pores=Ps, target=self.net2)
+        b = self.geo21.map_pores(pores=Ps, origin=self.net2)
         assert sp.all(b == [0, 1, 2, 3, 4])
         Ps = self.net2.Ps[-5:]
-        b = self.geo22.map_pores(pores=Ps, target=self.net2)
+        b = self.geo22.map_pores(pores=Ps, origin=self.net2)
         assert sp.all(b == [4, 5, 6, 7, 8])
 
     def test_map_pores_missing(self):
         Ps = self.net2.Ps[:5]
-        b = self.geo22.map_pores(pores=Ps, target=self.net2)
+        b = self.geo22.map_pores(pores=Ps, origin=self.net2)
         assert len(b) == 0
 
     def test_interleave_data_bool(self):


### PR DESCRIPTION
The mapping functions used to take IDs as arguments, now they take pore numbers and the associated object.  It hides ids from the users.