### PR TITLE
Fix1408 throat models break with no throats

### DIFF
--- a/openpnm/models/misc/neighbor_lookups.py
+++ b/openpnm/models/misc/neighbor_lookups.py
@@ -92,19 +92,22 @@ def from_neighbor_pores(target, prop=None, pore_prop='pore.seed', mode='min',
 
     """
     prj = target.project
+    lookup = prj.find_full_domain(target)
     network = prj.network
     throats = network.map_throats(target.throats(), target)
     P12 = network.find_connected_pores(throats)
-    lookup = prj.find_full_domain(target)
     if prop is not None:
         pore_prop = prop
     pvalues = lookup[pore_prop][P12]
     if ignore_nans:
         pvalues = np.ma.MaskedArray(data=pvalues, mask=np.isnan(pvalues))
-    if mode == 'min':
-        value = np.amin(pvalues, axis=1)
-    if mode == 'max':
-        value = np.amax(pvalues, axis=1)
-    if mode == 'mean':
-        value = np.mean(pvalues, axis=1)
+    try:  # If pvalues is not empty
+        if mode == 'min':
+            value = np.amin(pvalues, axis=1)
+        if mode == 'max':
+            value = np.amax(pvalues, axis=1)
+        if mode == 'mean':
+            value = np.mean(pvalues, axis=1)
+    except np.AxisError:  # Handle case of empty pvalues
+        value = []
     return np.array(value)

--- a/tests/integration/MultidomainTest.py
+++ b/tests/integration/MultidomainTest.py
@@ -28,6 +28,20 @@ class MultipleDomainTest():
         Ts = ~pn['throat.geo_01']
         geo2 = op.geometry.StickAndBall(network=pn, pores=range(1, 27), throats=Ts)
 
+    def test_multiple_domain_all_throats_in_one_domain(self):
+        pn = op.network.Cubic(shape=[3, 3, 1])
+        Ps = pn['pore.coords'][:, 0] > 0.5
+        geo1 = op.geometry.StickAndBall(network=pn, pores=Ps, throats=pn.Ts)
+        Ps = pn['pore.coords'][:, 0] <= 0.5
+        geo2 = op.geometry.StickAndBall(network=pn, pores=Ps)
+
+    def test_multiple_domain_all_throats_in_other_domain(self):
+        pn = op.network.Cubic(shape=[3, 3, 1])
+        Ps = pn['pore.coords'][:, 0] > 0.5
+        geo1 = op.geometry.StickAndBall(network=pn, pores=Ps)
+        Ps = pn['pore.coords'][:, 0] <= 0.5
+        geo2 = op.geometry.StickAndBall(network=pn, pores=Ps, throats=pn.Ts)
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
The from_neighbor_pores model was breaking on domains that had no throats...now fixed.