### PR TITLE
Automatic kr

### DIFF
--- a/directionalrelpermc.py
+++ b/directionalrelpermc.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jan  9 14:59:50 2019
+
+@author: work
+"""
+# sample code for relperm
+import openpnm as op
+import matplotlib.pyplot as plt
+import numpy as np
+pn = op.network.Cubic(shape=[20, 20, 20], spacing=0.00006)
+geom = op.geometry.StickAndBall(network=pn, pores=pn['pore.all'],
+                                throats=pn['throat.all'])
+oil = op.phases.GenericPhase(network=pn, name='oil')
+water = op.phases.GenericPhase(network=pn, name='water')
+oil['pore.viscosity']=0.547
+oil['throat.surface_tension'] = 0.072
+oil['pore.surface_tension']=0.072
+oil['pore.contact_angle']=110
+water['throat.contact_angle'] = 70
+water['pore.contact_angle'] = 70
+water['throat.surface_tension'] = 0.0483
+water['pore.surface_tension'] = 0.0483
+water['pore.viscosity']=0.4554
+mod = op.models.physics.hydraulic_conductance.hagen_poiseuille
+oil.add_model(propname='throat.hydraulic_conductance',
+              model=mod)
+oil.add_model(propname='throat.entry_pressure',
+              model=op.models.physics.capillary_pressure.washburn)
+water.add_model(propname='throat.hydraulic_conductance',
+                model=mod)
+water.add_model(propname='throat.entry_pressure',
+                model=op.models.physics.capillary_pressure.washburn)
+Finlets_init = {'x': pn.pores('left')}
+Finlets=dict()
+ff=[]
+for key in Finlets_init.keys():
+    ff=([Finlets_init[key][x] for x in range(0, len(Finlets_init[key]), 2)])
+    Finlets.update({key: ff})
+Foutlets_init = {'x': pn.pores('right')}
+ip = op.algorithms.InvasionPercolation(network=pn, phase=oil)
+ip.set_inlets(pores=Finlets['x'])
+ip.run()
+rp = op.algorithms.DirectionalRelativePermeability(network=pn)
+rp.setup(invading_phase=oil, defending_phase=water,
+         pore_invasion_sequence=ip['pore.invasion_sequence'],
+         throat_invasion_sequence=ip['throat.invasion_sequence'])
+rp.set_inlets(pores=Finlets_init['x'])
+rp.set_outlets(pores=Foutlets_init['x'])
+rp.run(Snw_num=50, IP_pores=Finlets['x'])
+results=rp.get_Kr_data()
+rp.plot_Kr_curve()

--- a/openpnm/algorithms/DirectionalRelativePermeability.py
+++ b/openpnm/algorithms/DirectionalRelativePermeability.py
@@ -1,0 +1,165 @@
+from openpnm.algorithms import GenericAlgorithm, StokesFlow
+from openpnm.utils import logging
+from openpnm import models
+import numpy as np
+import matplotlib.pyplot as plt
+logger = logging.getLogger(__name__)
+
+
+default_settings = {'sat': [],
+                    'relperm_wp': [],
+                    'relperm_nwp': [],
+                    'perm_wp': [],
+                    'perm_nwp': [],
+                    'wp': [],
+                    'nwp': [],
+                    'pore.invasion_sequence': [],
+                    'throat.invasion_sequence': [],
+                    'flow_inlet': [],
+                    'flow_outlet': [],
+                    'pore_volume': [],
+                    'throat_volume': [],
+                    'results': {'sat': [], 'krw': [], 'krnw': []}
+                    }
+
+
+class DirectionalRelativePermeability(GenericAlgorithm):
+    r"""
+    A subclass of Generic Algorithm to calculate relative permeabilities of
+    fluids in a drainage process. The main roles of this subclass are to
+    get invasion sequence and implement a method for calculating the relative
+    permeabilities of the fluids flowing through a user-specified direction.
+    """
+    def __init__(self, settings={}, **kwargs):
+        super().__init__(**kwargs)
+        self.settings.update(default_settings)
+        self.settings.update(settings)
+
+    def setup(self, invading_phase=None, defending_phase=None,
+              pore_invasion_sequence=None,
+              throat_invasion_sequence=None):
+        self.settings['nwp']=invading_phase
+        self.settings['wp']= defending_phase
+        self.settings['pore.invasion_sequence']=pore_invasion_sequence
+        self.settings['throat.invasion_sequence']=throat_invasion_sequence
+        self.settings['throat_volume']='pore.volume'
+        self.settings['pore_volume']='throat.volume'
+
+    def set_inlets(self, pores):
+        self.settings['flow_inlet'] = pores
+
+    def set_outlets(self, pores):
+        self.settings['flow_outlet'] = pores
+
+    def _regenerate_models(self):
+        modelwp=models.physics.multiphase.conduit_conductance
+        self.settings['wp'].add_model(model=modelwp,
+                                      propname='throat.conduit_hydraulic_conductance',
+                                      throat_conductance='throat.hydraulic_conductance')
+        modelnwp=models.physics.multiphase.conduit_conductance
+        self.settings['nwp'].add_model(model=modelnwp,
+                                       propname='throat.conduit_hydraulic_conductance',
+                                       throat_conductance='throat.hydraulic_conductance')
+
+    def abs_perm_calc(self, B_pores, in_outlet_pores):
+        network=self.project.network
+        St_wp = StokesFlow(network=network, phase=self.settings['wp'])
+        St_wp.set_value_BC(pores=B_pores[0], values=1)
+        St_wp.set_value_BC(pores=B_pores[1], values=0)
+        St_wp.run()
+        val=St_wp.calc_effective_permeability(inlets=in_outlet_pores[0],
+                                              outlets=in_outlet_pores[1])
+        Kwp=val
+        self.project.purge_object(obj=St_wp)
+        St_nwp = StokesFlow(network=network, phase=self.settings['nwp'])
+        St_nwp.set_value_BC(pores=B_pores[0], values=1)
+        St_nwp.set_value_BC(pores=B_pores[1], values=0)
+        St_nwp.run()
+        val=St_nwp.calc_effective_permeability(inlets=in_outlet_pores[0],
+                                               outlets=in_outlet_pores[1])
+        Knwp=val
+        self.project.purge_object(obj=St_nwp)
+        return [Kwp, Knwp]
+
+    def rel_perm_calc(self, B_pores, in_outlet_pores):
+        network=self.project.network
+        self._regenerate_models()
+        St_mp_wp = StokesFlow(network=network, phase=self.settings['wp'])
+        St_mp_wp.setup(conductance='throat.conduit_hydraulic_conductance')
+        St_mp_wp.set_value_BC(pores=B_pores[0], values=1)
+        St_mp_wp.set_value_BC(pores=B_pores[1], values=0)
+        St_mp_nwp = StokesFlow(network=network, phase=self.settings['nwp'])
+        St_mp_nwp.set_value_BC(pores=B_pores[0], values=1)
+        St_mp_nwp.set_value_BC(pores=B_pores[1], values=0)
+        St_mp_nwp.setup(conductance='throat.conduit_hydraulic_conductance')
+        St_mp_wp.run()
+        St_mp_nwp.run()
+        Kewp=St_mp_wp.calc_effective_permeability(inlets=in_outlet_pores[0],
+                                                        outlets=in_outlet_pores[1])
+        Kenwp=St_mp_nwp.calc_effective_permeability(inlets=in_outlet_pores[0],
+                                                    outlets=in_outlet_pores[1])
+        self.project.purge_object(obj=St_mp_wp)
+        self.project.purge_object(obj=St_mp_nwp)
+        return [Kewp, Kenwp]
+
+    def _sat_occ_update(self, i):
+        network=self.project.network
+        pore_mask=self.settings['pore.invasion_sequence']<i
+        throat_mask=self.settings['throat.invasion_sequence']<i
+        sat_p=np.sum(network['pore.volume'][pore_mask])
+        sat_t=np.sum(network['throat.volume'][throat_mask])
+        sat1=sat_p+sat_t
+        bulk=(np.sum(network['pore.volume']) + np.sum(network['throat.volume']))
+        sat=sat1/bulk
+        self.settings['nwp']['pore.occupancy'] = pore_mask
+        self.settings['wp']['pore.occupancy'] = 1-pore_mask
+        self.settings['nwp']['throat.occupancy'] = throat_mask
+        self.settings['wp']['throat.occupancy'] = 1-throat_mask
+        return sat
+
+    def run(self, Snw_num=None, IP_pores=None):
+        [Kwp, Knwp]=self.abs_perm_calc(B_pores=[self.settings['flow_inlet'],
+                                       self.settings['flow_outlet']],
+                                       in_outlet_pores=[self.settings['flow_inlet'],
+                                       self.settings['flow_outlet']])
+        self.settings['perm_wp']=Kwp
+        self.settings['perm_nwp']=Knwp
+        self.settings['IP_pores']=IP_pores
+        if Snw_num is None:
+            Snw_num=10
+        max_seq = np.max([np.max(self.settings['pore.invasion_sequence']),
+                          np.max(self.settings['throat.invasion_sequence'])])
+        start=max_seq//Snw_num
+        stop=max_seq
+        step=max_seq//Snw_num
+        self.settings['sat']=[]
+        self.settings['relperm_wp']=[]
+        self.settings['relperm_nwp']=[]
+        for i in range(start, stop, step):
+            sat=self._sat_occ_update(i)
+            self.settings['sat'].append(sat)
+            [Kewp, Kenwp]=self.rel_perm_calc(B_pores=[self.settings['flow_inlet'],
+                                             self.settings['flow_outlet']],
+                                             in_outlet_pores=[self.settings['flow_inlet'],
+                                             self.settings['flow_outlet']])
+            Krwp=Kewp/self.settings['perm_wp']
+            Krnwp=Kenwp/self.settings['perm_nwp']
+            self.settings['relperm_wp'].append(Krwp)
+            self.settings['relperm_nwp'].append(Krnwp)
+
+    def get_Kr_data(self):
+        self.settings['results']['sat']=self.settings['sat']
+        self.settings['results']['krw']=self.settings['relperm_wp']
+        self.settings['results']['krnw']=self.settings['relperm_nwp']
+        return self.settings['results']
+
+    def plot_Kr_curve(self):
+        f = plt.figure()
+        sp = f.add_subplot(111)
+        sp.plot(self.settings['sat'], self.settings['relperm_wp'], 'o-', label="Krwp")
+        sp.plot(self.settings['sat'], self.settings['relperm_nwp'], '*-', label="Krnwp")
+        sp.set_xlabel('Snw')
+        sp.set_ylabel('Kr')
+        sp.set_title('Relative Permability Curves')
+        sp.legend()
+        return f

--- a/openpnm/algorithms/RelativePermeability.py
+++ b/openpnm/algorithms/RelativePermeability.py
@@ -1,0 +1,153 @@
+from openpnm.algorithms import GenericAlgorithm, InvasionPercolation
+from openpnm.algorithms import DirectionalRelativePermeability
+from openpnm.utils import logging
+from openpnm.core import Base
+# from openpnm import models
+import numpy as np
+import openpnm
+# import matplotlib.pyplot as plt
+# from collections import namedtuple
+# import csv
+# import matplotlib.pyplot as plt
+logger = logging.getLogger(__name__)
+
+
+default_settings = {
+                    'inv_inlets': dict(),
+                    'flow_inlets': dict(),
+                    'flow_outlets': dict(),
+                    'mode': 'strict',
+                    'sat': dict(),
+                    'relperm_wp': dict(),
+                    'relperm_nwp': dict(),
+                    'perm_wp': dict(),
+                    'perm_nwp': dict(),
+                    'wp': [],
+                    'nwp': [],
+                    'BP_1': dict(),
+                    'BP_2': dict(),
+                    'pore.invasion_sequence':[],
+                    'throat.invasion_sequence':[],
+                    'input_vect':[]}
+
+class RelativePermeability(DirectionalRelativePermeability):
+    r"""
+    A subclass of Generic Algorithm to calculate relative permeabilities of
+    fluids in a drainage process. The main roles of this subclass are to
+    implement Invasion Percolation if no invasion sequence is given as an
+    argument and to implement a method for calculating the relative
+    permeabilities of the fluids.
+    """
+    def __init__(self, settings={}, **kwargs):
+        super().__init__(**kwargs)
+        self.settings.update(default_settings)
+        self.settings.update(settings)
+
+    def setup(self, input_vect=['xx', 'xy', 'xz', 'yx', 'yy', 'yz',
+                                'zx', 'zy', 'zz']):
+        input_vect.sort()
+        self.settings['input_vect']=input_vect
+        inlet_dict={'x': 'left', 'y': 'front', 'z': 'top'}
+        outlet_dict={'x': 'right', 'y': 'back', 'z': 'bottom'}
+        for i in range(len(input_vect)):
+            inv=input_vect[i][0]
+            flow=input_vect[i][1]
+            self.settings['BP_1'].update({flow: (inlet_dict[flow])})
+            self.settings['BP_2'].update({flow: (outlet_dict[flow])})
+            self.settings['inv_inlets'].update({inv: (inlet_dict[inv])})
+            self.settings['flow_inlets'].update({flow: (inlet_dict[flow])})
+            self.settings['flow_outlets'].update({flow: (outlet_dict[flow])})
+
+
+    def abs_perm_calc(self,B_pores,in_outlet_pores):
+        [Kw,Knw]=super(RelativePermeability,self).abs_perm_calc(B_pores,in_outlet_pores)
+        return [Kw,Knw]
+    def run(self,Snw_num=None):
+        net= self.project.network
+        oil = openpnm.phases.GenericPhase(network=net, name='oil')
+        water = openpnm.phases.GenericPhase(network=net, name='water')
+        oil['pore.viscosity']=0.547
+        oil['throat.surface_tension'] = 0.072
+        oil['pore.surface_tension']=0.072
+        oil['pore.contact_angle']=110
+        water['throat.contact_angle'] = 70
+        water['pore.contact_angle'] = 70
+        water['throat.surface_tension'] = 0.0483
+        water['pore.surface_tension'] = 0.0483
+        water['pore.viscosity']=0.4554
+        mod = openpnm.models.physics.hydraulic_conductance.hagen_poiseuille
+        oil.add_model(propname='throat.hydraulic_conductance',
+                          model=mod)
+        oil.add_model(propname='throat.entry_pressure',
+                          model=openpnm.models.physics.capillary_pressure.washburn)
+        water.add_model(propname='throat.hydraulic_conductance',
+                          model=mod)
+        water.add_model(propname='throat.entry_pressure',
+                          model=openpnm.models.physics.capillary_pressure.washburn)
+        self.settings['nwp']= oil
+        self.settings['wp']= water
+        # define inlet/outlets
+        Iinlets_init=dict()
+        for dim in self.settings['inv_inlets']:
+            Iinlets_init.update({dim: net.pores(self.settings['inv_inlets'][dim])}) 
+        Iinlets=dict()
+        for key in Iinlets_init.keys():
+            Iinlets.update({key: ([Iinlets_init[key][x] for x in \
+                                   range(0, len(Iinlets_init[key]), 2)])})
+        Foutlets_init=dict()
+        for dim in self.settings['flow_outlets']:
+            Foutlets_init.update({dim: net.pores(self.settings['flow_outlets'][dim])})
+        Foutlets=dict()
+        for key in Foutlets_init.keys():
+            Foutlets.update({key: ([Foutlets_init[key][x] for x in \
+                                    range(0, len(Foutlets_init[key]), 2)])})
+        Finlets_init=dict()
+        for dim in self.settings['flow_inlets']:
+            Finlets_init.update({dim: net.pores(self.settings['flow_inlets'][dim])})
+        Finlets=dict()
+        for key in Finlets_init.keys():
+            Finlets.update({key: ([Finlets_init[key][x] for x in \
+                                   range(0, len(Finlets_init[key]), 2)])})
+        inv=InvasionPercolation(network=net)
+        inv.setup(phase=self.settings['nwp'],
+                  entry_pressure='throat.entry_pressure',
+                  pore_volume='pore.volume',
+                  throat_volume='throat.volume')
+        K_dir=set(self.settings['flow_inlets'].keys())
+        for dim in K_dir:
+            B_pores=[net.pores(self.settings['BP_1'][dim]),net.pores(self.settings['BP_2'][dim])]
+            in_outlet_pores=[Finlets_init[dim],Foutlets_init[dim]]
+            [Kw,Knw]=self.abs_perm_calc(B_pores,in_outlet_pores)
+            self.settings['perm_wp'].update({dim:Kw})
+            self.settings['perm_nwp'].update({dim: Knw})
+        for i in range(len(self.settings['input_vect'])):
+            invasion=self.settings['input_vect'][i][0]
+            flow=self.settings['input_vect'][i][1]
+            relperm_wp=[]
+            relperm_nwp=[]
+            inv.set_inlets(pores=Iinlets[invasion])
+            inv.run()
+            self.settings['pore.invasion_sequence']=inv['pore.invasion_sequence']
+            self.settings['throat.invasion_sequence']=inv['throat.invasion_sequence']
+            if Snw_num is None:
+                Snw_num=10
+            max_seq = np.max([np.max(self.settings['pore.invasion_sequence']),
+                          np.max(self.settings['throat.invasion_sequence'])])
+            start=max_seq//Snw_num
+            stop=max_seq
+            step=max_seq//Snw_num
+            Snwparr = []
+            B_pores=[net.pores(self.settings['BP_1'][flow]), net.pores(self.settings['BP_2'][flow])]
+            in_outlet_pores=[Finlets_init[flow], Foutlets_init[flow]]
+            for j in range(start, stop, step):
+                sat=super()._sat_occ_update(j)
+                Snwparr.append(sat)
+                [Kewp,Kenwp]=super().rel_perm_calc(B_pores, in_outlet_pores)
+                relperm_wp.append(Kewp/self.settings['perm_wp'][flow])
+                relperm_nwp.append(Kenwp/self.settings['perm_nwp'][flow])
+            self.settings['relperm_wp'].update({self.settings['input_vect'][i]:\
+                                                   relperm_wp})
+            self.settings['relperm_nwp'].update({self.settings['input_vect'][i]:\
+                                                    relperm_nwp})
+            self.settings['sat'].update({self.settings['input_vect'][i]: Snwparr})
+        

--- a/openpnm/algorithms/RelativePermeability.py
+++ b/openpnm/algorithms/RelativePermeability.py
@@ -2,6 +2,7 @@ from openpnm.algorithms import GenericAlgorithm, InvasionPercolation
 from openpnm.algorithms import DirectionalRelativePermeability
 from openpnm.utils import logging
 from openpnm.core import Base
+import matplotlib.pyplot as plt
 # from openpnm import models
 import numpy as np
 import openpnm
@@ -26,9 +27,9 @@ default_settings = {
                     'nwp': [],
                     'BP_1': dict(),
                     'BP_2': dict(),
-                    'pore.invasion_sequence':[],
-                    'throat.invasion_sequence':[],
-                    'input_vect':[]}
+                    'pore.invasion_sequence': [],
+                    'throat.invasion_sequence': [],
+                    'input_vect': []}
 
 class RelativePermeability(DirectionalRelativePermeability):
     r"""
