### PR TITLE
Enhance plot_networkx

### DIFF
--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -2316,17 +2316,19 @@ def plot_networkx(network, plot_throats=True, labels=None, colors=None,
     dims = dimensionality(network)
     if dims.sum() > 2:
         raise Exception("NetworkX plotting only works for 2D networks.")
-    x, y, z = network['pore.coords'].T
-    x, y = [j for j in [x, y, z] if not np.allclose(j, j.mean())]
+    temp = network['pore.coords'].T[dims].squeeze()
+    if dims.sum() == 1:
+        x = temp
+        y = np.zeros_like(x)
+    if dims.sum() == 2:
+        x, y = temp
 
     G = Graph()
     pos = {network.Ps[i]: [x[i], y[i]] for i in range(network.Np)}
-    manual_sizing = False
     try:
         node_size = scale * network['pore.diameter']
-        manual_sizing = True
     except KeyError:
-        node_size = scale * 300     # 300 is default node size in networkx
+        node_size = np.ones_like(x) * scale * 0.5
     node_color = np.array(['k'] * len(network.Ps))
 
     if labels:
@@ -2347,28 +2349,27 @@ def plot_networkx(network, plot_throats=True, labels=None, colors=None,
     ax.axis("off")
 
     # Plot pores
-    draw_networkx_nodes(G, ax=ax, pos=pos, nodelist=network.Ps.tolist(),
-                        alpha=alpha, node_color="w", edgecolors=node_color,
-                        node_size=node_size)
+    gplot = draw_networkx_nodes(G, ax=ax, pos=pos, nodelist=network.Ps.tolist(),
+                                alpha=alpha, node_color="w", edgecolors=node_color,
+                                node_size=node_size)
     # (Optionally) Plot throats
     if plot_throats:
         draw_networkx_edges(G, pos=pos, edge_color='k', alpha=alpha,
                             edgelist=network['throat.conns'].tolist(), ax=ax)
 
-    if manual_sizing:
-        spi = 2700  # 1250 was obtained by trial and error
-        figwidth, figheight = ax.get_figure().get_size_inches()
-        figsize_ratio = figheight / figwidth
-        data_ratio = ax.get_data_ratio()
-        corr = min(figsize_ratio / data_ratio, 1)
-        xrange = np.ptp(ax.get_xlim())
-        markersize = sp.atleast_1d((corr*figwidth)**2 / xrange**2 * node_size**2 * spi)
-        collections = ax.collections
-        for item in collections:
-            if type(item) == PathCollection:
-                item.set_sizes(markersize)
+    spi = 2700  # 1250 was obtained by trial and error
+    figwidth, figheight = ax.get_figure().get_size_inches()
+    figsize_ratio = figheight / figwidth
+    data_ratio = ax.get_data_ratio()
+    corr = min(figsize_ratio / data_ratio, 1)
+    xrange = np.ptp(ax.get_xlim())
+    markersize = sp.atleast_1d((corr*figwidth)**2 / xrange**2 * node_size**2 * spi)
+    collections = ax.collections
+    for item in collections:
+        if type(item) == PathCollection:
+            item.set_sizes(markersize)
 
-    return G
+    return gplot
 
 
 def plot_vpython(network,

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -1,8 +1,9 @@
-import openpnm as op
+import pytest
 import numpy as np
+import openpnm as op
+import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
 from openpnm import topotools
-import pytest
 
 
 class TopotoolsTest:
@@ -325,6 +326,36 @@ class TopotoolsTest:
         air['pore.test_bool'] = True
         with pytest.raises(Exception):
             op.topotools.extend(network=pn, pore_coords=[[3, 3, 3], [3, 3, 4]])
+
+    def test_plot_networkx(self):
+        # 2D networks in XY, YZ, XZ planes
+        for i in range(3):
+            shape = np.ones(3, dtype=int)
+            shape[np.arange(3)!=i] = [5, 8]
+            pn = op.network.Cubic(shape=shape)
+            x, y = pn["pore.coords"].T[op.topotools.dimensionality(pn)]
+            fig, ax = plt.subplots()
+            m = op.topotools.plot_networkx(pn, ax=ax)
+            x_plot, y_plot = np.array(m.get_offsets()).T
+            np.testing.assert_allclose(x_plot, x)
+            np.testing.assert_allclose(y_plot, y)
+            plt.close()
+        # 1D networks in XY, YZ, XZ planes
+        for i in range(3):
+            shape = np.ones(3, dtype=int)
+            shape[np.arange(3)==i] = [5]
+            pn = op.network.Cubic(shape=shape)
+            x, = pn["pore.coords"].T[op.topotools.dimensionality(pn)]
+            fig, ax = plt.subplots()
+            m = op.topotools.plot_networkx(pn, ax=ax)
+            x_plot, y_plot = np.array(m.get_offsets()).T
+            np.testing.assert_allclose(x_plot, x)
+            plt.close()
+
+    def test_plot_networkx_3d(self):
+        pn = op.network.Cubic(shape=[5, 8, 3])
+        with pytest.raises(Exception):
+            op.topotools.plot_networkx(pn)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes issue #1388. `plot_networkx` now supports 1D networks, and is also much more robust with respect to inferring pore size/doing the right thing if not found.