### PR TITLE
add labels for 2D and 3D quick ploting.

### DIFF
--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -2262,10 +2262,15 @@ def plot_coordinates(network, pores=None, fig=None, **kwargs):
     if ThreeD:
         _scale_3d_axes(ax=ax, X=X, Y=Y, Z=Z)
         ax.scatter(xs=X, ys=Y, zs=Z, **kwargs)
+        ax.set_xlabel('x-axis')
+        ax.set_ylabel('y-axis')
+        ax.set_zlabel('z-axis')
     else:
         dummy_dim = temp.index(1)
         X, Y = [xi for j, xi in enumerate([X, Y, Z]) if j != dummy_dim]
         ax.scatter(X, Y, **kwargs)
+        ax.set_xlabel('x-axis')
+        ax.set_ylabel('y-axis')
 
     return fig
 


### PR DESCRIPTION
@jgostick, as you suggested, add labels for both 2D and 3D network quick plotting method.
For example:

![image](https://user-images.githubusercontent.com/44153643/84451443-a52c6780-ac85-11ea-8bae-6b3fc39b8c40.png)