@@ -57,12 +58,13 @@ class RelativePermeability(DirectionalRelativePermeability):
             self.settings['inv_inlets'].update({inv: (inlet_dict[inv])})
             self.settings['flow_inlets'].update({flow: (inlet_dict[flow])})
             self.settings['flow_outlets'].update({flow: (outlet_dict[flow])})
-
-
-    def abs_perm_calc(self,B_pores,in_outlet_pores):
-        [Kw,Knw]=super(RelativePermeability,self).abs_perm_calc(B_pores,in_outlet_pores)
-        return [Kw,Knw]
-    def run(self,Snw_num=None):
+            
+            
+    def abs_perm_calc(self, B_pores, in_outlet_pores):
+        [Kw, Knw]=super(RelativePermeability, self).abs_perm_calc(B_pores, in_outlet_pores)
+        return [Kw, Knw]
+    
+    def run(self, Snw_num=None):
         net= self.project.network
         oil = openpnm.phases.GenericPhase(network=net, name='oil')
         water = openpnm.phases.GenericPhase(network=net, name='water')
@@ -91,23 +93,26 @@ class RelativePermeability(DirectionalRelativePermeability):
         for dim in self.settings['inv_inlets']:
             Iinlets_init.update({dim: net.pores(self.settings['inv_inlets'][dim])}) 
         Iinlets=dict()
