### PR TITLE
Add docrep version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more details about the package can be found in the [on-line documentation](h
 
 ## Stay Informed
 
-It's surprizingly hard to communicate with our users, since Github doesn't allow sending out email newsletters or announcements. To address this gap, we have created a [Substack channel](https://openpnm.substack.com/), where you can subscribe to our feed to receive periodic news about important events and updates.  Also, follow us on Twitter [(@OpenPnm)](https://twitter.com/OpenPnm) for periodic announcements about new releases and other important events.
+It is surprizingly hard to communicate with our users, since Github doesn't allow sending out email newsletters or announcements. To address this gap, we have created a [Substack channel](https://openpnm.substack.com/), where you can subscribe to our feed to receive periodic news about important events and updates.  Also, follow us on Twitter [(@OpenPnm)](https://twitter.com/OpenPnm) for periodic announcements about new releases and other important events.
 
 ## Installation and Requirements
 

--- a/requirements/conda_requirements.txt
+++ b/requirements/conda_requirements.txt
@@ -1,5 +1,5 @@
 chemicals
-docrep
+docrep>=0.3
 flatdict
 gitpython
 h5py

--- a/requirements/pip_requirements.txt
+++ b/requirements/pip_requirements.txt
@@ -1,4 +1,4 @@
-docrep
+docrep>=0.3
 flatdict
 gitpython
 h5py

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         'gitpython',
         'jsonschema',
         'terminaltables',
-        'docrep',
+        'docrep>=0.3',
         'json-tricks',
     ],
     author='OpenPNM Team',


### PR DESCRIPTION
This PR closes #1946. Docrep minimum version is added to make sure about compatibility.