### PR TITLE
Fix PyPI issue with our README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,17 @@ with open(ver_path) as f:
         if line.startswith('__version__'):
             exec(line, main_)
 
+# Read the contents of README file
+this_directory = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
 setup(
     name='openpnm',
     description='A framework for conducting pore network modeling simulations '
     + 'of multiphase transport in porous materials',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     version=main_['__version__'],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
This PR fixes #1352. Basically, the problem was that the old PyPI could only render `rst` files, but the new one (since late 2018) is much more advanced and can even render GitHub-flavored `markdown`. You only need to explicitly state that in `setup.py`.

Ref: https://packaging.python.org/guides/making-a-pypi-friendly-readme/