### PR TITLE
Pass initial condition to phase object and regenerate physics models as part of set_IC()

### DIFF
--- a/openpnm/algorithms/TransientReactiveTransport.py
+++ b/openpnm/algorithms/TransientReactiveTransport.py
@@ -161,7 +161,9 @@ class TransientReactiveTransport(ReactiveTransport):
 
     def set_IC(self, values):
         r"""
-        A method to set simulation initial conditions
+        A method to set simulation initial conditions. The values for initial
+        condition get passed to phase object and are used to update physics
+        models automatically.
 
         Parameters
         ----------

--- a/openpnm/algorithms/TransientReactiveTransport.py
+++ b/openpnm/algorithms/TransientReactiveTransport.py
@@ -179,6 +179,13 @@ class TransientReactiveTransport(ReactiveTransport):
         if not quantity:
             raise Exception('"quantity" has not been defined on this algorithm')
         self[quantity] = values
+        # Pass initial condition to phase
+        phase = self.project.phases()[self.settings['phase']]
+        phase[quantity] = self[quantity]
+        # Regenerate physics using initial condition now in phase
+        physics = phase.find_physics(phase=phase)
+        for obj in physics:
+            obj.regenerate_models()
 
     def _get_f1_f2_f3(self):
         r"""


### PR DESCRIPTION
Trying to fix issue #1738 

Right now I am regenerating all physics models. I am wondering if this could cause problems. Is there a way to regenerate only the physics models that depend on `quantity`? If so, I think that would be a better way to handle this.
