### PR TITLE
Updating math functions in misc to accept an array of props instead of individual args

### DIFF
--- a/openpnm/core/ModelsMixin.py
+++ b/openpnm/core/ModelsMixin.py
@@ -114,8 +114,13 @@ class ModelsDict(PrintableDict):
             # Filter pore/throat props only
             dependencies = set()
             for param in self[model].values():
-                if is_valid_propname(param):
-                    dependencies.add(param)
+                if type(param) == list:
+                    for element in param:
+                        if is_valid_propname(element):
+                            dependencies.add(element)
+                else:
+                    if is_valid_propname(param):
+                        dependencies.add(param)
             # Add depenency from model's parameters
             for d in dependencies:
                 if not deep:

--- a/openpnm/geometry/CirclesAndRectangles.py
+++ b/openpnm/geometry/CirclesAndRectangles.py
@@ -78,8 +78,7 @@ class CirclesAndRectangles(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.circle,

--- a/openpnm/geometry/ConesAndCylinders.py
+++ b/openpnm/geometry/ConesAndCylinders.py
@@ -82,8 +82,7 @@ class ConesAndCylinders(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.sphere,

--- a/openpnm/geometry/CubesAndCuboids.py
+++ b/openpnm/geometry/CubesAndCuboids.py
@@ -78,8 +78,7 @@ class CubesAndCuboids(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.cube,

--- a/openpnm/geometry/PyramidsAndCuboids.py
+++ b/openpnm/geometry/PyramidsAndCuboids.py
@@ -78,8 +78,7 @@ class PyramidsAndCuboids(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.sphere,

--- a/openpnm/geometry/SpheresAndCylinders.py
+++ b/openpnm/geometry/SpheresAndCylinders.py
@@ -78,8 +78,7 @@ class SpheresAndCylinders(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.sphere,

--- a/openpnm/geometry/SquaresAndRectangles.py
+++ b/openpnm/geometry/SquaresAndRectangles.py
@@ -78,8 +78,7 @@ class SquaresAndRectangles(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.square,

--- a/openpnm/geometry/StickAndBall.py
+++ b/openpnm/geometry/StickAndBall.py
@@ -80,8 +80,7 @@ class StickAndBall(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.area',
                        model=mods.geometry.pore_cross_sectional_area.sphere,

--- a/openpnm/geometry/StickAndBall2D.py
+++ b/openpnm/geometry/StickAndBall2D.py
@@ -184,8 +184,7 @@ class StickAndBall2D(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.area',
                        model=mods.geometry.pore_cross_sectional_area.circle,

--- a/openpnm/geometry/TrapezoidsAndRectangles.py
+++ b/openpnm/geometry/TrapezoidsAndRectangles.py
@@ -78,8 +78,7 @@ class TrapezoidsAndRectangles(GenericGeometry):
 
         self.add_model(propname='pore.diameter',
                        model=mods.misc.product,
-                       prop1='pore.max_size',
-                       prop2='pore.seed')
+                       props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.volume',
                        model=mods.geometry.pore_volume.circle,

--- a/openpnm/models/misc/basic_math.py
+++ b/openpnm/models/misc/basic_math.py
@@ -162,7 +162,7 @@ def product(target, props):
     value : NumPy ndarray
         Array containing product values of ``target[props[0]]``, ``target[props[1]], etc``
     """
-    value = 1
+    value = np.ones_like(target[props[0]])
     for item in props:
         value *= target[item]
     return value

--- a/openpnm/models/misc/basic_math.py
+++ b/openpnm/models/misc/basic_math.py
@@ -160,7 +160,7 @@ def product(target, props):
     Returns
     -------
     value : NumPy ndarray
-        Array containing product values of ``target[props[0]]``, ``target[props[1]], etc``
+        Array containing product values of ``target[props[0]]``, ``target[props[1]]``, etc.
     """
     value = np.ones_like(target[props[0]])
     for item in props:

--- a/openpnm/models/misc/basic_math.py
+++ b/openpnm/models/misc/basic_math.py
@@ -143,7 +143,7 @@ def constant(target, value):
     return value
 
 
-def product(target, prop1, prop2, **kwargs):
+def product(target, props):
     r"""
     Calculates the product of multiple property values
 
@@ -154,26 +154,16 @@ def product(target, prop1, prop2, **kwargs):
         length of the calculated array, and also provides access to other
         necessary properties.
 
-    prop1 : string
-        The name of the first argument
-
-    prop2 : string
-        The name of the second argument
+    props : Array of string
+        The name of the arguments to be used for the product.
 
     Returns
     -------
     value : NumPy ndarray
-        Array containing product values of ``target[prop1]``, ``target[prop2]``
-
-    Notes
-    -----
-    Additional properties can be specified beyond just ``prop1`` and ``prop2``
-    by including additional arguments in the function call (i.e. ``prop3 =
-    'pore.foo'``).
-
+        Array containing product values of ``target[props[0]]``, ``target[props[1]], etc``
     """
-    value = target[prop1]*target[prop2]
-    for item in kwargs.values():
+    value = 1
+    for item in props:
         value *= target[item]
     return value
 

--- a/tests/unit/core/ModelsTest.py
+++ b/tests/unit/core/ModelsTest.py
@@ -20,8 +20,9 @@ class ModelsTest:
         net = op.network.Cubic(shape=[3, 3, 3])
         geo = op.geometry.StickAndBall(network=net, pores=net.Ps,
                                        throats=net.Ts)
+
         s = geo.models.__str__().split('\n')
-        assert len(s) == 69
+        assert len(s) == 68
         assert s.count('―'*85) == 15
 
     def test_regenerate_models(self):

--- a/tests/unit/models/misc/MiscTest.py
+++ b/tests/unit/models/misc/MiscTest.py
@@ -27,17 +27,14 @@ class MiscTest:
                            value=2)
         self.geo.add_model(model=mods.product,
                            propname='pore.result1',
-                           prop1='pore.value1',
-                           prop2='pore.value2')
+                           props=['pore.value1', 'pore.value2'])
         assert np.all(np.unique(self.geo['pore.result1']) == 4)
         self.geo.add_model(model=mods.constant,
                            propname='pore.value3',
                            value=2)
         self.geo.add_model(model=mods.product,
                            propname='pore.result2',
-                           prop1='pore.value1',
-                           prop2='pore.value2',
-                           prop3='pore.value3')
+                           props=['pore.value1', 'pore.value2', 'pore.value3'])
         assert np.all(np.unique(self.geo['pore.result2']) == 8)
 
     def test_generic_function(self):


### PR DESCRIPTION
This PR closes  #1919. Currently, the product function accepts the arguments separately. Current product function can multiply more than two arguemnts (accepts **kwarg), but they all need to be passed individually. The function should accept the props in a list.
To do:
- [x] change the function
- [x] change in the examples,etc
- [x] test file (current test file already tests the product function)
Fixed this problem: Notes: the dependency list will be changed. Probably related to finding the model prop in dependency grpah (now we have props as an array). Looking into the problem.
Problem:
```python
import openpnm as op
import numpy as np
net = op.network.Cubic(shape=[3, 3, 3])
geom = op.geometry.GenericGeometry(network=net,
                                   pores=net.Ps)
geom['pore.max_size'] = 0.4

geom.add_model(propname='pore.seed',
               model=mods.misc.random,
               element='pore',
               num_range=[0, 0.1],
               seed=None)

geom.add_model(propname='pore.diameter',
               model=mods.misc.product,
               props=['pore.max_size', 'pore.seed'],
               regen_mode='normal')

geom.add_model(propname='pore.volume',
               model=mods.geometry.pore_volume.sphere,
               pore_diameter='pore.diameter',
               regen_mode='normal')


geom.add_model(propname='pore.area',
               model=mods.geometry.pore_cross_sectional_area.sphere,
               pore_diameter='pore.diameter',
               regen_mode='normal')


tree = np.asarray(geom.models.dependency_list())
print(tree)
# output: ['pore.diameter' 'pore.area' 'pore.seed' 'pore.volume']

# desired output: ['pore.seed' 'pore.diameter' 'pore.area' 'pore.volume']
```