+        inl=[]
         for key in Iinlets_init.keys():
-            Iinlets.update({key: ([Iinlets_init[key][x] for x in \
-                                   range(0, len(Iinlets_init[key]), 2)])})
+            inl=[Iinlets_init[key][x] for x in range(0, len(Iinlets_init[key]), 2)]
+            Iinlets.update({key: inl})
         Foutlets_init=dict()
         for dim in self.settings['flow_outlets']:
             Foutlets_init.update({dim: net.pores(self.settings['flow_outlets'][dim])})
         Foutlets=dict()
+        outl=[]
         for key in Foutlets_init.keys():
-            Foutlets.update({key: ([Foutlets_init[key][x] for x in \
-                                    range(0, len(Foutlets_init[key]), 2)])})
+            outl=[Foutlets_init[key][x] for x in range(0, len(Foutlets_init[key]), 2)]
+            Foutlets.update({key: outl})
         Finlets_init=dict()
         for dim in self.settings['flow_inlets']:
             Finlets_init.update({dim: net.pores(self.settings['flow_inlets'][dim])})
         Finlets=dict()
+        inl=[]
         for key in Finlets_init.keys():
-            Finlets.update({key: ([Finlets_init[key][x] for x in \
-                                   range(0, len(Finlets_init[key]), 2)])})
+            inl=([Finlets_init[key][x] for x in range(0, len(Finlets_init[key]), 2)])
+            Finlets.update({key: inl})
         inv=InvasionPercolation(network=net)
         inv.setup(phase=self.settings['nwp'],
                   entry_pressure='throat.entry_pressure',
@@ -115,10 +120,11 @@ class RelativePermeability(DirectionalRelativePermeability):
                   throat_volume='throat.volume')
         K_dir=set(self.settings['flow_inlets'].keys())
         for dim in K_dir:
