### PR TITLE
Prevent connectivity = 8 or 12 in Cubic networks

### DIFF
--- a/examples/tutorials/Intro to OpenPNM - Intermediate.ipynb
+++ b/examples/tutorials/Intro to OpenPNM - Intermediate.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Building-a-Cubic-Network\" data-toc-modified-id=\"Building-a-Cubic-Network-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Building a Cubic Network</a></span></li><li><span><a href=\"#Initialize-and-Build-Multiple-Geometry-Objects\" data-toc-modified-id=\"Initialize-and-Build-Multiple-Geometry-Objects-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Initialize and Build <em>Multiple</em> Geometry Objects</a></span><ul class=\"toc-item\"><li><span><a href=\"#Assign-Static-Seed-values-to-Each-Geometry\" data-toc-modified-id=\"Assign-Static-Seed-values-to-Each-Geometry-2.1\"><span class=\"toc-item-num\">2.1&nbsp;&nbsp;</span>Assign Static Seed values to <em>Each</em> Geometry</a></span></li><li><span><a href=\"#Accessing-Data-Distributed-Between-Geometries\" data-toc-modified-id=\"Accessing-Data-Distributed-Between-Geometries-2.2\"><span class=\"toc-item-num\">2.2&nbsp;&nbsp;</span>Accessing Data Distributed Between Geometries</a></span></li><li><span><a href=\"#Add-Pore-Size-Distribution-Models-to-Each-Geometry\" data-toc-modified-id=\"Add-Pore-Size-Distribution-Models-to-Each-Geometry-2.3\"><span class=\"toc-item-num\">2.3&nbsp;&nbsp;</span>Add Pore Size Distribution Models to Each Geometry</a></span></li><li><span><a href=\"#Add-Additional-Pore-Scale-Models-to-Each-Geometry\" data-toc-modified-id=\"Add-Additional-Pore-Scale-Models-to-Each-Geometry-2.4\"><span class=\"toc-item-num\">2.4&nbsp;&nbsp;</span>Add Additional Pore-Scale Models to Each Geometry</a></span></li></ul></li><li><span><a href=\"#Create-a-Phase-Object-and-Assign-Thermophysical-Property-Models\" data-toc-modified-id=\"Create-a-Phase-Object-and-Assign-Thermophysical-Property-Models-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>Create a Phase Object and Assign Thermophysical Property Models</a></span></li><li><span><a href=\"#Create-Physics-Objects-for-Each-Geometry\" data-toc-modified-id=\"Create-Physics-Objects-for-Each-Geometry-4\"><span class=\"toc-item-num\">4&nbsp;&nbsp;</span>Create Physics Objects for Each Geometry</a></span><ul class=\"toc-item\"><li><span><a href=\"#Accessing-Data-Distributed-Between-Multiple-Physics-Objects\" data-toc-modified-id=\"Accessing-Data-Distributed-Between-Multiple-Physics-Objects-4.1\"><span class=\"toc-item-num\">4.1&nbsp;&nbsp;</span>Accessing Data Distributed Between Multiple Physics Objects</a></span></li></ul></li><li><span><a href=\"#Pore-Scale-Models:-The-Big-Picture\" data-toc-modified-id=\"Pore-Scale-Models:-The-Big-Picture-5\"><span class=\"toc-item-num\">5&nbsp;&nbsp;</span>Pore-Scale Models: The Big Picture</a></span></li><li><span><a href=\"#Determine-Permeability-Tensor-by-Changing-Inlet-and-Outlet-Boundary-Conditions\" data-toc-modified-id=\"Determine-Permeability-Tensor-by-Changing-Inlet-and-Outlet-Boundary-Conditions-6\"><span class=\"toc-item-num\">6&nbsp;&nbsp;</span>Determine Permeability Tensor by Changing Inlet and Outlet Boundary Conditions</a></span></li></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Tutorial 2 of 3: Digging Deeper into OpenPNM\n",
@@ -55,14 +65,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn = op.network.Cubic(shape=[20, 20, 10], spacing=0.0001, connectivity=8)"
+    "pn = op.network.Cubic(shape=[20, 20, 10], spacing=0.0001, connectivity=14)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* This **Network** has pores distributed in a cubic lattice, but connected to diagonal neighbors due to the ``connectivity`` being set to 8 (the default is 6 which is orthogonal neighbors).  The various options are outlined in the **Cubic** class's documentation which can be viewed with the Object Inspector in Spyder.\n",
+    "* This **Network** has pores distributed in a cubic lattice, but connected to diagonal neighbors due to the ``connectivity`` being set to 14 (the default is 6 which is orthogonal neighbors).  The various options are outlined in the **Cubic** class's documentation which can be viewed with the Object Inspector in Spyder.\n",
     "\n",
     "* OpenPNM includes several other classes for generating networks including random topology based on Delaunay tessellations (**Delaunay**).\n",
     "\n",
