### PR TITLE
Improve connect pores to be able to connect multiple batches of pores in a 1 to 1 fashion

### DIFF
--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1426,11 +1426,23 @@ def connect_pores(network, pores1, pores2, labels=[], add_conns=True):
            [32, 68]])
 
     '''
-    size1 = sp.size(pores1)
-    size2 = sp.size(pores2)
-    array1 = sp.repeat(pores1, size2)
-    array2 = sp.tile(pores2, size1)
-    conns = sp.vstack([array1, array2]).T
+    # Assert that `pores1` and `pores2` are list of lists
+    try:
+        len(pores1[0])
+        len(pores2[0])
+    except TypeError:
+        pores1 = [pores1]
+        pores2 = [pores2]
+    if len(pores1) != len(pores2):
+        raise Exception('pores1 and pores2 should be of the same length.')
+
+    arr1, arr2 = [], []
+    for ps1, ps2 in zip(pores1, pores2):
+        size1 = sp.size(ps1)
+        size2 = sp.size(ps2)
+        arr1.append(sp.repeat(ps1, size2))
+        arr2.append(sp.tile(ps2, size1))
+    conns = sp.vstack([sp.concatenate(arr1), sp.concatenate(arr2)]).T
     if add_conns:
         extend(network=network, throat_conns=conns, labels=labels)
     else:

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1382,6 +1382,8 @@ def connect_pores(network, pores1, pores2, labels=[], add_conns=True):
     Returns the possible connections between two group of pores, and optionally
     makes the connections.
 
+    See (1) under ``Notes`` for advanced usage.
+
     Parameters
     ----------
     network : OpenPNM Network Object
@@ -1403,7 +1405,14 @@ def connect_pores(network, pores1, pores2, labels=[], add_conns=True):
 
     Notes
     -----
-    It creates the connections in a format which is acceptable by
+    (1) The method also works if ``pores1`` and ``pores2`` are list of lists,
+    in which case it consecutively connects corresponding members of the two
+    lists in a 1-to-1 fashion. Example: pores1 = [[0, 1], [2, 3]] and
+    pores2 = [[5], [7, 9]] leads to creation of the following connections:
+        0 --> 5     2 --> 7     3 --> 7
+        1 --> 5     2 --> 9     3 --> 9
+
+    (2) It creates the connections in a format which is acceptable by
     the default OpenPNM connection ('throat.conns') and either adds them to
     the network or returns them.
 

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1412,7 +1412,10 @@ def connect_pores(network, pores1, pores2, labels=[], add_conns=True):
         0 --> 5     2 --> 7     3 --> 7
         1 --> 5     2 --> 9     3 --> 9
 
-    (2) It creates the connections in a format which is acceptable by
+    (2) If you want to use the batch functionality, make sure that each element
+    within ``pores1`` and ``pores2`` are of type list or ndarray.
+
+    (3) It creates the connections in a format which is acceptable by
     the default OpenPNM connection ('throat.conns') and either adds them to
     the network or returns them.
 

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1442,7 +1442,7 @@ def connect_pores(network, pores1, pores2, labels=[], add_conns=True):
     try:
         len(pores1[0])
         len(pores2[0])
-    except TypeError:
+    except (TypeError, IndexError):
         pores1 = [pores1]
         pores2 = [pores2]
     if len(pores1) != len(pores2):

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1689,7 +1689,7 @@ def merge_pores(network, pores, labels=['merged']):
     extend(network, pore_coords=XYZs, labels=labels)
     Pnew = network.Ps[-N::]
     for P, NB in zip(Pnew, NBs):
-        connect_pores(network, pores1=P, pores2=NB, labels=labels)
+        connect_pores(network, pores2=P, pores1=NB, labels=labels)
     trim(network=network, pores=sp.concatenate(pores))
 
 

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -134,6 +134,24 @@ class TopotoolsTest:
         assert_allclose(xyz1, xyz1_desired)
         assert_allclose(xyz2, xyz2_desired)
 
+    def test_connect_pores(self):
+        testnet = op.network.Cubic(shape=[10, 10, 10])
+        Nt_old= testnet.Nt
+        ps1 = [[0, 1], [23, 65]]
+        ps2 = [[55], [982, 555]]
+        topotools.connect_pores(testnet, pores1=ps1, pores2=ps2)
+        am = testnet.create_adjacency_matrix(weights=np.ones(testnet.Nt,
+                                                             dtype=int),
+                                             fmt='csr')
+        conns = testnet['throat.conns']
+        assert len(conns) == Nt_old + 6
+        assert am[0, 55] == 1
+        assert am[1, 55] == 1
+        assert am[23, 982] == 1
+        assert am[23, 555] == 1
+        assert am[65, 982] == 1
+        assert am[65, 555] == 1
+
     def test_ispercolating(self):
         net = op.network.Cubic(shape=[10, 10, 10], connectivity=26)
         tmask = net['throat.all']


### PR DESCRIPTION
This PR is similar to what was recently done to `merge_pores`. Previously, `connect_pores` would create new connections between two lists of pores, `pores1` and `pores2`. This PR preserves the old functionality but adds the possibility that user sends in a list of lists of pores as `pores1` and `pores2`, and consecutively make connections between the corresponding batches in a 1 to 1 fashion. 

Example:
```
ps1 = [[1, 2], [3, 4, 5]]
ps2 = [[55], [9, 99]]
op.topotools.connect_pores(net, pores1=ps1, pores2=ps2)
>>> net['throat.conns'][-8::]
array([[ 1, 55],
       [ 2, 55],
       [ 3,  9],
       [ 3, 99],
       [ 4,  9],
       [ 4, 99],
       [ 5,  9],
       [ 5, 99]])
```
The reason behind this PR is similar to that for `merge_pores`. In `connect_pores`, there are multiple calls to `extend` which slows it down significantly. This PR potentially helps `merge_pores` as well since it includes multiple calls to `connect_pores`, which can now be done in a single call. Fixing `merge_pores` for further performance gain is WIP.