### PR TITLE
Fix 1066 prop naming

### DIFF
--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -175,6 +175,17 @@ class Base(dict):
                 prop = item.replace('pore.', '').replace('throat.', '')
                 self.__setitem__(key+'.'+prop, value[item])
             return
+        # Ensure that 'pore.foo.bar' does not exist before creating 'pore.foo'
+        for item in self.keys():
+            if len(item.split('.')) > 2:
+                if key == '.'.join(item.split('.')[:2]):
+                    raise Exception(key + ' is already in use as a subdict')
+        # Ensure that 'pore.foo' does not exist before creating 'pore.foo.bar'
+        if len(key.split('.')) > 2:
+            for item in self.keys():
+                if '.'.join(key.split('.')[:2]) == item:
+                    raise Exception(item + ' is already in use, cannot make ' +
+                                    'a subdict')
 
         value = sp.array(value, ndmin=1)  # Convert value to an ndarray
 

--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -175,17 +175,19 @@ class Base(dict):
                 prop = item.replace('pore.', '').replace('throat.', '')
                 self.__setitem__(key+'.'+prop, value[item])
             return
-        # Ensure that 'pore.foo.bar' does not exist before creating 'pore.foo'
-        for item in self.keys():
-            if len(item.split('.')) > 2:
-                if key == '.'.join(item.split('.')[:2]):
-                    raise Exception(key + ' is already in use as a subdict')
-        # Ensure that 'pore.foo' does not exist before creating 'pore.foo.bar'
-        if len(key.split('.')) > 2:
+        if key not in self.keys():
+            # Ensure 'pore.foo.bar' does not exist before creating 'pore.foo'
             for item in self.keys():
-                if '.'.join(key.split('.')[:2]) == item:
-                    raise Exception(item + ' is already in use, cannot make ' +
-                                    'a subdict')
+                if len(item.split('.')) > 2:
+                    if key == '.'.join(item.split('.')[:2]):
+                        raise Exception(key + ' is already in use as a ' +
+                                        'subdict')
+            # Ensure 'pore.foo' does not exist before creating 'pore.foo.bar'
+            if len(key.split('.')) > 2:
+                for item in self.keys():
+                    if '.'.join(key.split('.')[:2]) == item:
+                        raise Exception(item + ' is already in use, cannot ' +
+                                        'make a subdict')
 
         value = sp.array(value, ndmin=1)  # Convert value to an ndarray
 

--- a/tests/unit/core/BaseTest.py
+++ b/tests/unit/core/BaseTest.py
@@ -560,6 +560,14 @@ class BaseTest:
         # self.geo['pore.all'][0] = False
         # assert sp.sum(self.geo['pore.all']) == array_sum
 
+    def test_setitem_subdict_conflicts(self):
+        self.geo['pore.foo'] = 1
+        with pytest.raises(Exception):
+            self.geo['pore.foo.bar'] = 1
+        self.geo['throat.foo.bar'] = 1
+        with pytest.raises(Exception):
+            self.geo['throat.foo'] = 1
+
     def test_object_name_name_conflict(self):
         with pytest.raises(Exception):
             self.geo.name = self.net.name


### PR DESCRIPTION
Adding a check to setitem in Base so that trying to add 'pore.foo' will raise an exception when 'pore.foo.bar' is already present, and vice-versa.