### PR TITLE
Fix CI Actions

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           CACHE_NUMBER: 0  # increase value -> force reset cache
         with:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         env:
-          CACHE_NUMBER: 0  # increase value -> force reset cache
+          CACHE_NUMBER: 1  # increase value -> force reset cache
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/conda_requirements.txt') }}

--- a/.github/workflows/ci-min.yml
+++ b/.github/workflows/ci-min.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           CACHE_NUMBER: 0  # increase value -> force reset cache
         with:
@@ -52,7 +52,7 @@ jobs:
           cat requirements/conda_requirements.txt >> requirements.txt
           cat requirements/test_requirements.txt >> requirements.txt
           cat requirements/optional_requirements.txt >> requirements.txt
-          printf "pyamg\nmpi4py\npetsc\npetsc4py\n" >> requirements.txt
+          printf "pyamg\n" >> requirements.txt
           mamba install --file requirements.txt
           # Install OpenPNM from the checked-out branch
           pip install -e . --no-deps

--- a/.github/workflows/ci-min.yml
+++ b/.github/workflows/ci-min.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         env:
-          CACHE_NUMBER: 0  # increase value -> force reset cache
+          CACHE_NUMBER: 1  # increase value -> force reset cache
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/conda_requirements.txt') }}

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -52,7 +52,7 @@ jobs:
           cat requirements/conda_requirements.txt >> requirements.txt
           cat requirements/test_requirements.txt >> requirements.txt
           cat requirements/optional_requirements.txt >> requirements.txt
-          printf "pyamg\nmpi4py\npetsc\npetsc4py\n" >> requirements.txt
+          printf "pyamg\nmpi4py\npetsc\npetsc4py\nmpich\n" >> requirements.txt
           mamba install --file requirements.txt
           # Install OpenPNM from the checked-out branch
           pip install -e . --no-deps

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           CACHE_NUMBER: 0  # increase value -> force reset cache
         with:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         env:
-          CACHE_NUMBER: 0  # increase value -> force reset cache
+          CACHE_NUMBER: 1  # increase value -> force reset cache
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/conda_requirements.txt') }}

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -52,7 +52,7 @@ jobs:
           cat requirements/conda_requirements.txt >> requirements.txt
           cat requirements/test_requirements.txt >> requirements.txt
           cat requirements/optional_requirements.txt >> requirements.txt
-          printf "pyamg\nmpi4py\npetsc\npetsc4py\nmpich\n" >> requirements.txt
+          printf "pyamg\nmpi4py\npetsc\npetsc4py\nopenmpi\n" >> requirements.txt
           mamba install --file requirements.txt
           # Install OpenPNM from the checked-out branch
           pip install -e . --no-deps

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache conda
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           CACHE_NUMBER: 0  # increase value -> force reset cache
         with:
@@ -39,7 +39,6 @@ jobs:
         with:
           mamba-version: "*"
           allow-softlinks: true
-          auto-update-conda: true
           use-only-tar-bz2: true
           show-channel-urls: false
           auto-activate-base: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         env:
-          CACHE_NUMBER: 0  # increase value -> force reset cache
+          CACHE_NUMBER: 1  # increase value -> force reset cache
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/conda_requirements.txt') }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v1
         env:
-          CACHE_NUMBER: 0  # increase value -> force reset cache
+          CACHE_NUMBER: 1  # increase value -> force reset cache
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('**/conda_requirements.txt') }}


### PR DESCRIPTION
This PR fixes the Ubuntu Action that's recently failing (possibly due to the recent upgrade of CI machines to Ubuntu 20.04). It seems that `mpi` needs to be manually installed, which is now done by listing `openmpi` as a test dependency.