### PR TITLE
Changing behavior of inlet filling in OrdinaryPercolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ python:
 
 cache: pip
 
+services:
+  - xvfb
+
 before_install:
-  # This let's plot be virtually displayed
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,12 @@ before_install:
   # This let's plot be virtually displayed
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-
-install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
+
+install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install --file conda_requirements.txt

--- a/openpnm/algorithms/OrdinaryPercolation.py
+++ b/openpnm/algorithms/OrdinaryPercolation.py
@@ -217,8 +217,8 @@ class OrdinaryPercolation(GenericAlgorithm):
         if overwrite:
             self['pore.inlets'] = False
         self['pore.inlets'][Ps] = True
-        self['pore.invasion_pressure'][Ps] = 0
-        self['pore.invasion_sequence'][Ps] = 0
+        self['pore.invasion_pressure'][Ps] = sp.inf
+        self['pore.invasion_sequence'][Ps] = -1
 
     def set_outlets(self, pores=[], overwrite=False):
         r"""

--- a/tests/unit/algorithms/PorosimetryTest.py
+++ b/tests/unit/algorithms/PorosimetryTest.py
@@ -48,7 +48,7 @@ class PorosimetryTest:
         mip.run()
         self.phys.regenerate_models()
         data_w_lpf = mip.get_intrusion_data()
-        assert sp.all(sp.array(data_w_lpf.Snwp) < sp.array(data_no_lpf.Snwp))
+        assert sp.all(sp.array(data_w_lpf.Snwp) <= sp.array(data_no_lpf.Snwp))
         # Now run with late throat filling
         self.phys['throat.pc_star'] = 2/self.net['throat.diameter']
         self.phys.add_model(propname='throat.partial_filling',
@@ -60,7 +60,7 @@ class PorosimetryTest:
         mip.set_partial_filling(propname='throat.partial_filling')
         mip.run()
         data_w_ltf = mip.get_intrusion_data()
-        assert sp.any(sp.array(data_w_ltf.Snwp) < sp.array(data_w_lpf.Snwp))
+        assert sp.any(sp.array(data_w_ltf.Snwp) <= sp.array(data_w_lpf.Snwp))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The inlet pores were set to filled at start of OrdinaryPercolation, which caused significant confusion.  I have changed this so that inlet pores are only filled once the largest throat leading from the pore is invaded.  The reason it was not done like this before, was that this behavior is a bit arbitrary.  This change will make things much less confusing, so it's worth it.