### PR TITLE
Fixing stitch

### DIFF
--- a/openpnm/network/Bravais.py
+++ b/openpnm/network/Bravais.py
@@ -155,13 +155,13 @@ class Bravais(GenericNetwork):
                 n.update({'throat.all': np.array([], dtype=bool)})
                 n.update({'throat.conns': np.ndarray([0, 2], dtype=bool)})
             # Join networks 2, 3 and 4 into one with all face sites
-            topotools.stitch(net2, net3, net2.Ps, net3.Ps,
-                             len_min=0.70, len_max=0.75)
-            topotools.stitch(net2, net4, net2.Ps, net4.Ps,
-                             len_min=0.70, len_max=0.75)
+            topotools.stitch(net2, net3, net2.Ps, net3.Ps, method='radius',
+                             len_max=0.75)
+            topotools.stitch(net2, net4, net2.Ps, net4.Ps, method='radius',
+                             len_max=0.75)
             # Join face sites network with the corner sites network
-            topotools.stitch(net1, net2, net1.Ps, net2.Ps,
-                             len_min=0.70, len_max=0.75)
+            topotools.stitch(net1, net2, net1.Ps, net2.Ps, method='radius',
+                             len_max=0.75)
             self.update(net1)
             ws.close_project(net1.project)
             # Deal with labels

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1487,7 +1487,7 @@ def merge_networks(network, donor=[]):
 
 
 def stitch(network, donor, P_network, P_donor, method='nearest',
-           len_max=sp.inf, len_min=0, label_suffix=''):
+           len_max=sp.inf, len_min=0, label_suffix='', label_stitches='stitched'):
     r'''
     Stitches a second a network to the current network.
 
@@ -1505,11 +1505,17 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
     P_donor : array_like
         The pores on the donor Network
 
-    label_suffix : string or None
+    label_suffix : str or None
         Some text to append to each label in the donor Network before
         inserting them into the recipient.  The default is to append no
         text, but a common option would be to append the donor Network's
-        name. To insert none of the donor labels, use None.
+        name. To insert none of the donor labels, use ``None``.
+
+    label_stitches : str or list of strings
+        The label to apply to the newly created 'stitch' throats.  The
+        defaul is 'stitched'.  If performing multiple stitches in a row it
+        might be helpful to the throats created during each step uniquely
+        for later identification.
 
     len_max : float
         Set a length limit on length of new throats
@@ -1547,7 +1553,11 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
     # Ensure Networks have no associated objects yet
     if (len(network.project) > 1) or (len(donor.project) > 1):
         raise Exception('Cannot stitch a Network with active objects')
-    network['throat.stitched'] = False
+    if isinstance(label_stitches, str):
+        label_stitches = [label_stitches]
+    for s in label_stitches:
+        if s not in network.keys():
+            network['throat.' + s] = False
     # Get the initial number of pores and throats
     N_init = {}
     N_init['pore'] = network.Np
@@ -1588,7 +1598,7 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
             network[label+label_suffix][locations] = donor[label]
 
     # Add the new stitch throats to the Network
-    extend(network=network, throat_conns=conns, labels='stitched')
+    extend(network=network, throat_conns=conns, labels=label_stitches)
 
     # Remove donor from Workspace, if present
     # This check allows for the reuse of a donor Network multiple times
@@ -1599,7 +1609,7 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
 
 def connect_pores(network, pores1, pores2, labels=[], add_conns=True):
     r'''
-    Returns the possible connections between two group of pores, and optionally
+    Returns the possible connections between two groups of pores, and optionally
     makes the connections.
 
     See ``Notes`` for advanced usage.

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1523,8 +1523,8 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
     method : string (default = 'nearest')
         The method to use when making pore to pore connections. Options are:
 
-        - 'radii' : Connects each pore on the recipient network to the
-                    nearest pores on the donor network, within ``len_max``
+        - 'radius' : Connects each pore on the recipient network to the
+                     nearest pores on the donor network, within ``len_max``
         - 'nearest' : Connects each pore on the recipienet network to the
                       nearest pore on the donor network.
 
