### PR TITLE
Adding reset method to GenericTransport and ReactiveTransport

### DIFF
--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -196,6 +196,29 @@ class GenericTransport(GenericAlgorithm):
             self.settings['conductance'] = conductance
         self.settings.update(**kwargs)
 
+    def reset(self, bcs=True, results=True, phase=False):
+        r"""
+        Resets the algorithm to enable re-use to avoid instantiating a new one.
+
+        Parameters
+        ----------
+        bcs : boolean
+            If ``True`` (default) all previous boundary conditions are removed.
+        results : boolean
+            If ``True`` (default) all previously calculated values pertaining
+            to results of the algorithm are removed.
+        phase : boolean
+            Removes the specified phase from the settings. The default is
+            ``False``.
+        """
+        if bcs:
+            self['pore.bc_value'] = np.nan
+            self['pore.bc_rate'] = np.nan
+        if results:
+            self.pop(self.settings['quantity'], None)
+        if phase:
+            self.settings['phase'] = None
+
     def set_iterative_props(self, propnames):
         r"""
         """

--- a/openpnm/algorithms/ReactiveTransport.py
+++ b/openpnm/algorithms/ReactiveTransport.py
@@ -120,6 +120,15 @@ class ReactiveTransport(GenericTransport):
             self.settings['relaxation_quantity'] = relaxation_quantity
         super().setup(**kwargs)
 
+    def reset(self, source_terms=True, **kwargs):
+        r"""
+        """
+        super().reset(**kwargs)
+        if source_terms:
+            for item in self.settings['sources']:
+                self.pop(item)
+            self.settings.pop('sources', None)
+
     def set_source(self, propname, pores):
         r"""
         Applies a given source term to the specified pores

--- a/tests/unit/algorithms/GenericTransportTest.py
+++ b/tests/unit/algorithms/GenericTransportTest.py
@@ -117,6 +117,27 @@ class GenericTransportTest:
         # Revert back changes to objects
         self.setup_class()
 
+    def test_reset(self):
+        alg = op.algorithms.GenericTransport(network=self.net,
+                                             phase=self.phase)
+        alg.settings['conductance'] = 'throat.diffusive_conductance'
+        alg.settings['quantity'] = 'pore.mole_fraction'
+        alg.set_rate_BC(pores=self.net.pores('bottom'), values=1)
+        alg.set_value_BC(pores=self.net.pores('top'), values=0)
+        alg.run()
+        assert ~sp.all(sp.isnan(alg['pore.bc_value']))
+        assert ~sp.all(sp.isnan(alg['pore.bc_rate']))
+        assert 'pore.mole_fraction' in alg.keys()
+        alg.reset(bcs=True, results=False)
+        assert sp.all(sp.isnan(alg['pore.bc_value']))
+        assert sp.all(sp.isnan(alg['pore.bc_rate']))
+        assert 'pore.mole_fraction' in alg.keys()
+        alg.reset(bcs=True, results=True)
+        assert 'pore.mole_fraction' not in alg.keys()
+        alg.set_rate_BC(pores=self.net.pores('bottom'), values=1)
+        alg.set_value_BC(pores=self.net.pores('top'), values=0)
+        alg.run()
+
     def teardown_class(self):
         ws = op.Workspace()
         ws.clear()

--- a/tests/unit/algorithms/ReactiveTransportTest.py
+++ b/tests/unit/algorithms/ReactiveTransportTest.py
@@ -132,6 +132,19 @@ class ReactiveTransportTest:
         with pytest.raises(Exception):
             rt.run()
 
+    def test_reset(self):
+        rt = op.algorithms.ReactiveTransport(network=self.net,
+                                             phase=self.phase)
+        rt.setup(rxn_tolerance=1e-10, max_iter=5000,
+                 relaxation_source=1.0, relaxation_quantity=1.0)
+        rt.settings.update({'conductance': 'throat.diffusive_conductance',
+                            'quantity': 'pore.concentration'})
+        rt.set_source(pores=self.net.pores('bottom'), propname='pore.reaction')
+        rt.set_value_BC(pores=self.net.pores('top'), values=1.0)
+        assert 'sources' in rt.settings.keys()
+        rt.reset(source_terms=True)
+        assert 'sources' not in rt.settings.keys()
+
     def teardown_class(self):
         ws = op.Workspace()
         ws.clear()


### PR DESCRIPTION
This should enable the re-use of algorithm objects inside for loops