### PR TITLE
Further optimize Cubic network generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .spyproject/
 .pytest_cache/
 .vscode/
-
+*.egg-info
 docs/_build/

--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -141,10 +141,10 @@ class Cubic(GenericNetwork):
             raise Exception('Invalid connectivity receieved. Must be 6, 8, '
                             '12, 14, 18, 20 or 26')
 
-        tails, heads = [], []
+        tails, heads = np.array([], dtype=int), np.array([], dtype=int)
         for T, H in joints:
-            tails.extend(T.flat)
-            heads.extend(H.flat)
+            tails = np.concatenate((tails, T.flatten()))
+            heads = np.concatenate((heads, H.flatten()))
         pairs = np.vstack([tails, heads]).T
 
         super().__init__(Np=points.shape[0], Nt=pairs.shape[0], name=name,

--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -141,7 +141,6 @@ class Cubic(GenericNetwork):
             raise Exception('Invalid connectivity receieved. Must be 6, 8, '
                             '12, 14, 18, 20 or 26')
 
-        I = np.arange(arr.size).reshape(arr.shape)
         tails, heads = [], []
         for T, H in joints:
             tails.extend(T.flat)


### PR DESCRIPTION
This PR further optimizes Cubic network generation by vectorizing the part of the code that is responsible for making connections between pores. Here's a speed comparison between master, dev (only the part for node generation was optimized), and this branch.
![performance](https://user-images.githubusercontent.com/14086031/54778776-f4ebc280-4beb-11e9-8190-a38b9fbbb1ab.png)
