### PR TITLE
Enhance tic/toc

### DIFF
--- a/openpnm/utils/misc.py
+++ b/openpnm/utils/misc.py
@@ -9,6 +9,7 @@ import scipy.sparse
 import time as _time
 from collections import OrderedDict
 from docrep import DocstringProcessor
+from IPython.core.magics.execution import _format_time
 
 __all__ = [
     "Docorator",
@@ -301,9 +302,8 @@ def toc(quiet=False):
     if "_startTime_for_tictoc" in globals():
         t = _time.time() - _startTime_for_tictoc
         if quiet is False:
-            print(f"Elapsed time in seconds: {t:0.2f}")
-        else:
-            return t
+            print(f"Elapsed time: {_format_time(t)}")
+        return t
     else:
         raise Exception("Start time not set, call tic first")
 

--- a/openpnm/utils/misc.py
+++ b/openpnm/utils/misc.py
@@ -299,13 +299,12 @@ def toc(quiet=False):
     tic
 
     """
-    if "_startTime_for_tictoc" in globals():
-        t = _time.time() - _startTime_for_tictoc
-        if quiet is False:
-            print(f"Elapsed time: {_format_time(t)}")
-        return t
-    else:
+    if "_startTime_for_tictoc" not in globals():
         raise Exception("Start time not set, call tic first")
+    t = _time.time() - _startTime_for_tictoc
+    if quiet is False:
+        print(f"Elapsed time: {_format_time(t)}")
+    return t
 
 
 def unique_list(input_list):

--- a/tests/unit/utils/UtilsTest.py
+++ b/tests/unit/utils/UtilsTest.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import openpnm as op
+from time import sleep
 
 
 class UtilsTest:
@@ -18,8 +19,13 @@ class UtilsTest:
         with pytest.raises(Exception):
             op.utils.toc()
         op.utils.tic()
+        sleep(0.5)
         t1 = op.utils.toc(quiet=True)
         assert t1 >= 0
+        op.utils.tic()
+        sleep(0.5)
+        t2 = op.utils.toc()
+        assert t2 >= 0
 
     def test_nested_dict(self):
         d = op.utils.NestedDict()

--- a/tests/unit/utils/UtilsTest.py
+++ b/tests/unit/utils/UtilsTest.py
@@ -7,9 +7,8 @@ class UtilsTest:
 
     def setup_class(self):
         self.net = op.network.Cubic(shape=[3, 3, 3])
-        self.geo = op.geometry.StickAndBall(network=self.net,
-                                            pores=self.net.Ps,
-                                            throats=self.net.Ts)
+        self.geo = op.geometry.StickAndBall(
+            network=self.net, pores=self.net.Ps, throats=self.net.Ts)
 
     def teardown_class(self):
         ws = op.Workspace()
@@ -19,10 +18,8 @@ class UtilsTest:
         with pytest.raises(Exception):
             op.utils.toc()
         op.utils.tic()
-        t1 = op.utils.toc()
-        assert t1 is None
-        t2 = op.utils.toc(quiet=True)
-        assert t2 >= 0
+        t1 = op.utils.toc(quiet=True)
+        assert t1 >= 0
 
     def test_nested_dict(self):
         d = op.utils.NestedDict()


### PR DESCRIPTION
- [x] Use IPython's timeit backend to format time duration
- [x] `toc` should always return time even in non-quiet mode

```python
from openpnm.utils import tic, toc
from time import sleep

tic()
sleep(50e-3)
toc()  # Elapsed time: 60 ms

tic()
sleep(1.3)
toc()  # Elapsed time: 1.3 s
```
