### PR TITLE
Fix spacing issue for a network of two pores

### DIFF
--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -254,10 +254,14 @@ class Cubic(GenericNetwork):
         for ax in [0, 1, 2]:
             if dims[ax]:
                 inds = np.where(unit_vec[:, ax] == unit_vec[:, ax].max())[0]
-                temp = np.unique(mag[inds])
-                if not np.allclose(temp, temp[0]):
-                    raise Exception("A unique value of spacing could not be found")
-                spacing[ax] = temp[0]
+                if np.ndim(mag) != 0:
+                    temp = np.unique(mag[inds])
+                    if not np.allclose(temp, temp[0]):
+                        raise Exception("A unique value of spacing could not be found")
+                    spacing[ax] = temp[0]
+                else:
+                    temp = mag
+                    spacing[ax] = temp
         self.settings['spacing'] = spacing
         return np.array(spacing)
 

--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -139,9 +139,7 @@ class Cubic(GenericNetwork):
         elif connectivity == 6 + 8 + 12:
             joints = face_joints + corner_joints + edge_joints
         else:
-            raise Exception(
-                "Invalid connectivity receieved. Must be 6, 14, 18, 20 or 26"
-            )
+            raise Exception("Invalid connectivity. Must be 6, 14, 18, 20 or 26.")
 
         tails, heads = np.array([], dtype=int), np.array([], dtype=int)
         for T, H in joints:

--- a/openpnm/network/Cubic.py
+++ b/openpnm/network/Cubic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ===============================================================================
 Cubic: Generate lattice-like networks
@@ -245,23 +244,19 @@ class Cubic(GenericNetwork):
         dims = topotools.dimensionality(self)
         # Ensure vectors point in n-dims unique directions
         c = {tuple(row): 1 for row in unit_vec}
+        mag = np.atleast_1d(mag.squeeze()).astype(float)
         if len(c.keys()) > sum(dims):
             raise Exception(
-                "Spacing is undefined when throats point in "
-                + "more directions than network has dimensions"
+                "Spacing is undefined when throats point in more directions"
+                " than network has dimensions."
             )
-        mag = np.float64(mag.squeeze())
         for ax in [0, 1, 2]:
             if dims[ax]:
                 inds = np.where(unit_vec[:, ax] == unit_vec[:, ax].max())[0]
-                if np.ndim(mag) != 0:
-                    temp = np.unique(mag[inds])
-                    if not np.allclose(temp, temp[0]):
-                        raise Exception("A unique value of spacing could not be found")
-                    spacing[ax] = temp[0]
-                else:
-                    temp = mag
-                    spacing[ax] = temp
+                temp = np.unique(mag[inds])
+                if not np.allclose(temp, temp[0]):
+                    raise Exception("A unique value of spacing could not be found.")
+                spacing[ax] = temp[0]
         self.settings['spacing'] = spacing
         return np.array(spacing)
 

--- a/tests/unit/network/CubicTest.py
+++ b/tests/unit/network/CubicTest.py
@@ -10,6 +10,11 @@ class CubicTest:
     def teardown_class(self):
         pass
 
+    def test_spacing_1D(self):
+        # in _get_spacing it will be np.ndim(mag) == 0 (scalar value)
+        net = op.network.Cubic(shape=[2, 1, 1], spacing=1)
+        assert np.all(net.spacing == [1.0, 0.0, 0.0])
+
     def test_spacing_2D(self):
         net = op.network.Cubic(shape=[5, 5, 1], spacing=[1, 1])
         assert np.all(net.spacing == [1.0, 1.0, 0.0])

--- a/tests/unit/network/CubicTest.py
+++ b/tests/unit/network/CubicTest.py
@@ -11,7 +11,6 @@ class CubicTest:
         pass
 
     def test_spacing_1D(self):
-        # in _get_spacing it will be np.ndim(mag) == 0 (scalar value)
         net = op.network.Cubic(shape=[2, 1, 1], spacing=1)
         assert np.all(net.spacing == [1.0, 0.0, 0.0])
 
@@ -119,13 +118,13 @@ class CubicTest:
         net = op.network.Cubic(shape=[3, 4, 5])
         net['pore.coords'] += np.random.rand(net.Np, 3)
         with pytest.raises(Exception):
-            net.spacing
+            _ = net.spacing
 
     def test_spacing_on_network_with_boundary_pores(self):
         net = op.network.Cubic(shape=[3, 4, 5])
         net.add_boundary_pores()
         with pytest.raises(Exception):
-            net.spacing
+            _ = net.spacing
 
     def test_connectivity(self):
         clist = [6, 14, 18, 20, 26]

--- a/tests/unit/network/CubicTest.py
+++ b/tests/unit/network/CubicTest.py
@@ -10,6 +10,12 @@ class CubicTest:
     def teardown_class(self):
         pass
 
+    def test_spacing_could_not_be_found(self):
+        net = op.network.Cubic(shape=[1, 5, 1], spacing=1)
+        net["pore.coords"][4, 1] += 5
+        with pytest.raises(Exception):
+            _ = net.spacing
+
     def test_spacing_1D(self):
         net = op.network.Cubic(shape=[2, 1, 1], spacing=1)
         assert np.all(net.spacing == [1.0, 0.0, 0.0])

--- a/tests/unit/network/GenericNetworkTest.py
+++ b/tests/unit/network/GenericNetworkTest.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy as sp
 import openpnm as op
 
 


### PR DESCRIPTION
This PR closes #1732 

Sample code:
```python
import openpnm as op
import numpy as np
net = op.network.Cubic([1, 3, 1])
print(net.spacing)
```
output: 
```python
[0. 1. 0.]
# net = op.network.Cubic([3, 3, 3]) # still works for 3D networks
# [1. 1. 1.]
# net = op.network.Cubic([3, 3, 1]) # still works for 2D networks
# [1. 1. 0.]
```