### PR TITLE
Add support for GPU solvers via CuPy library

### DIFF
--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -705,6 +705,7 @@ class GenericTransport(GenericAlgorithm):
                 r"""
                 Wrapper method for CuPy sparse linear solvers.
                 """
+                x0 = cupy.array(x0) if x0 is not None else x0
                 b = cupy.array(b)
                 A = cupy.sparse.csr_matrix(A)
                 direct = ["spsolve", "lsqr", "lschol"]

--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -671,7 +671,7 @@ class GenericTransport(GenericAlgorithm):
                 x = ml.solve(b=b, x0=x0, tol=rtol, maxiter=max_it, accel="bicgstab")
                 return x
         # PyPardiso
-        elif self.settings['solver_family'] == 'pypardiso':
+        elif self.settings['solver_family'] in ['pypardiso', 'pardiso']:
             try:
                 import pypardiso
             except ModuleNotFoundError:

--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -705,7 +705,7 @@ class GenericTransport(GenericAlgorithm):
                 r"""
                 Wrapper method for CuPy sparse linear solvers.
                 """
-                x0 = cupy.array(x0) if x0 is not None else x0
+                x0 = x0 if x0 is None else cupy.array(x0)
                 b = cupy.array(b)
                 A = cupy.sparse.csr_matrix(A)
                 direct = ["spsolve", "lsqr", "lschol"]

--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -690,6 +690,16 @@ class GenericTransport(GenericAlgorithm):
                 """
                 x = pypardiso.spsolve(A=A, b=b)
                 return x
+        # CuPy
+        elif self.settings['solver_family'] == 'cupy':
+            def solver(A, b, rtol=None, max_it=None, x0=None, **kwargs):
+                r"""
+                Wrapper method for CuPy sparse linear solvers.
+                """
+                import cupy
+                import cupyx.linalg.sparse
+                x = cupyx.linalg.sparse.lschol(A, cupy.array(b))
+                return cupy.asnumpy(x)
         else:
             raise Exception(f"{self.settings['solver_family']} not available.")
 

--- a/openpnm/algorithms/GenericTransport.py
+++ b/openpnm/algorithms/GenericTransport.py
@@ -619,7 +619,7 @@ class GenericTransport(GenericAlgorithm):
         # Fetch solver object based on settings dict.
         solver = self._get_solver()
         x = solver(A, b, atol=atol, rtol=rtol, max_it=max_it, x0=x0)
-        
+
         # Check solution convergence
         if not self._is_converged(x=x):
             raise Exception("Solver did not converge.")
@@ -696,9 +696,13 @@ class GenericTransport(GenericAlgorithm):
                 r"""
                 Wrapper method for CuPy sparse linear solvers.
                 """
-                import cupy
-                import cupyx.scipy.sparse.linalg
-                cupyx.scipy.sparse.linalg.lschol = cupyx.linalg.sparse.lschol
+                try:
+                    import cupy
+                    import cupyx.scipy.sparse.linalg
+                    cupyx.scipy.sparse.linalg.lschol = cupyx.linalg.sparse.lschol
+                except ModuleNotFoundError:
+                    msg = "CuPy not found. Install via: conda install -c conda-forge cupy"
+                    raise Exception(msg)
                 b = cupy.array(b)
                 A = cupy.sparse.csr_matrix(A)
                 direct = ["spsolve", "lsqr", "lschol"]


### PR DESCRIPTION
This PR adds support for the following GPU solvers via `cupy`:

- **Iterative**: `cg`, `gmres`
- **Direct**: `spsolve`, `lschol`, `lsqr`

The iterative methods are significantly faster than their `scipy` equivalent (~20-100X), but since we need to copy A and b from CPU to GPU at every iteration, the actual speed up I could get was ~7-8X, which is still great, but not as great as it could be.

The API is similar to what we're used to, i.e.
```python
alg.set_solver(solver_family="cupy", solver_type="lsqr")
```
where `alg` is an `openpnm` algorithm object.

**Note**: Since GitHub Actions instances don't have GPU, I excluded cupy wrappers from coverage.