### PR TITLE
Fix bug in subdivide

### DIFF
--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1818,11 +1818,11 @@ def subdivide(network, pores, shape, labels=[]):
             if neighbor in Pn_old_net:
                 coplanar_labels = network.labels(pores=nearest_neighbor)
                 new_neighbors = network.pores(coplanar_labels,
-                                              mode='xnor')
+                                              mode='and')
                 # This might happen to the edge of the small network
                 if sp.size(new_neighbors) == 0:
                     labels = network.labels(pores=nearest_neighbor,
-                                            mode='xnor')
+                                            mode='and')
                     common_label = [l for l in labels if 'surface_' in l]
                     new_neighbors = network.pores(common_label)
             elif neighbor in Pn_new_net:

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -133,6 +133,26 @@ class TopotoolsTest:
         assert 'pore.test1' not in net2
         assert 'pore.test2' not in net2
 
+    def test_subdivide_3D(self):
+        net = op.network.Cubic(shape=[3, 3, 3])
+        assert net.Np == 27
+        assert net.Nt == 54
+        op.topotools.subdivide(net, pores=13, shape=[5, 5, 5], labels="blah")
+        assert net.pores("blah").size == 125
+        assert net.throats("blah").size == 300 + 25 * 6
+        assert net.Np == 27 - 1 + 125
+        assert net.Nt == 54 - 6 + 300 + 25 * 6
+
+    def test_subdivide_2D(self):
+        net = op.network.Cubic(shape=[1, 3, 3])
+        assert net.Np == 9
+        assert net.Nt == 12
+        op.topotools.subdivide(net, pores=4, shape=[1, 5, 5], labels="blah")
+        assert net.pores("blah").size == 25
+        assert net.throats("blah").size == 40 + 5 * 4
+        assert net.Np == 9 - 1 + 25
+        assert net.Nt == 12 - 4 + 40 + 5 * 4
+
     def test_merge_pores(self):
         testnet = op.network.Cubic(shape=[10, 10, 10])
         to_merge = [[0, 1], [998, 999]]


### PR DESCRIPTION
This PR addresses issue #1190. There was a small bug in `subdivide` method that led to creating extraneous connections. Two of the query types in subdivide were mistakenly `xnor` instead of `and`. It seems to have fixed the problem. I also added two tests as we had none (probably forgot to port old tests from OpenPNM v1.6).