### PR TITLE
Optimize Cubic network generation speed

### DIFF
--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -11,6 +11,7 @@ from openpnm.network import GenericNetwork
 from openpnm import topotools
 from openpnm.utils import logging
 logger = logging.getLogger(__name__)
+from openpnm.utils.misc import tic, toc
 
 
 class Cubic(GenericNetwork):
@@ -100,8 +101,10 @@ class Cubic(GenericNetwork):
             spacing = sp.concatenate((spacing, [1]))
         self._spacing = sp.ones(3)*sp.array(spacing, ndmin=1)
 
-        points = np.array([i for i, v in np.ndenumerate(arr)], dtype=float)
-        points += 0.5
+        points = np.vstack(np.meshgrid(np.arange(shape[0]),
+                                       np.arange(shape[1]),
+                                       np.arange(shape[2]))).reshape(3,-1).T
+        points = points.astype(float) + 0.5
 
         I = np.arange(arr.size).reshape(arr.shape)
 
@@ -141,9 +144,11 @@ class Cubic(GenericNetwork):
 
         I = np.arange(arr.size).reshape(arr.shape)
         tails, heads = [], []
+        # tic()
         for T, H in joints:
             tails.extend(T.flat)
             heads.extend(H.flat)
+        # toc()
         pairs = np.vstack([tails, heads]).T
 
         super().__init__(Np=points.shape[0], Nt=pairs.shape[0], name=name,

--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -100,10 +100,10 @@ class Cubic(GenericNetwork):
             spacing = sp.concatenate((spacing, [1]))
         self._spacing = sp.ones(3)*sp.array(spacing, ndmin=1)
 
-        points = np.vstack(np.meshgrid(np.arange(shape[0]),
-                                       np.arange(shape[1]),
-                                       np.arange(shape[2]))).reshape(3,-1).T
-        points = points.astype(float) + 0.5
+        z = np.tile(np.arange(shape[2]), shape[0]*shape[1])
+        y = np.tile(np.repeat(np.arange(shape[1]), shape[2]), shape[0])
+        x = np.repeat(np.arange(shape[0]), shape[1]*shape[2])
+        points = (np.vstack([x, y, z]).T).astype(float) + 0.5
 
         I = np.arange(arr.size).reshape(arr.shape)
 

--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -11,7 +11,6 @@ from openpnm.network import GenericNetwork
 from openpnm import topotools
 from openpnm.utils import logging
 logger = logging.getLogger(__name__)
-from openpnm.utils.misc import tic, toc
 
 
 class Cubic(GenericNetwork):
@@ -144,11 +143,9 @@ class Cubic(GenericNetwork):
 
         I = np.arange(arr.size).reshape(arr.shape)
         tails, heads = [], []
-        # tic()
         for T, H in joints:
             tails.extend(T.flat)
             heads.extend(H.flat)
-        # toc()
         pairs = np.vstack([tails, heads]).T
 
         super().__init__(Np=points.shape[0], Nt=pairs.shape[0], name=name,


### PR DESCRIPTION
This PR optimizes Cubic network generation speed. The optimization was done by replacing the list comprehension for generating pore coordinates by a numpy-vectorized version. This small modification makes Cubic network generation about 2.5x faster. Here's a speed comparison between the two branches (`dev` and `optimize_Cubic`) for different network sizes ranging from 10 thousand to 10 million pores.
![performance](https://user-images.githubusercontent.com/14086031/54433986-957d4680-4703-11e9-94b1-e05617d22e76.png)