-            B_pores=[net.pores(self.settings['BP_1'][dim]),net.pores(self.settings['BP_2'][dim])]
-            in_outlet_pores=[Finlets_init[dim],Foutlets_init[dim]]
-            [Kw,Knw]=self.abs_perm_calc(B_pores,in_outlet_pores)
-            self.settings['perm_wp'].update({dim:Kw})
+            B_pores=[net.pores(self.settings['BP_1'][dim]),
+                     net.pores(self.settings['BP_2'][dim])]
+            in_outlet_pores=[Finlets_init[dim], Foutlets_init[dim]]
+            [Kw,Knw]=self.abs_perm_calc(B_pores, in_outlet_pores)
+            self.settings['perm_wp'].update({dim: Kw})
             self.settings['perm_nwp'].update({dim: Knw})
         for i in range(len(self.settings['input_vect'])):
             invasion=self.settings['input_vect'][i][0]
@@ -137,7 +143,8 @@ class RelativePermeability(DirectionalRelativePermeability):
             stop=max_seq
             step=max_seq//Snw_num
             Snwparr = []
-            B_pores=[net.pores(self.settings['BP_1'][flow]), net.pores(self.settings['BP_2'][flow])]
+            B_pores=[net.pores(self.settings['BP_1'][flow]),
+                     net.pores(self.settings['BP_2'][flow])]
             in_outlet_pores=[Finlets_init[flow], Foutlets_init[flow]]
             for j in range(start, stop, step):
                 sat=super()._sat_occ_update(j)
