### PR TITLE
Enhance CubicTemplate

### DIFF
--- a/openpnm/network/CubicTemplate.py
+++ b/openpnm/network/CubicTemplate.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 from openpnm.network import Cubic
 from openpnm import topotools
 from openpnm.utils import logging
@@ -68,17 +67,17 @@ class CubicTemplate(Cubic):
         template = np.atleast_3d(template)
         if 'shape' in kwargs:
             del kwargs['shape']
-            logger.warning('shape argument ignored, inferred from template')
+            logger.warning('"shape" argument ignored, inferred from template')
         super().__init__(shape=template.shape, spacing=spacing, **kwargs)
 
         coords = np.unravel_index(range(template.size), template.shape)
         self['pore.template_coords'] = np.vstack(coords).T
         self['pore.template_indices'] = self.Ps
-        self['pore.drop'] = template.flatten() == 0
-        topotools.trim(network=self, pores=self.pores('drop'))
-        del self['pore.drop']
-        # remove labels pertaining to surface pores, then redo post-trim
-        self.clear(mode='labels')
-        self['pore.internal'] = True
-        self['throat.internal'] = True
-        topotools.find_surface_pores(self)
+        topotools.trim(network=self, pores=template.flatten()==0)
+        # Add "internal_surface" label to "fake" surface pores!
+        ndims = topotools.dimensionality(self).sum()
+        max_neighbors = 6 if ndims == 3 else 4
+        num_neighbors = np.diff(self.get_adjacency_matrix(fmt="csr").indptr)
+        mask_surface = self["pore.surface"]
+        mask_internal_surface = (num_neighbors < max_neighbors) & ~mask_surface
+        self.set_label("pore.internal_surface", pores=mask_internal_surface)

--- a/openpnm/network/GenericNetwork.py
+++ b/openpnm/network/GenericNetwork.py
@@ -167,8 +167,8 @@ class GenericNetwork(Base, ModelsMixin):
 
     def get_adjacency_matrix(self, fmt='coo'):
         r"""
-        Returns an adjacency matrix in the specified sparse format, with 1's
-        indicating the non-zero values.
+        Returns an adjacency matrix in the specified sparse format, with throat
+        IDs indicating the non-zero values.
 
         Parameters
         ----------
@@ -190,7 +190,7 @@ class GenericNetwork(Base, ModelsMixin):
         this method will create and return the matrix, as well as store it
         for future use.
 
-        To obtain a matrix with weights other than ones at each non-zero
+        To obtain a matrix with weights other than throat IDs at each non-zero
         location use ``create_adjacency_matrix``.
 
         To obtain the non-directed graph, with only upper-triangular entries,
@@ -212,8 +212,8 @@ class GenericNetwork(Base, ModelsMixin):
 
     def get_incidence_matrix(self, fmt='coo'):
         r"""
-        Returns an incidence matrix in the specified sparse format, with 1's
-        indicating the non-zero values.
+        Returns an incidence matrix in the specified sparse format, with pore
+        IDs indicating the non-zero values.
 
         Parameters
         ----------
@@ -235,7 +235,7 @@ class GenericNetwork(Base, ModelsMixin):
         this method will create and return the matrix, as well as store it
         for future use.
 
-        To obtain a matrix with weights other than ones at each non-zero
+        To obtain a matrix with weights other than pore IDs at each non-zero
         location use ``create_incidence_matrix``.
         """
         if fmt in self._im.keys():

--- a/tests/unit/network/CubicTemplateTest.py
+++ b/tests/unit/network/CubicTemplateTest.py
@@ -1,3 +1,4 @@
+import numpy as np
 import openpnm as op
 from skimage.morphology import ball, disk
 
@@ -18,6 +19,24 @@ class CubicTemplateTest:
         net = op.network.CubicTemplate(template=ball(5), spacing=1)
         assert net.Np == 515
         assert net.Nt == 1302
+
+    def test_labels(self):
+        template = np.array(
+            [[1, 1, 1, 1, 1],
+             [1, 1, 0, 1, 1],
+             [1, 1, 0, 0, 1],
+             [1, 0, 0, 0, 1],
+             [1, 1, 0, 1, 1]]
+        )
+        net = op.network.CubicTemplate(template=template)
+        # Test "surface" label
+        Ps_surf_desired = np.array([0, 1, 2, 3, 4, 5, 8, 9, 11, 12, 13, 14, 15, 16, 17])
+        Ps_surf = net.pores("surface")
+        np.testing.assert_allclose(Ps_surf, Ps_surf_desired)
+        # Test "internal_surface" label
+        Ps_int_surf_desired = np.array([6, 7, 10])
+        Ps_int_surf = net.pores("internal_surface")
+        np.testing.assert_allclose(Ps_int_surf, Ps_int_surf_desired)
 
 
 if __name__ == '__main__':

--- a/tests/unit/network/CubicTemplateTest.py
+++ b/tests/unit/network/CubicTemplateTest.py
@@ -28,7 +28,7 @@ class CubicTemplateTest:
              [1, 0, 0, 0, 1],
              [1, 1, 0, 1, 1]]
         )
-        net = op.network.CubicTemplate(template=template)
+        net = op.network.CubicTemplate(template=template, shape=[5, 5])
         # Test "surface" label
         Ps_surf_desired = np.array([0, 1, 2, 3, 4, 5, 8, 9, 11, 12, 13, 14, 15, 16, 17])
         Ps_surf = net.pores("surface")


### PR DESCRIPTION
This PR fixes issue #1427, addressing the slow instantiation of `CubicTemplate` due to the call to `find_surface_pores` method. It doesn't do that anymore, `"pore.internal_surface"` label was introduced, which indicates surface pores that are not part of the "exterior" of the network.