### PR TITLE
Default values for source term pore-scale models must ensure zero rate/S1/S2

### DIFF
--- a/example.py
+++ b/example.py
@@ -31,7 +31,7 @@ mod = op.models.physics.generic_source_term.standard_kinetics
 phys_air['pore.n'] = 2
 phys_air['pore.A'] = -1e-5
 phys_air.add_model(propname='pore.2nd_order_rxn', model=mod,
-                   quantity='pore.concentration',
+                   X='pore.concentration',
                    prefactor='pore.A', exponent='pore.n',
                    regen_mode='deferred')
 rxn = op.algorithms.FickianDiffusion(network=pn)

--- a/openpnm/models/physics/generic_source_term.py
+++ b/openpnm/models/physics/generic_source_term.py
@@ -93,7 +93,7 @@ def charge_conservation(target, phase, p_alg, e_alg, assumption):
     return values
 
 
-def standard_kinetics(target, quantity, prefactor, exponent):
+def standard_kinetics(target, X, prefactor, exponent):
     r"""
     Calculates the rate, as well as slope and intercept of the following
     function at the given value of `X`:
@@ -128,7 +128,7 @@ def standard_kinetics(target, quantity, prefactor, exponent):
             rate = S_{1} X + S_{2}
 
     """
-    X = target[quantity]
+    X = target[X]
     A = target[prefactor]
     b = target[exponent]
 

--- a/openpnm/models/physics/generic_source_term.py
+++ b/openpnm/models/physics/generic_source_term.py
@@ -63,13 +63,13 @@ def charge_conservation(target, phase, p_alg, e_alg, assumption):
     if assumption == 'poisson':
         v = network['pore.volume']
         for e in e_alg:
-            rhs += (v * F * phase['pore.valence.'+e.settings['ion']] *
-                    e[e.settings['quantity']])
+            rhs += (v * F * phase['pore.valence.'+e.settings['ion']]
+                    * e[e.settings['quantity']])
     elif assumption == 'poisson_2D':
         s = network['pore.area']
         for e in e_alg:
-            rhs += (s * F * phase['pore.valence.'+e.settings['ion']] *
-                    e[e.settings['quantity']])
+            rhs += (s * F * phase['pore.valence.'+e.settings['ion']]
+                    * e[e.settings['quantity']])
     elif assumption in ['electroneutrality', 'electroneutrality_2D']:
         for e in e_alg:
             try:
@@ -84,10 +84,10 @@ def charge_conservation(target, phase, p_alg, e_alg, assumption):
     elif assumption in ['laplace', 'laplace_2D']:
         pass  # rhs should remain 0
     else:
-        raise Exception('Unknown keyword for "charge_conservation", can ' +
-                        'only be "poisson", "poisson_2D", "laplace", ' +
-                        '"laplace_2D", "electroneutrality" or ' +
-                        "electroneutrality_2D")
+        raise Exception('Unknown keyword for "charge_conservation", can '
+                        + 'only be "poisson", "poisson_2D", "laplace", '
+                        + '"laplace_2D", "electroneutrality" or '
+                        + "electroneutrality_2D")
     S1 = _sp.zeros(shape=(p_alg.Np, ), dtype=float)
     values = {'S1': S1, 'S2': rhs, 'rate': rhs}
     return values
@@ -182,7 +182,7 @@ def linear(target, X, A1='', A2=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=0.0)
     X = target[X]
 
@@ -228,7 +228,7 @@ def power_law(target, X, A1='', A2='', A3=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=1.0)
     C = _parse_args(target=target, key=A3, default=0.0)
     X = target[X]
@@ -275,7 +275,7 @@ def exponential(target, X, A1='', A2='', A3='', A4='', A5='', A6=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=1.0)
     C = _parse_args(target=target, key=A3, default=1.0)
     D = _parse_args(target=target, key=A4, default=1.0)