@@ -145,9 +152,22 @@ class RelativePermeability(DirectionalRelativePermeability):
                 [Kewp,Kenwp]=super().rel_perm_calc(B_pores, in_outlet_pores)
                 relperm_wp.append(Kewp/self.settings['perm_wp'][flow])
                 relperm_nwp.append(Kenwp/self.settings['perm_nwp'][flow])
-            self.settings['relperm_wp'].update({self.settings['input_vect'][i]:\
-                                                   relperm_wp})
-            self.settings['relperm_nwp'].update({self.settings['input_vect'][i]:\
-                                                    relperm_nwp})
-            self.settings['sat'].update({self.settings['input_vect'][i]: Snwparr})
+            key=self.settings['input_vect'][i]
+            self.settings['relperm_wp'].update({key: relperm_wp})
+            self.settings['relperm_nwp'].update({key: relperm_nwp})
+            self.settings['sat'].update({key: Snwparr})
+    def plot_Kr_curve(self):
+        f = plt.figure()
+        sp = f.add_subplot(111)
+        for inp in self.settings['input_vect']:
+            sp.plot(self.settings['sat'][inp], self.settings['relperm_wp'][inp],
+                    'o-', label='Krwp'+inp)
+            sp.plot(self.settings['sat'][inp], self.settings['relperm_nwp'][inp],
+                    '*-', label='Krnwp'+inp)
+        sp.set_xlabel('Snw')
+        sp.set_ylabel('Kr')
+        sp.set_title('Relative Permability Curves')
+        sp.legend()
+        return f
+        
         

