### PR TITLE
Merge geometries

### DIFF
--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -149,6 +149,8 @@ class Base(dict):
         super().__init__()
         if project is None:
             project = ws.new_project()
+        if name is None:
+            name = project._generate_name(self)
         project.extend(self)
         self.name = name
         self.update({'pore.all': np.ones(shape=(Np, ), dtype=bool)})

--- a/openpnm/core/Subdomain.py
+++ b/openpnm/core/Subdomain.py
@@ -135,7 +135,7 @@ class Subdomain(Base):
             for name in objs:
                 if element+'.'+name in boss.keys():
                     if np.any(boss[element+'.'+name][indices]):
-                        raise Exception('Given indices are already assigned to' + name)
+                        raise Exception('Given indices already assigned to ' + name)
 
         # Find mask of existing locations (network indexing)
         mask = boss[element+'.'+self.name]

--- a/openpnm/topotools/topotools.py
+++ b/openpnm/topotools/topotools.py
@@ -1434,6 +1434,17 @@ def merge_networks(network, donor=[]):
     else:
         donors = [donor]
 
+    # First fix up geometries
+    main_proj = network.project
+    main_geoms = main_proj.geometries()
+    for donor in donors:
+        proj = donor.project
+        geoms = proj.geometries().values()
+        for geo in geoms:
+            if geo.name in network.project.names:
+                geo.name = network.project._generate_name(geo)
+            network.project.append(geo)
+
     for donor in donors:
         network['pore.coords'] = np.vstack((network['pore.coords'],
                                             donor['pore.coords']))
@@ -1495,7 +1506,7 @@ def stitch(network, donor, P_network, P_donor, method='nearest',
 
     Parameters
     ----------
-    networK : OpenPNM Network Object
+    network : OpenPNM Network Object
         The Network to which to donor Network will be attached
 
     donor : OpenPNM Network Object

--- a/openpnm/utils/Project.py
+++ b/openpnm/utils/Project.py
@@ -397,8 +397,8 @@ class Project(list):
 
     def _generate_name(self, obj):
         prefix = obj.settings['prefix']
-        num = str(len([item for item in self if item._isa() == obj._isa()]))
-        name = prefix + '_' + num.zfill(2)
+        num = len(self._get_objects_by_type(obj._isa())) + 1
+        name = prefix + '_' + str(num).zfill(2)
         return name
 
     @property

--- a/openpnm/utils/Project.py
+++ b/openpnm/utils/Project.py
@@ -74,7 +74,8 @@ class Project(list):
         r"""
         This function is used to add objects to the project.  Arguments can
         be single OpenPNM objects, an OpenPNM project list, or a plain list of
-        OpenPNM objects.
+        OpenPNM objects.  Note that if an object has the same name as one
+        already existing on the project, the it will be renamed automatically.
 
         """
         if type(obj) is not list:
@@ -86,6 +87,10 @@ class Project(list):
                         raise Exception('Project already has a network')
                 # Must use append since extend breaks the dicts up into
                 # separate objects, while append keeps it as a single object.
+                if item in self:
+                    raise Exception('Supplied object already part of project')
+                if item.name in self.names:
+                    item.name = self._generate_name(item)
                 super().append(item)
             else:
                 raise Exception('Only OpenPNM objects can be added')

--- a/tests/unit/topotools/TopotoolsTest.py
+++ b/tests/unit/topotools/TopotoolsTest.py
@@ -164,6 +164,19 @@ class TopotoolsTest:
         assert 'pore.test1' not in net2
         assert 'pore.test2' not in net2
 
+    def test_merge_networks_with_active_geometries(self):
+        pn = op.network.Cubic(shape=[3, 3, 3])
+        pn2 = op.network.Cubic(shape=[3, 3, 3])
+        pn2['pore.coords'] += [0, 0, 3]
+        pn2['pore.net_02'] = True
+        pn2['throat.net_02'] = True
+        geo = op.geometry.StickAndBall(network=pn, pores=pn.Ps, throats=pn.Ts)
+        geo2 = op.geometry.StickAndBall(network=pn2, pores=pn2.Ps, throats=pn2.Ts)
+        geo2['pore.test_vals'] = 1.5
+        op.topotools.merge_networks(network=pn, donor=pn2)
+        assert isinstance(pn['pore.test_vals'], np.ndarray)
+        assert ('pore.' + geo2.name) in pn.keys()
+
     def test_subdivide_3D(self):
         net = op.network.Cubic(shape=[3, 3, 3])
         assert net.Np == 27


### PR DESCRIPTION
When merging two networks that have geometries associated, they are not merged properly, including keeping of models and the whole bit.