@@ -325,10 +325,10 @@ def natural_exponential(target, X, A1='', A2='', A3='', A4='', A5=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
-    B = _parse_args(target=target, key=A2, default=1.0)
-    C = _parse_args(target=target, key=A3, default=1.0)
-    D = _parse_args(target=target, key=A4, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
+    B = _parse_args(target=target, key=A2, default=0.0)
+    C = _parse_args(target=target, key=A3, default=0.0)
+    D = _parse_args(target=target, key=A4, default=0.0)
     E = _parse_args(target=target, key=A5, default=0.0)
     X = target[X]
 
@@ -374,8 +374,8 @@ def logarithm(target, X, A1='', A2='', A3='', A4='', A5='', A6=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
-    B = _parse_args(target=target, key=A2, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
+    B = _parse_args(target=target, key=A2, default=10.0)
     C = _parse_args(target=target, key=A3, default=1.0)
     D = _parse_args(target=target, key=A4, default=1.0)
     E = _parse_args(target=target, key=A5, default=0.0)
@@ -425,10 +425,10 @@ def natural_logarithm(target, X, A1='', A2='', A3='', A4='', A5=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=1.0)
     C = _parse_args(target=target, key=A3, default=1.0)
-    D = _parse_args(target=target, key=A4, default=1.0)
+    D = _parse_args(target=target, key=A4, default=0.0)
     E = _parse_args(target=target, key=A5, default=0.0)
     X = target[X]
 
@@ -488,7 +488,7 @@ def linear_sym(target, X, A1='', A2=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=0.0)
     X = target[X]
     # Symbols used in symbolic function
@@ -540,7 +540,7 @@ def power_law_sym(target, X, A1='', A2='', A3=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=1.0)
     C = _parse_args(target=target, key=A3, default=0.0)
     X = target[X]
@@ -593,7 +593,7 @@ def exponential_sym(target, X, A1='', A2='', A3='', A4='', A5='', A6=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=1.0)
     C = _parse_args(target=target, key=A3, default=1.0)
     D = _parse_args(target=target, key=A4, default=1.0)
@@ -649,10 +649,10 @@ def natural_exponential_sym(target, X, A1='', A2='', A3='', A4='', A5=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=1.0)
     C = _parse_args(target=target, key=A3, default=1.0)
-    D = _parse_args(target=target, key=A4, default=1.0)
+    D = _parse_args(target=target, key=A4, default=0.0)
     E = _parse_args(target=target, key=A5, default=0.0)
     X = target[X]
     # Symbols used in symbolic function
@@ -704,8 +704,8 @@ def logarithm_sym(target, X, A1='', A2='', A3='', A4='', A5='', A6=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
-    B = _parse_args(target=target, key=A2, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
+    B = _parse_args(target=target, key=A2, default=10.0)
     C = _parse_args(target=target, key=A3, default=1.0)
     D = _parse_args(target=target, key=A4, default=1.0)
     E = _parse_args(target=target, key=A5, default=0.0)
@@ -760,10 +760,10 @@ def natural_logarithm_sym(target, X, A1='', A2='', A3='', A4='', A5=''):
             rate = S_{1}   X  +  S_{2}
 
     """
-    A = _parse_args(target=target, key=A1, default=1.0)
+    A = _parse_args(target=target, key=A1, default=0.0)
     B = _parse_args(target=target, key=A2, default=1.0)
     C = _parse_args(target=target, key=A3, default=1.0)
-    D = _parse_args(target=target, key=A4, default=1.0)
+    D = _parse_args(target=target, key=A4, default=0.0)
     E = _parse_args(target=target, key=A5, default=0.0)
     X = target[X]
     # Symbols used in symbolic function
@@ -827,7 +827,7 @@ def general_symbolic(target, eqn=None, arg_map=None):
             if key not in arg_map.keys():
                 raise Exception('argument mapping incomplete, missing '+key)
     if 'x' not in arg_map.keys():
-        raise Exception('argument mapping must contain "x" for the ' +
+        raise Exception('argument mapping must contain "x" for the '
                         'independent variable')
     # Get the data
     data = {}

--- a/tests/unit/algorithms/ReactiveTransportTest.py
+++ b/tests/unit/algorithms/ReactiveTransportTest.py
@@ -20,7 +20,7 @@ class ReactiveTransportTest:
         std_kinetics = op.models.physics.generic_source_term.standard_kinetics
         self.phys.add_model(propname='pore.reaction', model=std_kinetics,
                             prefactor='pore.A', exponent='pore.k',
-                            quantity='pore.concentration',
+                            X='pore.concentration',
                             regen_mode='deferred')
 
     def test_one_value_one_source(self):
@@ -65,7 +65,7 @@ class ReactiveTransportTest:
         std_kinetics = op.models.physics.generic_source_term.standard_kinetics
         self.phys.add_model(propname='pore.another_reaction', model=std_kinetics,
                             prefactor='pore.A', exponent='pore.k',
-                            quantity='pore.concentration',
+                            X='pore.concentration',
                             regen_mode='deferred')
         rt.set_source(pores=self.net.pores('left'), propname='pore.reaction')
         rt.set_source(pores=self.net.pores('left'), propname='pore.another_reaction')

--- a/tests/unit/algorithms/TransientReactiveTransportTest.py
+++ b/tests/unit/algorithms/TransientReactiveTransportTest.py
@@ -24,7 +24,7 @@ class TransientImplicitReactiveTransportTest:
                             model=mod,
                             prefactor='pore.A',
                             exponent='pore.k',
-                            quantity='pore.concentration',
+                            X='pore.concentration',
                             regen_mode='deferred')
         self.settings = {'conductance': 'throat.diffusive_conductance',
                          'quantity': 'pore.concentration'}

--- a/tests/unit/models/physics/GenericSourceTermTest.py
+++ b/tests/unit/models/physics/GenericSourceTermTest.py
@@ -1,9 +1,10 @@
-import openpnm as op
-import numpy as np
-import openpnm.models.physics as pm
-from sympy import symbols
-from sympy import ln as sym_ln
 import collections
+import numpy as np
+import openpnm as op
+import openpnm.models.physics as pm
+from numpy.testing import assert_allclose
+from sympy import ln as sym_ln
+from sympy import symbols
 
 
 class GenericSourceTermTest:
@@ -21,6 +22,26 @@ class GenericSourceTermTest:
         self.phase['pore.mole_fraction'] = 0.0
         self.BC_pores = np.arange(20, 30)
         self.source_pores = np.arange(55, 85)
+
+    def test_default_values_should_give_zero_rate(self):
+        sources = ["linear", "power_law", "exponential", "natural_exponential",
+                   "logarithm", "natural_logarithm"]
+        self.alg = op.algorithms.ReactiveTransport(network=self.net,
+                                                   phase=self.phase)
+        self.alg.settings.update({'conductance': 'throat.diffusive_conductance',
+                                  'quantity': 'pore.mole_fraction'})
+        self.alg.set_value_BC(values=0.4, pores=self.BC_pores)
+        self.alg.set_source(propname='pore.source_term',
+                            pores=self.source_pores)
+        # To avoid nans in logarithm-based source term models
+        self.phase['pore.mole_fraction'] = 0.1
+        for source in sources:
+            self.phys.add_model(propname="pore.source_term",
+                                model=getattr(pm.generic_source_term, source),
+                                X="pore.mole_fraction")
+            assert self.phys["pore.source_term.rate"].mean() == 0
+            assert self.phys["pore.source_term.S1"].mean() == 0
+            assert self.phys["pore.source_term.S2"].mean() == 0
 
     def test_linear(self):
         self.phys['pore.item1'] = 0.5e-11
@@ -130,12 +151,11 @@ class GenericSourceTermTest:
         self.phys.regenerate_models(propnames='pore.source1')
         self.phys.regenerate_models(propnames='pore.source2')
         X = self.phase['pore.mole_fraction']
-        r1 = np.round(np.sum(0.8e-11 * 3 ** (0.5 * X[self.source_pores]**2 -
-                      0.34) + 2e-14), 20)
-        r2 = np.round(np.sum(self.phys['pore.source1.rate'][self.source_pores]), 20)
-        rs = np.round(np.sum(self.phys['pore.source2.rate'][self.source_pores]), 20)
-        assert r1 == r2
-        assert r1== rs
+        r1 = np.sum(0.8e-11 * 3 ** (0.5 * X[self.source_pores]**2 - 0.34) + 2e-14)
+        r2 = np.sum(self.phys['pore.source1.rate'][self.source_pores])
+        rs = np.sum(self.phys['pore.source2.rate'][self.source_pores])
+        assert_allclose(actual=r2, desired=r1, rtol=1e-7)
+        assert_allclose(actual=rs, desired=r1, rtol=1e-7)
 
     def test_natural_exponential(self):
         self.phys['pore.item1'] = 0.8e-11
@@ -173,12 +193,11 @@ class GenericSourceTermTest:
         self.phys.regenerate_models(propnames='pore.source1')
         self.phys.regenerate_models(propnames='pore.source2')
         X = self.phase['pore.mole_fraction']
-        r1 = np.round(np.sum(0.8e-11 * np.exp(0.5 * X[self.source_pores]**2 -
-                      0.34) + 2e-14), 20)
-        r2 = np.round(np.sum(self.phys['pore.source1.rate'][self.source_pores]), 20)
-        rs = np.round(np.sum(self.phys['pore.source1.rate'][self.source_pores]), 20)
-        assert r1 == r2
-        assert r1 == rs
+        r1 = np.sum(0.8e-11 * np.exp(0.5 * X[self.source_pores]**2 - 0.34) + 2e-14)
+        r2 = np.sum(self.phys['pore.source1.rate'][self.source_pores])
+        rs = np.sum(self.phys['pore.source1.rate'][self.source_pores])
+        assert_allclose(actual=r2, desired=r1)
+        assert_allclose(actual=rs, desired=r1)
 
     def test_logarithm(self):
         self.phys['pore.item1'] = 0.16e-13
@@ -219,12 +238,12 @@ class GenericSourceTermTest:
         self.phys.regenerate_models(propnames='pore.source1')
         self.phys.regenerate_models(propnames='pore.source2')
         X = self.phase['pore.mole_fraction']
-        r1 = np.round(np.sum(0.16e-13*np.log(4*X[self.source_pores]**(1.4) +
-                             0.133) / np.log(10) - 5.1e-13), 20)
-        r2 = np.round(np.sum(self.phys['pore.source1.rate'][self.source_pores]), 20)
-        rs = np.round(np.sum(self.phys['pore.source2.rate'][self.source_pores]), 20)
-        assert r1 == r2
-        assert r1 == rs
+        r1 = np.sum(0.16e-13 * np.log(4*X[self.source_pores]**(1.4) + 0.133)
+                    / np.log(10) - 5.1e-13)
+        r2 = np.sum(self.phys['pore.source1.rate'][self.source_pores])
+        rs = np.sum(self.phys['pore.source2.rate'][self.source_pores])
+        assert_allclose(actual=r2, desired=r1)
+        assert_allclose(actual=rs, desired=r1)
 
     def test_natural_logarithm(self):
         self.phys['pore.item1'] = 0.16e-14
@@ -262,10 +281,9 @@ class GenericSourceTermTest:
         self.phys.regenerate_models(propnames='pore.source1')
         self.phys.regenerate_models(propnames='pore.source2')
         X = self.phase['pore.mole_fraction']
-        r1 = np.round(np.sum(0.16e-14*np.log(4*X[self.source_pores]**(1.4) +
-                             0.133) - 5.1e-14), 20)
-        r2 = np.round(np.sum(self.phys['pore.source1.rate'][self.source_pores]), 20)
-        rs = np.round(np.sum(self.phys['pore.source1.rate'][self.source_pores]), 20)
+        r1 = np.sum(0.16e-14*np.log(4*X[self.source_pores]**1.4 + 0.133) - 5.1e-14)
+        r2 = np.sum(self.phys['pore.source1.rate'][self.source_pores])
+        rs = np.sum(self.phys['pore.source1.rate'][self.source_pores])
         assert r1 == r2
         assert r1 == rs
 
@@ -301,6 +319,7 @@ class GenericSourceTermTest:
         assert np.allclose(phys['pore.source1.rate'], phys['pore.general.rate'])
         assert np.allclose(phys['pore.source1.S1'], phys['pore.general.S1'])
         assert np.allclose(phys['pore.source1.S2'], phys['pore.general.S2'])
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
This PR fixes #1366. Basically, our previous default values for some of the pore-scale models led to non-zero rates, which was confusing for some users (for instance, when using `linear`, a user assumed `A1` is by default zero and only set `A2`, which led to a hard-to-debug situation).

Also, for consistency, `quantity` argument was renamed to `X` in `standard_kinetics` like the rest of the source term models (fixes #1386)