### PR TITLE
Improve nans support in throat_length models

### DIFF
--- a/openpnm/models/geometry/throat_length.py
+++ b/openpnm/models/geometry/throat_length.py
@@ -1,4 +1,4 @@
-from scipy.linalg import norm as _norm
+from scipy import sqrt as _sqrt
 from openpnm.utils import logging as _logging
 _logger = _logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def ctc(target, pore_diameter='pore.diameter'):
     cn = network['throat.conns'][throats]
     C1 = network['pore.coords'][cn[:, 0]]
     C2 = network['pore.coords'][cn[:, 1]]
-    return _norm(C1 - C2, axis=1)
+    return _sqrt(((C1 - C2)**2).sum(axis=1))
 
 
 def piecewise(target, throat_endpoints='throat.endpoints',
@@ -66,11 +66,12 @@ def piecewise(target, throat_endpoints='throat.endpoints',
     EP1 = network[throat_endpoints + '.head'][throats]
     EP2 = network[throat_endpoints + '.tail'][throats]
     # Calculate throat length
-    Lt = _norm(EP1 - EP2, axis=1)
+    Lt = _sqrt(((EP1 - EP2)**2).sum(axis=1))
     # Handle the case where pores & throat centroids are not colinear
     try:
         Ct = network[throat_centroid][throats]
-        Lt = _norm(Ct - EP1, axis=1) + _norm(Ct - EP2, axis=1)
+        Lt = _sqrt(((Ct - EP1)**2).sum(axis=1)) + \
+            _sqrt(((Ct - EP2)**2).sum(axis=1))
     except KeyError:
         pass
     return Lt
@@ -119,8 +120,8 @@ def conduit_lengths(target, throat_endpoints='throat.endpoints',
         Lt = network[throat_length][throats]
     except KeyError:
         # Calculate throat length otherwise
-        Lt = _norm(EP1 - EP2, axis=1)
+        Lt = _sqrt(((EP1 - EP2)**2).sum(axis=1))
     # Calculate conduit lengths
-    L1 = _norm(C1 - EP1, axis=1)
-    L2 = _norm(C2 - EP2, axis=1)
+    L1 = _sqrt(((C1 - EP1)**2).sum(axis=1))
+    L2 = _sqrt(((C2 - EP2)**2).sum(axis=1))
     return {'pore1': L1, 'throat': Lt, 'pore2': L2}

--- a/openpnm/models/geometry/throat_length.py
+++ b/openpnm/models/geometry/throat_length.py
@@ -1,3 +1,4 @@
+import numpy as _np
 from scipy import sqrt as _sqrt
 from openpnm.utils import logging as _logging
 _logger = _logging.getLogger(__name__)
@@ -20,12 +21,18 @@ def ctc(target, pore_diameter='pore.diameter'):
         Dictionary key of the pore diameter values
 
     """
+    _np.warnings.filterwarnings('ignore', category=RuntimeWarning)
+
     network = target.project.network
     throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
     C1 = network['pore.coords'][cn[:, 0]]
     C2 = network['pore.coords'][cn[:, 1]]
-    return _sqrt(((C1 - C2)**2).sum(axis=1))
+    value = _sqrt(((C1 - C2)**2).sum(axis=1))
+
+    _np.warnings.filterwarnings('default', category=RuntimeWarning)
+
+    return value
 
 
 def piecewise(target, throat_endpoints='throat.endpoints',
@@ -60,6 +67,7 @@ def piecewise(target, throat_endpoints='throat.endpoints',
     length. This could be useful for Voronoi or extracted networks.
 
     """
+    _np.warnings.filterwarnings('ignore', category=RuntimeWarning)
     network = target.project.network
     throats = network.map_throats(throats=target.Ts, origin=target)
     # Get throat endpoints
@@ -74,6 +82,9 @@ def piecewise(target, throat_endpoints='throat.endpoints',
             _sqrt(((Ct - EP2)**2).sum(axis=1))
     except KeyError:
         pass
+
+    _np.warnings.filterwarnings('default', category=RuntimeWarning)
+
     return Lt
 
 
@@ -106,6 +117,8 @@ def conduit_lengths(target, throat_endpoints='throat.endpoints',
     keys 'pore1', 'pore2', and 'throat'.
 
     """
+    _np.warnings.filterwarnings('ignore', category=RuntimeWarning)
+
     network = target.project.network
     throats = network.map_throats(throats=target.Ts, origin=target)
     cn = network['throat.conns'][throats]
@@ -124,4 +137,7 @@ def conduit_lengths(target, throat_endpoints='throat.endpoints',
     # Calculate conduit lengths
     L1 = _sqrt(((C1 - EP1)**2).sum(axis=1))
     L2 = _sqrt(((C2 - EP2)**2).sum(axis=1))
+
+    _np.warnings.filterwarnings('default', category=RuntimeWarning)
+
     return {'pore1': L1, 'throat': Lt, 'pore2': L2}


### PR DESCRIPTION
This is useful when dealing with undefined geometries. Previously, since numpy's norm was used to calculate the distance between points, models wouldn't run complaining there's nans in pore.diameter/etc. Now, distance calculation is done manually, and annoying numpy RuntimeWarnings are caught on the fly.