### PR TITLE
Fix Voronoi Hulls

### DIFF
--- a/openpnm/materials/VoronoiFibers.py
+++ b/openpnm/materials/VoronoiFibers.py
@@ -538,6 +538,10 @@ class DelaunayGeometry(GenericGeometry):
             verts = np.asarray(unique_list(np.around(verts, 6)))
             verts /= self.network.resolution
             self.inhull(verts, pore)
+        # Catch the voxels that escaped the hulls
+        max_h = ndimage.maximum_filter(self._hull_image, size=2)
+        mask = self._hull_image == -1
+        self._hull_image[mask] = max_h[mask]
         self._process_pore_voxels()
 
     def _process_pore_voxels(self):


### PR DESCRIPTION
Catch the voxels that escape the hull image procedure and assign them to the nearest pore (using max_filter). Scikit-image flood fill would potentially be faster but is not implemented yet and speed is not so bad