### PR TITLE
Speed up find_neighbor_sites and num_neighbors

### DIFF
--- a/examples/tutorials/Intro to OpenPNM - Intermediate.ipynb
+++ b/examples/tutorials/Intro to OpenPNM - Intermediate.ipynb
@@ -55,14 +55,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pn = op.network.Cubic(shape=[20, 20, 10], spacing=0.0001, connectivity=8)"
+    "pn = op.network.Cubic(shape=[20, 20, 10], spacing=0.0001, connectivity=14)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* This **Network** has pores distributed in a cubic lattice, but connected to diagonal neighbors due to the ``connectivity`` being set to 8 (the default is 6 which is orthogonal neighbors).  The various options are outlined in the **Cubic** class's documentation which can be viewed with the Object Inspector in Spyder.\n",
+    "* This **Network** has pores distributed in a cubic lattice, but connected to diagonal neighbors due to the ``connectivity`` being set to 14 (the default is 6 which is orthogonal neighbors).  The various options are outlined in the **Cubic** class's documentation which can be viewed with the Object Inspector in Spyder.\n",
     "\n",
     "* OpenPNM includes several other classes for generating networks including random topology based on Delaunay tessellations (**Delaunay**).\n",
     "\n",
@@ -266,9 +266,9 @@
     {
      "data": {
       "text/plain": [
-       "array([[5.21639565e-05, 5.88927751e-05],\n",
-       "       [5.83316363e-05, 5.43440496e-05],\n",
-       "       [5.63074931e-05, 5.81044386e-05],\n",
+       "array([[5.21639565e-05, 5.83316363e-05],\n",
+       "       [5.83316363e-05, 5.63074931e-05],\n",
+       "       [5.63074931e-05, 5.92495511e-05],\n",
        "       ...,\n",
        "       [5.95407077e-05, 5.39710315e-05],\n",
        "       [5.31619482e-05, 5.42961235e-05],\n",
@@ -803,7 +803,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[1.43421902e-10] [3.17745347e-10] [1.13961253e-10]\n"
+      "[1.8792235e-10] [4.46916277e-10] [1.69341333e-10]\n"
      ]
     }
    ],
@@ -832,7 +832,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/openpnm/network/GenericNetwork.py
+++ b/openpnm/network/GenericNetwork.py
@@ -790,7 +790,7 @@ class GenericNetwork(Base, ModelsMixin):
             num = np.size(num)
         else:   # Could be done much faster if flatten == False
             am = self.create_adjacency_matrix(fmt="csr")
-            num = am[pores].sum(axis=1).squeeze()
+            num = am[pores].sum(axis=1).A1
         return num
 
     def find_nearby_pores(self, pores, r, flatten=False, include_input=False):

--- a/openpnm/network/GenericNetwork.py
+++ b/openpnm/network/GenericNetwork.py
@@ -9,6 +9,8 @@ import openpnm.models.topology as tm
 logger = logging.getLogger(__name__)
 ws = Workspace()
 
+from openpnm.utils import tic, toc
+
 
 class GenericNetwork(Base, ModelsMixin):
     r"""
@@ -781,13 +783,14 @@ class GenericNetwork(Base, ModelsMixin):
         1
         """
         pores = self._parse_indices(pores)
-        # Count number of neighbors
-        num = self.find_neighbor_pores(pores, flatten=flatten,
-                                       mode=mode, include_input=True)
         if flatten:
+            # Count number of neighbors
+            num = self.find_neighbor_pores(pores, flatten=flatten,
+                                           mode=mode, include_input=True)
             num = np.size(num)
