### PR TITLE
Improve pore/throat volume calculations

### DIFF
--- a/openpnm/geometry/StickAndBall.py
+++ b/openpnm/geometry/StickAndBall.py
@@ -192,7 +192,8 @@ class StickAndBall(GenericGeometry):
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.sphere,
-                       pore_diameter='pore.diameter')
+                       pore_diameter='pore.diameter',
+                       conduit_lengths='throat.conduit_lengths')
 
         self.add_model(propname='throat.max_size',
                        model=mods.misc.from_neighbor_pores,
@@ -201,7 +202,7 @@ class StickAndBall(GenericGeometry):
 
         self.add_model(propname='throat.diameter',
                        model=mods.misc.scaled,
-                       factor=0.5,
+                       factor=0.99,
                        prop='throat.max_size')
 
         self.add_model(propname='throat.endpoints',

--- a/openpnm/models/geometry/throat_surface_area.py
+++ b/openpnm/models/geometry/throat_surface_area.py
@@ -4,7 +4,7 @@ import scipy as _sp
 def cylinder(target, throat_diameter='throat.diameter',
              throat_length='throat.length'):
     r"""
-    Calculate surface area for a cylindrical throat
+    Calculate surface area for a cylindrical throat.
 
     Parameters
     ----------
@@ -29,7 +29,7 @@ def cylinder(target, throat_diameter='throat.diameter',
 def cuboid(target, throat_diameter='throat.diameter',
            throat_length='throat.length'):
     r"""
-    Calculate surface area for a cuboid throat
+    Calculate surface area for a cuboid throat.
 
     Parameters
     ----------

--- a/openpnm/models/geometry/throat_volume.py
+++ b/openpnm/models/geometry/throat_volume.py
@@ -13,9 +13,11 @@ def cylinder(target, throat_length='throat.length',
         length of the calculated array, and also provides access to other
         necessary properties.
 
-    throat_length and throat_diameter : strings
-        The dictionary keys containing the arrays with the throat diameter and
-        length values.
+    throat_length : strings
+        The dictionary key containing the array with the throat length values.
+
+    throat_diameter : strings
+        The dictionary key containing the array with the throat diam values.
 
     Notes
     -----
@@ -40,9 +42,11 @@ def cuboid(target, throat_length='throat.length',
         length of the calculated array, and also provides access to other
         necessary properties.
 
-    throat_length and throat_diameter : strings
-        The dictionary keys containing the arrays with the throat diameter and
-        length values.
+    throat_length : strings
+        The dictionary key containing the array with the throat length values.
+
+    throat_diameter : strings
+        The dictionary key containing the array with the throat diam values.
 
     Notes
     -----
@@ -68,15 +72,13 @@ def extrusion(target, throat_length='throat.length',
         length of the calculated array, and also provides access to other
         necessary properties.
 
-    throat_length and throat_area : strings
-        The dictionary keys containing the arrays with the throat area and
-        length values.
+    throat_length : strings
+        The dictionary key containing the array with the throat length values.
 
-    Notes
-    -----
-    At present this models does NOT account for the volume reprsented by the
-    intersection of the throat with a spherical pore body.
-        """
+    throat_area : strings
+        The dictionary key containing the array with the throat area values.
+
+    """
     leng = target[throat_length]
     area = target[throat_area]
     value = leng*area


### PR DESCRIPTION
Currently, pore/throat volume calculations are done base on non-overlapping pores and throats. This PR tries to improve how they are calculated. 

The new method is based on calculating the lens volume and subtracting it from the volume of a perfect sphere. This method is still very fragile and only works fine when throat diameter is reasonably smaller than pore diameter (at most 70% as big). When throat diameter gets close enough to pore diameter, there are lots of hard-to-efficiently-track overlaps. 

I strongly suggest we don't include it in v2.0. Once we found a better/more robust way, we can release it then.