### PR TITLE
Refactor plot_conns and plot_coords, fix scaling issue plot_conns in 2D

### DIFF
--- a/example_PNP.py
+++ b/example_PNP.py
@@ -1,3 +1,4 @@
+"""
 import openpnm as op
 import numpy as np
 ws = op.Workspace()
@@ -116,3 +117,4 @@ sw.update(p.results())
 sw.update(eA.results())
 sw.update(eB.results())
 # op.io.VTK.save(network=net, phases=[sw], filename='OUTPUT_PNP')
+"""

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -2122,17 +2122,11 @@ def plot_connections(network, throats=None, fig=None, **kwargs):
 
     """
     import matplotlib.pyplot as plt
-    from mpl_toolkits.mplot3d import Axes3D
 
-    if throats is None:
-        Ts = network.Ts
-    else:
-        Ts = network._parse_indices(indices=throats)
+    Ts = network.Ts if throats is None else network._parse_indices(throats)
 
-    if len(sp.unique(network['pore.coords'][:, 2])) == 1:
-        ThreeD = False
-    else:
-        ThreeD = True
+    temp = [sp.unique(network["pore.coords"][:, i]).size for i in range(3)]
+    ThreeD = False if 1 in temp else True
 
     if fig is None:
         fig = plt.figure()
@@ -2150,9 +2144,8 @@ def plot_connections(network, throats=None, fig=None, **kwargs):
 
     # Collect coordinates and scale axes to fit
     Ps = sp.unique(network['throat.conns'][Ts])
-    X = network['pore.coords'][Ps, 0]
-    Y = network['pore.coords'][Ps, 1]
-    Z = network['pore.coords'][Ps, 2]
+    X, Y, Z = network['pore.coords'][Ps].T
+
     _scale_3d_axes(ax=ax, X=X, Y=Y, Z=Z)
 
     # Add sp.inf to the last element of pore.coords (i.e. -1)
@@ -2160,10 +2153,14 @@ def plot_connections(network, throats=None, fig=None, **kwargs):
     X = sp.hstack([network['pore.coords'][:, 0], inf])
     Y = sp.hstack([network['pore.coords'][:, 1], inf])
     Z = sp.hstack([network['pore.coords'][:, 2], inf])
+
     if ThreeD:
         ax.plot(xs=X[i], ys=Y[i], zs=Z[i], **kwargs)
     else:
+        dummy_dim = temp.index(1)
+        X, Y = [xi for j, xi in enumerate([X, Y, Z]) if j != dummy_dim]
         ax.plot(X[i], Y[i], **kwargs)
+        ax.autoscale()
 
     return fig
 
@@ -2220,17 +2217,11 @@ def plot_coordinates(network, pores=None, fig=None, **kwargs):
 
     """
     import matplotlib.pyplot as plt
-    from mpl_toolkits.mplot3d import Axes3D
 
-    if pores is None:
-        Ps = network.Ps
-    else:
-        Ps = network._parse_indices(indices=pores)
+    Ps = network.Ps if pores is None else network._parse_indices(pores)
 
-    if len(sp.unique(network['pore.coords'][:, 2])) == 1:
-        ThreeD = False
-    else:
-        ThreeD = True
+    temp = [sp.unique(network["pore.coords"][:, i]).size for i in range(3)]
+    ThreeD = False if 1 in temp else True
 
     if fig is None:
         fig = plt.figure()
@@ -2242,15 +2233,14 @@ def plot_coordinates(network, pores=None, fig=None, **kwargs):
         ax = fig.gca()
 
     # Collect specified coordinates
-    X = network['pore.coords'][Ps, 0]
-    Y = network['pore.coords'][Ps, 1]
-    Z = network['pore.coords'][Ps, 2]
-    if ThreeD:
-        _scale_3d_axes(ax=ax, X=X, Y=Y, Z=Z)
+    X, Y, Z = network['pore.coords'][Ps].T
 
     if ThreeD:
+        _scale_3d_axes(ax=ax, X=X, Y=Y, Z=Z)
         ax.scatter(xs=X, ys=Y, zs=Z, **kwargs)
     else:
+        dummy_dim = temp.index(1)
+        X, Y = [xi for j, xi in enumerate([X, Y, Z]) if j != dummy_dim]
         ax.scatter(X, Y, **kwargs)
 
     return fig


### PR DESCRIPTION
This PR addresses issues #1126 and #623. The scaling problem in 2D for `plot_connections` is now fixed. Also, if 1/2D networks are passed, no longer the plot is 3D. I also refactored `plot_coordinates` and `plot_connections` a little bit.