### PR TITLE
Fix broken vtk

### DIFF
--- a/openpnm/io/VTK.py
+++ b/openpnm/io/VTK.py
@@ -87,6 +87,9 @@ class VTK(GenericIO):
             array = am[key]
             if array.dtype == np.bool:
                 array = array.astype(int)
+            if np.any(np.isnan(array)):
+                logger.warning(key + ' has nans, will not write to file')
+                continue
             if array.size != num_points:
                 continue
             element = VTK._array_to_element(key, array)
@@ -98,6 +101,9 @@ class VTK(GenericIO):
             array = am[key]
             if array.dtype == np.bool:
                 array = array.astype(int)
+            if np.any(np.isnan(array)):
+                logger.warning(key + ' has nans, will not write to file')
+                continue
             if array.size != num_throats:
                 continue
             element = VTK._array_to_element(key, array)


### PR DESCRIPTION
When nans are present paraview does not like the vtk file.  This add a `fill_nans` option to the save method that controls how they are dealt with.  None means the array is skipped, while any other value will get written in place of the nans (e.g. 0 or -1).