### PR TITLE
Improve merge_pores to be able to merge list of lists of pores

### DIFF
--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1650,7 +1650,10 @@ def merge_pores(network, pores, labels=['merged']):
 
     Notes
     -----
-    The selection of pores should be chosen carefully, preferrable so that
+    (1) The method also works if a list of lists is passed, in which case
+    it consecutively merges the given selections of pores.
+
+    (2) The selection of pores should be chosen carefully, preferrable so that
     they all form a continuous cluster.  For instance, it is recommended
     to use the ``find_nearby_pores`` method to find all pores within a
     certain distance of a given pore, and these can then be merged without
@@ -1670,15 +1673,24 @@ def merge_pores(network, pores, labels=['merged']):
     32
 
     """
-    Pn = network.find_neighbor_pores(pores=pores,
-                                     mode='union',
-                                     flatten=True,
-                                     include_input=False)
-    xyz = sp.mean(network['pore.coords'][pores], axis=0)
-    extend(network, pore_coords=xyz, labels=labels)
-    Pnew = network.Ps[-1]
-    connect_pores(network, pores1=Pnew, pores2=Pn, labels=labels)
-    trim(network=network, pores=pores)
+    # Assert that `pores` is list of lists
+    try:
+        len(pores[0])
+    except TypeError:
+        pores = [pores]
+    N = len(pores)
+    NBs, XYZs = [], []
+    for Ps in pores:
+        NBs.append(network.find_neighbor_pores(pores=Ps,
+                                               mode='union',
+                                               flatten=True,
+                                               include_input=False))
+        XYZs.append(network['pore.coords'][Ps].mean(axis=0))
+    extend(network, pore_coords=XYZs, labels=labels)
+    Pnew = network.Ps[-N::]
+    for P, NB in zip(Pnew, NBs):
+        connect_pores(network, pores1=P, pores2=NB, labels=labels)
+    trim(network=network, pores=sp.concatenate(pores))
 
 
 def _template_sphere_disc(dim, outer_radius, inner_radius):
@@ -1835,7 +1847,6 @@ def plot_connections(network, throats=None, fig=None, **kwargs):
 
     """
     import matplotlib.pyplot as plt
-    from mpl_toolkits.mplot3d import Axes3D
 
     if throats is None:
         Ts = network.Ts
@@ -1933,7 +1944,6 @@ def plot_coordinates(network, pores=None, fig=None, **kwargs):
 
     """
     import matplotlib.pyplot as plt
-    from mpl_toolkits.mplot3d import Axes3D
 
     if pores is None:
         Ps = network.Ps

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[pycodestyle]
+ignore = E127,E222,E226,E225,E241,E402
+max-line-length = 90
+
 [pep8]
 ignore = E127,E222,E226,E225,E241,E402
 max-line-length = 90

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[flake8]
+ignore = E127,E222,E226,E225,E241,E402
+max-line-length = 90
+
 [pycodestyle]
 ignore = E127,E222,E226,E225,E241,E402
 max-line-length = 90

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -1,7 +1,6 @@
 import openpnm as op
 import numpy as np
-import pytest
-from numpy.testing import assert_approx_equal
+from numpy.testing import assert_allclose
 from openpnm import topotools
 
 
@@ -21,7 +20,7 @@ class TopotoolsTest:
         topotools.reduce_coordination(network=net, z=6)
         a = np.mean(net.num_neighbors(pores=net.Ps, flatten=False))
         b = 6.0
-        assert_approx_equal(a, b)
+        assert_allclose(a, b)
         h = net.check_network_health()
         assert h.health
 
@@ -120,6 +119,20 @@ class TopotoolsTest:
         assert np.sum(net1['pore.test4'][27:]) == 270
         assert 'pore.test1' not in net2
         assert 'pore.test2' not in net2
+
+    def test_merge_pores(self):
+        testnet = op.network.Cubic(shape=[10, 10, 10])
+        xyz_old = testnet['pore.coords'].copy()
+        to_merge = [[0, 1], [998, 999]]
+        topotools.merge_pores(testnet, to_merge)
+        xyz = testnet['pore.coords']
+        xyz1 = xyz[-2]
+        xyz2 = xyz[-1]
+        xyz1_desired = xyz_old[0:2].mean(axis=0)
+        xyz2_desired = xyz_old[998::].mean(axis=0)
+        assert testnet.Np == 998
+        assert_allclose(xyz1, xyz1_desired)
+        assert_allclose(xyz2, xyz2_desired)
 
     def test_ispercolating(self):
         net = op.network.Cubic(shape=[10, 10, 10], connectivity=26)


### PR DESCRIPTION
If you want to consecutively merge selections of pores, you need to consecutively call merge_pores (obviously) but since at the end of each call, the adjacency matrix is rebuilt, it's super slow. This PR basically enables merge_pores to accept list of lists of pores (instead of single list of pores), so the rebuilding of the adjacency matrix only happens once. This small change significantly speeds up the whole process of consecutively merging pores. (related to issue #1104)