### PR TITLE
Add license_file metadata and other metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .vscode/
 *.egg-info
 docs/_build/
+
+build/
+dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,6 @@ max-violations-per-file = 0
 
 [options]
 python_requires = >= 3.6
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,10 @@ setup(
     author='OpenPNM Team',
     author_email='jgostick@uwaterloo.ca',
     download_url='https://github.com/pmeal/OpenPNM/',
-    url='http://openpnm.org'
+    url='http://openpnm.org',
+    project_urls={
+        'Documentation': 'https://openpnm.readthedocs.io/en/master/',
+        'Source': 'https://github.com/PMEAL/OpenPNM',
+        'Tracker': 'https://github.com/PMEAL/OpenPNM/issues',
+    },
 )


### PR DESCRIPTION
This pull request adds the LICENSE file to source and binary distributions, adds some additional metadata to the `setup()` call, and ignores the temporary files from a build.