### PR TITLE
Lens volume models

### DIFF
--- a/openpnm/models/geometry/throat_volume.py
+++ b/openpnm/models/geometry/throat_volume.py
@@ -132,14 +132,14 @@ def rectangle(target, throat_length='throat.length',
     return target[throat_length] * target[throat_diameter]
 
 
-def lens_volume(target, throat_diameter='throat.diameter',
-                pore_diameter='pore.diameter'):
+def lens(target, throat_diameter='throat.diameter',
+         pore_diameter='pore.diameter'):
     r"""
     Calculates the volume residing the hemispherical caps formed by the
     intersection between cylindrical throats and spherical pores.
 
-    This volume should be subtracted from throat volumes if the throat
-    endpoints model was used to find throat length.
+    This volume should be subtracted from throat volumes if the throat lengths
+    were found using throat end points.
 
     Parameters
     ----------
@@ -164,7 +164,7 @@ def lens_volume(target, throat_diameter='throat.diameter',
 
     See Also
     --------
-    pendular_ring_volume
+    pendular_ring
     """
     network = target.network
     conns = network['throat.conns']
@@ -178,15 +178,15 @@ def lens_volume(target, throat_diameter='throat.diameter',
     return _sp.sum(V, axis=1)
 
 
-def pendular_ring_volume(target, throat_diameter='throat.diameter',
-                         pore_diameter='pore.diameter'):
+def pendular_ring(target, throat_diameter='throat.diameter',
+                  pore_diameter='pore.diameter'):
     r"""
     Calculates the volume of the pendular rings residing between the end of
     a cylindrical throat and spherical pores that are in contact but not
     overlapping.
 
-    This volume should be added to the throat volume if it was found as the
-    center-to-center distance less the pore radii.
+    This volume should be added to the throat volume if the throat length was
+    found as the center-to-center distance less the pore radii.
 
     Parameters
     ----------
@@ -211,7 +211,7 @@ def pendular_ring_volume(target, throat_diameter='throat.diameter',
 
     See Also
     --------
-    lens_volume
+    lens
     """
     network = target.network
     conns = network['throat.conns']

--- a/tests/unit/models/geometry/ThroatVolumeTest.py
+++ b/tests/unit/models/geometry/ThroatVolumeTest.py
@@ -18,6 +18,22 @@ class ThroatVolumeTest:
         self.geo['throat.length'] = 1.0
         self.geo['throat.area'] = 0.03
 
+    def test_lens_and_pendular_ring(self):
+        net = op.network.Cubic(shape=[2, 1, 1])
+        net['pore.diameter'] = 0.5
+        net['throat.diameter'] = 0.25
+        mod = op.models.geometry.throat_volume.lens
+        net.add_model(propname='throat.lens_volume',
+                      model=mod)
+        Vlens = net['throat.lens_volume']
+        assert Vlens == 2*(0.006733852203712552)
+        mod = op.models.geometry.throat_volume.pendular_ring
+        net.add_model(propname='throat.ring_volume',
+                      model=mod)
+        Vcyl = 2*(0.01315292522620208)
+        Vring = net['throat.ring_volume']
+        assert (Vcyl - Vring) == 2*(0.006733852203712552)
+
     def test_cylinder(self):
         self.geo.add_model(propname='throat.volume',
                            model=mods.cylinder,


### PR DESCRIPTION
This PR adds two simple models for calculating the volume of lens and pendular rings due to overlap or not of cylindrical throats and spherical pores.  The lens model is meant to be subtracted from the throat volume in the overlapping case (when throat.endpoints are used) and the pendular_rings model is meant to be added in the case when sphere and throats just barely contact each other.  