-        else:
-            num = np.array([np.size(i) for i in num], dtype=int)
+        else:   # Could be done much faster if flatten == False
+            am = self.create_adjacency_matrix(fmt="csr")
+            num = am[pores].sum(axis=1).squeeze()
         return num
 
     def find_nearby_pores(self, pores, r, flatten=False, include_input=False):

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -76,7 +76,7 @@ def find_neighbor_sites(sites, am, flatten=True, include_input=False,
         am = am.tolil(copy=False)
     am_coo = am.tocoo()
     n_sites = am.shape[0]
-    rows = am.rows[sites]
+    rows = am.rows[sites].tolist()
     if len(rows) == 0:
         return []
     neighbors = am_coo.col[np.in1d(am_coo.row, sites)]

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -9,8 +9,6 @@ from openpnm.utils import PrintableDict, logging, Workspace
 logger = logging.getLogger(__name__)
 ws = Workspace()
 
-from openpnm.utils import tic, toc
-
 
 def find_neighbor_sites(sites, am, flatten=True, include_input=False,
                         logic='or'):
@@ -103,7 +101,7 @@ def find_neighbor_sites(sites, am, flatten=True, include_input=False,
     if flatten:
         neighbors = np.where(mask)[0]
     else:
-        if (neighbors.size > 0):
+        if neighbors.size > 0:
             for i in range(len(rows)):
                 vals = np.array(rows[i], dtype=sp.int64)
                 rows[i] = vals[mask[vals]]

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -74,6 +74,7 @@ def find_neighbor_sites(sites, am, flatten=True, include_input=False,
     """
     if am.format != 'lil':
         am = am.tolil(copy=False)
+    sites = np.array(sites, ndmin=1)
     am_coo = am.tocoo()
     n_sites = am.shape[0]
     rows = am.rows[sites].tolist()

--- a/openpnm/utils/misc.py
+++ b/openpnm/utils/misc.py
@@ -1,10 +1,10 @@
+import copy
 import inspect
 import warnings
 import functools
 import numpy as _np
 import scipy as _sp
 import time as _time
-import copy
 from collections import OrderedDict
 from docrep import DocstringProcessor
 
@@ -602,6 +602,7 @@ def nbr_to_str(nbr, t_precision):
 
     t_precision : integer
         The time precision (number of decimal places). Default value is 12.
+
     """
     from decimal import Decimal as dc
     n = int(-dc(str(round(nbr, t_precision))).as_tuple().exponent

--- a/tests/unit/topotools/GraphToolsTest.py
+++ b/tests/unit/topotools/GraphToolsTest.py
@@ -373,6 +373,15 @@ class GraphToolsTest:
             topotools.find_neighbor_sites(sites=[0, 1], am=am, flatten=True,
                                           logic='foobar')
 
+    def test_find_neighbor_sites_include_inputs(self):
+        am = self.net.create_adjacency_matrix(fmt='lil')
+        Ps = topotools.find_neighbor_sites(sites=[0, 1], am=am, flatten=True,
+                                           logic='or', include_input=True)
+        assert (Ps == [0, 1, 2, 3, 4]).all()
+        Ps = topotools.find_neighbor_sites(sites=[0, 1], am=am, flatten=True,
+                                           logic='or', include_input=False)
+        assert (Ps == [2, 3, 4]).all()
+
     def test_istriu(self):
         net = op.network.Cubic(shape=[5, 5, 5])
         am = net.create_adjacency_matrix(triu=False)

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 import openpnm as op
-import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
 from openpnm import topotools
 


### PR DESCRIPTION
**Optimized**
```python
Flatten: True
num_neighbors:       720 ms ± 7.39 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
find_neighbor_sites: 716 ms ± 8.64 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Flatten: False
num_neighbors:       219 ms ± 1.14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
find_neighbor_sites: 2.73 s ± 12.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
**Dev**
```python
Flatten: True
num_neighbors:       2.87 s ± 14.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
find_neighbor_sites: 2.97 s ± 84.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Flatten: False
num_neighbors:       5.88 s ± 67.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
find_neighbor_sites: 4.9 s ± 64 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
- With `flatten=True`, they're both **~4x** faster.
- With `flatten=False`, `num_neighbors` is **~30x** faster, and `find_neighbor_sites` is **~2x** faster.