@@ -266,9 +276,9 @@
     {
      "data": {
       "text/plain": [
-       "array([[5.21639565e-05, 5.88927751e-05],\n",
-       "       [5.83316363e-05, 5.43440496e-05],\n",
-       "       [5.63074931e-05, 5.81044386e-05],\n",
+       "array([[5.21639565e-05, 5.83316363e-05],\n",
+       "       [5.83316363e-05, 5.63074931e-05],\n",
+       "       [5.63074931e-05, 5.92495511e-05],\n",
        "       ...,\n",
        "       [5.95407077e-05, 5.39710315e-05],\n",
        "       [5.31619482e-05, 5.42961235e-05],\n",
@@ -803,7 +813,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1.43421902e-10] [3.17745347e-10] [1.13961253e-10]\n"
+      "[1.8792235e-10] [4.46916277e-10] [1.69341333e-10]\n"
      ]
     }
    ],
@@ -832,7 +842,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -138,21 +138,17 @@ class Cubic(GenericNetwork):
 
         if connectivity == 6:
             joints = face_joints
-        elif connectivity == 8:
-            joints = corner_joints
-        elif connectivity == 12:
-            joints = edge_joints
-        elif connectivity == 14:
+        elif connectivity == 6 + 8:
             joints = face_joints + corner_joints
-        elif connectivity == 18:
+        elif connectivity == 6 + 12:
             joints = face_joints + edge_joints
-        elif connectivity == 20:
+        elif connectivity == 12 + 8:
             joints = edge_joints + corner_joints
-        elif connectivity == 26:
+        elif connectivity == 6 + 8 + 12:
             joints = face_joints + corner_joints + edge_joints
         else:
             raise Exception(
-                "Invalid connectivity receieved. Must be 6, 8, " "12, 14, 18, 20 or 26"
+                "Invalid connectivity receieved. Must be 6, 14, 18, 20 or 26"
             )
 
         tails, heads = np.array([], dtype=int), np.array([], dtype=int)

--- a/tests/unit/network/CubicTest.py
+++ b/tests/unit/network/CubicTest.py
@@ -1,6 +1,5 @@
 import pytest
 import numpy as np
-import scipy as sp
 import openpnm as op
 
 
@@ -122,6 +121,116 @@ class CubicTest:
         net.add_boundary_pores()
         with pytest.raises(Exception):
             net.spacing
+
+    def test_connectivity(self):
+        clist = [6, 14, 18, 20, 26]
+        conns_dict = {
+            6: np.array([[0, 1],
+                         [2, 3],
+                         [4, 5],
+                         [6, 7],
+                         [0, 2],
+                         [1, 3],
+                         [4, 6],
+                         [5, 7],
+                         [0, 4],
+                         [1, 5],
+                         [2, 6],
+                         [3, 7]]),
+            14: np.array([[0, 1],
+                          [2, 3],
+                          [4, 5],
+                          [6, 7],
+                          [0, 2],
+                          [1, 3],
+                          [4, 6],
+                          [5, 7],
+                          [0, 4],
+                          [1, 5],
+                          [2, 6],
+                          [3, 7],
+                          [0, 7],
+                          [1, 6],
+                          [2, 5],
+                          [3, 4]]),
+            18: np.array([[0, 1],
+                          [2, 3],
+                          [4, 5],
+                          [6, 7],
+                          [0, 2],
+                          [1, 3],
+                          [4, 6],
+                          [5, 7],
+                          [0, 4],
+                          [1, 5],
+                          [2, 6],
+                          [3, 7],
+                          [0, 3],
+                          [4, 7],
+                          [1, 2],
+                          [5, 6],
+                          [0, 5],
+                          [2, 7],
+                          [1, 4],
+                          [3, 6],
+                          [0, 6],
+                          [1, 7],
+                          [2, 4],
+                          [3, 5]]),
+            20: np.array([[0, 3],
+                          [4, 7],
+                          [1, 2],
+                          [5, 6],
+                          [0, 5],
+                          [2, 7],
+                          [1, 4],
+                          [3, 6],
+                          [0, 6],
+                          [1, 7],
+                          [2, 4],
+                          [3, 5],
+                          [0, 7],
+                          [1, 6],
+                          [2, 5],
+                          [3, 4]]),
+            26: np.array([[0, 1],
+                          [2, 3],
+                          [4, 5],
+                          [6, 7],
+                          [0, 2],
+                          [1, 3],
+                          [4, 6],
+                          [5, 7],
+                          [0, 4],
+                          [1, 5],
+                          [2, 6],
+                          [3, 7],
+                          [0, 7],
+                          [1, 6],
+                          [2, 5],
+                          [3, 4],
+                          [0, 3],
+                          [4, 7],
+                          [1, 2],
+                          [5, 6],
+                          [0, 5],
+                          [2, 7],
+                          [1, 4],
+                          [3, 6],
+                          [0, 6],
+                          [1, 7],
+                          [2, 4],
+                          [3, 5]])
+        }
+        for x in clist:
+            net = op.network.Cubic(shape=[2, 2, 2], connectivity=x)
+            np.testing.assert_allclose(net.conns, conns_dict[x])
+
+    def test_invalid_connectivity(self):
+        invalid_clist = [8, 12, 45]
+        for x in invalid_clist:
+            with pytest.raises(Exception):
+                _ = op.network.Cubic(shape=[3, 4, 5], connectivity=x)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1556. check_net Basically, passing `connectivity=8` or `12` generates a disconnected network by design! So we shouldn't allow for that.