--- a/openpnm/algorithms/RelativePermeability.py
+++ b/openpnm/algorithms/RelativePermeability.py
@@ -13,8 +13,7 @@ import openpnm
 logger = logging.getLogger(__name__)
 
 
-default_settings = {
-                    'inv_inlets': dict(),
+default_settings = {'inv_inlets': dict(),
                     'flow_inlets': dict(),
                     'flow_outlets': dict(),
                     'mode': 'strict',
@@ -30,6 +29,7 @@ default_settings = {
                     'pore.invasion_sequence': [],
                     'throat.invasion_sequence': [],
                     'input_vect': []}
+
 
 class RelativePermeability(DirectionalRelativePermeability):
     r"""
@@ -58,12 +58,12 @@ class RelativePermeability(DirectionalRelativePermeability):
             self.settings['inv_inlets'].update({inv: (inlet_dict[inv])})
             self.settings['flow_inlets'].update({flow: (inlet_dict[flow])})
             self.settings['flow_outlets'].update({flow: (outlet_dict[flow])})
-            
-            
+
     def abs_perm_calc(self, B_pores, in_outlet_pores):
-        [Kw, Knw]=super(RelativePermeability, self).abs_perm_calc(B_pores, in_outlet_pores)
+        [Kw, Knw]=super(RelativePermeability, self).abs_perm_calc(B_pores,
+                                                                  in_outlet_pores)
         return [Kw, Knw]
-    
+
     def run(self, Snw_num=None):
         net= self.project.network
         oil = openpnm.phases.GenericPhase(network=net, name='oil')
@@ -91,7 +91,7 @@ class RelativePermeability(DirectionalRelativePermeability):
         # define inlet/outlets
         Iinlets_init=dict()
         for dim in self.settings['inv_inlets']:
-            Iinlets_init.update({dim: net.pores(self.settings['inv_inlets'][dim])}) 
+            Iinlets_init.update({dim: net.pores(self.settings['inv_inlets'][dim])})
         Iinlets=dict()
         inl=[]
         for key in Iinlets_init.keys():
@@ -123,7 +123,7 @@ class RelativePermeability(DirectionalRelativePermeability):
             B_pores=[net.pores(self.settings['BP_1'][dim]),
                      net.pores(self.settings['BP_2'][dim])]
             in_outlet_pores=[Finlets_init[dim], Foutlets_init[dim]]
-            [Kw,Knw]=self.abs_perm_calc(B_pores, in_outlet_pores)
+            [Kw, Knw]=self.abs_perm_calc(B_pores, in_outlet_pores)
             self.settings['perm_wp'].update({dim: Kw})
             self.settings['perm_nwp'].update({dim: Knw})
         for i in range(len(self.settings['input_vect'])):
@@ -138,7 +138,7 @@ class RelativePermeability(DirectionalRelativePermeability):
             if Snw_num is None:
                 Snw_num=10
             max_seq = np.max([np.max(self.settings['pore.invasion_sequence']),
-                          np.max(self.settings['throat.invasion_sequence'])])
+                              np.max(self.settings['throat.invasion_sequence'])])
             start=max_seq//Snw_num
             stop=max_seq
             step=max_seq//Snw_num
@@ -149,13 +149,14 @@ class RelativePermeability(DirectionalRelativePermeability):
             for j in range(start, stop, step):
                 sat=super()._sat_occ_update(j)
                 Snwparr.append(sat)
-                [Kewp,Kenwp]=super().rel_perm_calc(B_pores, in_outlet_pores)
+                [Kewp, Kenwp]=super().rel_perm_calc(B_pores, in_outlet_pores)
                 relperm_wp.append(Kewp/self.settings['perm_wp'][flow])
                 relperm_nwp.append(Kenwp/self.settings['perm_nwp'][flow])
             key=self.settings['input_vect'][i]
             self.settings['relperm_wp'].update({key: relperm_wp})
             self.settings['relperm_nwp'].update({key: relperm_nwp})
             self.settings['sat'].update({key: Snwparr})
+
     def plot_Kr_curve(self):
         f = plt.figure()
         sp = f.add_subplot(111)
@@ -169,5 +170,3 @@ class RelativePermeability(DirectionalRelativePermeability):
         sp.set_title('Relative Permability Curves')
         sp.legend()
         return f
-        
-        

--- a/openpnm/algorithms/__init__.py
+++ b/openpnm/algorithms/__init__.py
@@ -30,4 +30,3 @@ from .NernstPlanck import NernstPlanck
 from .ChargeConservationNernstPlanck import ChargeConservationNernstPlanck
 from .DirectionalRelativePermeability import DirectionalRelativePermeability
 from .RelativePermeability import RelativePermeability
-

--- a/openpnm/algorithms/__init__.py
+++ b/openpnm/algorithms/__init__.py
@@ -28,3 +28,6 @@ from .MixedInvasionPercolation import MixedInvasionPercolation
 from .Porosimetry import Porosimetry
 from .NernstPlanck import NernstPlanck
 from .ChargeConservationNernstPlanck import ChargeConservationNernstPlanck
+from .DirectionalRelativePermeability import DirectionalRelativePermeability
+from .RelativePermeability import RelativePermeability
+


### PR DESCRIPTION
Automatic Kr calculation: 
There are two scenarios: 
1) User defines direction(s) of invasion & flow


sample code:
import openpnm as op
import matplotlib.pyplot as plt
import numpy as np
pn = op.network.Cubic(shape=[20, 20, 20], spacing=0.00006)
geom = op.geometry.StickAndBall(network=pn, pores=pn['pore.all'],
                                throats=pn['throat.all'])
relcalc=op.algorithms.RelativePermeability(network=pn)
relcalc.setup(input_vect=['xx'])
relcalc.run(Snw_num=50)
results=relcalc.get_Kr_data()
relcalc.plot_Kr_curve()


 2) If no input is given, all possible directions would be considered by the algorithm


sample code: 
import openpnm as op
import matplotlib.pyplot as plt
import numpy as np
pn = op.network.Cubic(shape=[20, 20, 20], spacing=0.00006)
geom = op.geometry.StickAndBall(network=pn, pores=pn['pore.all'],
                                throats=pn['throat.all'])
relcalc=op.algorithms.RelativePermeability(network=pn)
relcalc.setup()
relcalc.run()
results=relcalc.get_Kr_data()
relcalc.plot_Kr_curve()


default phases: water and oil
default swn-num=10