@@ -1545,7 +1545,7 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
     [125, 300]
     >>> pn2['pore.coords'][:, 2] += 5.0
     >>> op.topotools.stitch(network=pn, donor=pn2, P_network=pn.pores('top'),
-    ...                     P_donor=pn2.pores('bottom'), method='radii',
+    ...                     P_donor=pn2.pores('bottom'), method='radius',
     ...                     len_max=1.0)
     >>> [pn.Np, pn.Nt]
     [250, 625]

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -327,7 +327,7 @@ class TopotoolsTest:
         with pytest.raises(Exception):
             op.topotools.extend(network=pn, pore_coords=[[3, 3, 3], [3, 3, 4]])
 
-    def test_stitch_no_connections(self):
+    def test_stitch_radius_no_connections(self):
         Nx, Ny, Nz = (10, 10, 1)
         Lc = 1e-4
         pn = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
@@ -335,7 +335,7 @@ class TopotoolsTest:
         pn2['pore.coords'] += [Lc*Nx, 0, 0]
         op.topotools.stitch(network=pn, donor=pn2,
                             P_network=pn.pores('back'), P_donor=pn2.pores('front'),
-                            len_max=0,
+                            method='radius', len_max=0,
                             label_stitches=['test', 'test2'])
         assert pn.Nt == (pn2.Nt*2)
 
@@ -347,7 +347,6 @@ class TopotoolsTest:
         pn2['pore.coords'] += [Lc*Nx, 0, 0]
         op.topotools.stitch(network=pn, donor=pn2,
                             P_network=pn.pores('back'), P_donor=pn2.pores('front'),
-                            len_max=Lc,
                             label_stitches=['test', 'test2'])
         assert pn.Nt == (pn2.Nt*2 + 10)
 
@@ -359,10 +358,23 @@ class TopotoolsTest:
         pn2['pore.coords'] += [Lc*Nx, 0, 0]
         op.topotools.stitch(network=pn, donor=pn2,
                             P_network=pn.pores('back'), P_donor=pn2.pores('front'),
-                            len_max=Lc,
                             label_stitches=['test', 'test2'])
         assert 'throat.test' in pn.keys()
         assert 'throat.test2' in pn.keys()
+
+    def test_stitch_repeatedly(self):
+        pn = op.network.Cubic(shape=[10, 10, 1], spacing=1e-4)
+        pn2 = op.network.Cubic(shape=[10, 10, 1], spacing=1e-4)
+        pn2['pore.coords'] += [1e-4*10, 0, 0]
+        pn3 = op.network.Cubic(shape=[10, 10, 1], spacing=1e-4)
+        pn3['pore.coords'] += [1e-4*20, 0, 0]
+        op.topotools.stitch(network=pn, donor=pn2,
+                            P_network=pn.pores('back'), P_donor=pn2.pores('front'),
+                            method='nearest')
+        op.topotools.stitch(network=pn, donor=pn3,
+                            P_network=pn.pores('back'), P_donor=pn2.pores('front'),
+                            method='nearest')
+        assert pn.Nt == (pn2.Nt*3 + 20)
 
     def test_dimensionality(self):
         # 3D network

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -327,7 +327,31 @@ class TopotoolsTest:
         with pytest.raises(Exception):
             op.topotools.extend(network=pn, pore_coords=[[3, 3, 3], [3, 3, 4]])
 
-    def test_stitch(self):
+    def test_stitch_no_connections(self):
+        Nx, Ny, Nz = (10, 10, 1)
+        Lc = 1e-4
+        pn = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
+        pn2 = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
+        pn2['pore.coords'] += [Lc*Nx, 0, 0]
+        op.topotools.stitch(network=pn, donor=pn2,
+                            P_network=pn.pores('back'), P_donor=pn2.pores('front'),
+                            len_max=0,
+                            label_stitches=['test', 'test2'])
+        assert pn.Nt == (pn2.Nt*2)
+
+    def test_stitch_10_connections(self):
+        Nx, Ny, Nz = (10, 10, 1)
+        Lc = 1e-4
+        pn = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
+        pn2 = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
+        pn2['pore.coords'] += [Lc*Nx, 0, 0]
+        op.topotools.stitch(network=pn, donor=pn2,
+                            P_network=pn.pores('back'), P_donor=pn2.pores('front'),
+                            len_max=Lc,
+                            label_stitches=['test', 'test2'])
+        assert pn.Nt == (pn2.Nt*2 + 10)
+
+    def test_stitch_with_multiple_labels(self):
         Nx, Ny, Nz = (10, 10, 1)
         Lc = 1e-4
         pn = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
@@ -339,7 +363,6 @@ class TopotoolsTest:
                             label_stitches=['test', 'test2'])
         assert 'throat.test' in pn.keys()
         assert 'throat.test2' in pn.keys()
-        assert pn.Nt == (pn2.Nt*2 + 10)
 
     def test_dimensionality(self):
         # 3D network

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -327,35 +327,19 @@ class TopotoolsTest:
         with pytest.raises(Exception):
             op.topotools.extend(network=pn, pore_coords=[[3, 3, 3], [3, 3, 4]])
 
-    def test_plot_networkx(self):
-        # 2D networks in XY, YZ, XZ planes
-        for i in range(3):
-            shape = np.ones(3, dtype=int)
-            shape[np.arange(3) != i] = [5, 8]
-            pn = op.network.Cubic(shape=shape)
-            x, y = pn["pore.coords"].T[op.topotools.dimensionality(pn)]
-            fig, ax = plt.subplots()
-            m = op.topotools.plot_networkx(pn, ax=ax)
-            x_plot, y_plot = np.array(m.get_offsets()).T
-            np.testing.assert_allclose(x_plot, x)
-            np.testing.assert_allclose(y_plot, y)
-            plt.close()
-        # 1D networks in XY, YZ, XZ planes
-        for i in range(3):
-            shape = np.ones(3, dtype=int)
-            shape[np.arange(3) == i] = [5]
-            pn = op.network.Cubic(shape=shape)
-            x, = pn["pore.coords"].T[op.topotools.dimensionality(pn)]
-            fig, ax = plt.subplots()
-            m = op.topotools.plot_networkx(pn, ax=ax)
-            x_plot, y_plot = np.array(m.get_offsets()).T
-            np.testing.assert_allclose(x_plot, x)
-            plt.close()
-
-    def test_plot_networkx_3d(self):
-        pn = op.network.Cubic(shape=[5, 8, 3])
-        with pytest.raises(Exception):
-            op.topotools.plot_networkx(pn)
+    def test_stitch(self):
+        Nx, Ny, Nz = (10, 10, 1)
+        Lc = 1e-4
+        pn = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
+        pn2 = op.network.Cubic(shape=[Nx, Ny, Nz], spacing=Lc)
+        pn2['pore.coords'] += [Lc*Nx, 0, 0]
+        op.topotools.stitch(network=pn, donor=pn2,
+                            P_network=pn.pores('back'), P_donor=pn2.pores('front'),
+                            len_max=Lc,
+                            label_stitches=['test', 'test2'])
+        assert 'throat.test' in pn.keys()
+        assert 'throat.test2' in pn.keys()
+        assert pn.Nt == (pn2.Nt*2 + 10)
 
     def test_dimensionality(self):
         # 3D network


### PR DESCRIPTION
Fixes #1532 and closes #1533 which does not seem to be a problem.

the stitch function now: 
* accepts ``label_stitches`` which will apply a list of specified labels to any newly generated throats
* has a ``radius`` method which only connects to pores within the given ``len_max`` distance
* has an improved ``nearest`` method which actually does what it says and only connects to the true nearest pore

This is actually a breaking change since the 'radius' method now acts like the 'nearest' method used to, and the 'nearest' method ignores the ``len_max`` argument