### PR TITLE
A more restrained attempt to refactor Base

### DIFF
--- a/openpnm/algorithms/GenericAlgorithm.py
+++ b/openpnm/algorithms/GenericAlgorithm.py
@@ -1,4 +1,4 @@
-from openpnm.core import Base
+from openpnm.core import Base, LegacyMixin, LabelMixin
 from openpnm.utils import logging, Docorator
 import numpy as np
 logger = logging.getLogger(__name__)
@@ -7,7 +7,7 @@ docstr = Docorator()
 
 @docstr.get_sections(base='GenericAlgorithm', sections=['Parameters'])
 @docstr.dedent
-class GenericAlgorithm(Base):
+class GenericAlgorithm(Base, LegacyMixin, LabelMixin):
     r"""
     Generic class to define the foundation of Algorithms.
 

--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -21,119 +21,10 @@ class Base(dict):
         then a new Project is created
     name : string, optional
         The unique name of the object.  If not given one will be generated.
-
     Np : int, default is 0
         The total number of pores to be assigned to the object
     Nt : int, default is 0
         The total number of throats to be assigned to the object
-
-    Notes
-    -----
-    This Base class is used as the template for all other OpenPNM objects,
-    including Networks, Geometries, Phases, Physics, and Algorithms.  This
-    class is a subclass of the standard ``dict`` so has the usual methods such
-    as ``pop`` and ``keys``, and has extra methods for working specifically
-    with OpenPNM data.  These are outlined briefly in the following table:
-
-    +----------------------+--------------------------------------------------+
-    | Method or Attribute  | Functionality                                    |
-    +======================+==================================================+
-    | ``props``            | List of keys containing numerical arrays         |
-    +----------------------+--------------------------------------------------+
-    | ``labels``           | List of key containing boolean arrays            |
-    +----------------------+--------------------------------------------------+
-    | ``pores``            | Returns pore / throat indices that have given    |
-    |                      | labels                                           |
-    | ``throats``          |                                                  |
-    +----------------------+--------------------------------------------------+
-    | ``Ps``, ``Ts``       | Indices for ALL pores and throats on object      |
-    +----------------------+--------------------------------------------------+
-    | ``num_pores`` ,      | Counts the number of pores or throats with a     |
-    |                      | given label                                      |
-    | ``num_throats``      |                                                  |
-    +----------------------+--------------------------------------------------+
-    | ``Np``, ``Nt``       | Total number of pores and throats on the object  |
-    +----------------------+--------------------------------------------------+
-    | ``tomask``           | Converts a list of pore or throat indices to a   |
-    |                      | boolean mask                                     |
-    +----------------------+--------------------------------------------------+
-    | ``toindices``        | Converts a boolean mask to pore or throat indices|
-    +----------------------+--------------------------------------------------+
-    | ``map_pores`` ,      | Given indices on object B returns corresponding  |
-    |                      | indices on object A                              |
-    | ``map_throats``      |                                                  |
-    +----------------------+--------------------------------------------------+
-    | ``interleave_data``  | Fetches data from associated objects into a      |
-    |                      | single array                                     |
-    +----------------------+--------------------------------------------------+
-    | ``interpolate_data`` | Given pore or throat data, interpolate the other |
-    +----------------------+--------------------------------------------------+
-    | ``filter_by_label``  | Given indices find those with specific labels    |
-    +----------------------+--------------------------------------------------+
-    | ``show_hist``        | Method for quickly plotting histograms of data   |
-    +----------------------+--------------------------------------------------+
-    | ``check_data_health``| Ensures all data arrays are valid and complete   |
-    +----------------------+--------------------------------------------------+
-
-
-    In addition to the above methods, there are a few attributes which provide
-    access to useful items:
-
-    +----------------+--------------------------------------------------------+
-    | Attribute      | Functionality                                          |
-    +================+========================================================+
-    | ``name``       | The string name of the object, unique to each Project  |
-    +----------------+--------------------------------------------------------+
-    | ``settings``   | A dictionary containing various setting values         |
-    +----------------+--------------------------------------------------------+
-    | ``project``    | A handle to the Project containing the object          |
-    +----------------+--------------------------------------------------------+
-
-    Examples
-    --------
-    It is possible to create an instance of Base, although it is not very
-    useful except for demonstration purposes as done here.
-
-    >>> import openpnm as op
-    >>> obj = op.core.Base(Np=4, Nt=5)
-
-    Now query the object for its basic properties:
-
-    >>> obj.Np, obj.Nt  # Number of pores and throats
-    (4, 5)
-
-    Add a label to the object, as a boolean with True where the label applies:
-
-    >>> obj['pore.new_label'] = [ True, False, False, True]
-
-    See list of available labels and confirm new_label was added:
-
-    >>> print(obj.labels())
-    ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
-    1     : pore.all
-    2     : pore.new_label
-    3     : throat.all
-    ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
-
-    Use the label to fetch pores where it was applied:
-
-    >>> Ps = obj.pores('new_label')
-    >>> print(Ps)
-    [0 3]
-
-    Find the number of pores with label:
-
-    >>> print(obj.num_pores('new_label'))
-    2
-
-    Convert between indices and boolean mask
-
-    >>> mask = obj.tomask(throats=[0, 2, 4])
-    >>> print(mask)
-    [ True False  True False  True]
-    >>> inds = obj.toindices(mask)
-    >>> print(inds)
-    [0 2 4]
 
     """
 
@@ -146,12 +37,15 @@ class Base(dict):
         instance.settings['_uuid'] = str(uuid.uuid4())
         return instance
 
-    def __init__(self, Np=0, Nt=0, name=None, project=None, settings={}):
+    def __init__(self, Np=0, Nt=0, name=None, project=None, network=None, settings={}):
         self.settings.setdefault('prefix', 'base')
         self.settings.update(settings)
         super().__init__()
         if project is None:
-            project = ws.new_project()
+            if network is None:
+                project = ws.new_project()
+            else:
+                project = network.project
         if name is None:
             name = project._generate_name(self)
         project._validate_name(name)
@@ -170,7 +64,7 @@ class Base(dict):
         r"""
         This is a subclass of the default __setitem__ behavior.  The main aim
         is to limit what type and shape of data can be written to protect
-        the integrity of the network.  Specifically, this means only Np or Nt
+        the integrity of the data.  Specifically, this means only Np or Nt
         long arrays can be written, and they must be called 'pore.***' or
         'throat.***'.  Also, any scalars are cast into full length vectors.
 
@@ -273,12 +167,6 @@ class Base(dict):
         elif hasattr(self, 'models') and key in self.models:
             self.regenerate_models(key)
             vals = super().__getitem__(key)
-        # The following is probably a bad idea, but just trying it for fun
-        # elif self.settings['interpolation_mode'] is not None:
-        #     temp = list(set(['pore', 'throat']).difference(set([element])))[0]
-        #     vals = self.interpolate_data(temp + '.' + prop,
-        #                                  mode=self.settings['interpolation_mode'])
-        #     self[element + '.' + prop] = vals
         else:
             raise KeyError(key)
         return vals
@@ -565,474 +453,28 @@ class Base(dict):
                     vals += item.props(element=element, mode=mode, deep=False)
         return vals
 
-    def _get_labels(self, element, locations, mode):
-        r"""
-        This is the actual label getter method, but it should not be called
-        directly.  Use ``labels`` instead.
-        """
-        # Parse inputs
-        locations = self._parse_indices(locations)
-        element = self._parse_element(element=element)
-        # Collect list of all pore OR throat labels
-        labels = self.keys(mode='labels', element=element)
-        labels.sort()
-        labels = np.array(labels)  # Convert to ND-array for following checks
-        # Make an 2D array with locations in rows and labels in cols
-        arr = np.vstack([self[item][locations] for item in labels]).T
-        num_hits = np.sum(arr, axis=0)  # Number of locations with each label
-        if mode in ['or', 'union', 'any']:
-            temp = labels[num_hits > 0]
-        elif mode in ['and', 'intersection']:
-            temp = labels[num_hits == locations.size]
-        elif mode in ['xor', 'exclusive_or']:
-            temp = labels[num_hits == 1]
-        elif mode in ['nor', 'not', 'none']:
-            temp = labels[num_hits == 0]
-        elif mode in ['nand']:
-            temp = labels[num_hits == (locations.size - 1)]
-        elif mode in ['xnor', 'nxor']:
-            temp = labels[num_hits > 1]
-        else:
-            raise Exception('Unrecognized mode:'+str(mode))
-        return PrintableList(temp)
+    @property
+    def Np(self):
+        return self._N('pore')
 
-    def labels(self, pores=[], throats=[], element=None, mode='union'):
-        r"""
-        Returns a list of labels present on the object
+    @property
+    def Nt(self):
+        return self._N('throat')
 
-        Additionally, this function can return labels applied to a specified
-        set of pores or throats
-
-        Parameters
-        ----------
-        element : string
-            Controls whether pore or throat labels are returned.  If empty then
-            both are returned (default).
-
-        pores (or throats) : array_like
-            The pores (or throats) whose labels are sought.  If left empty a
-            list containing all pore and throat labels is returned.
-
-        mode : string, optional
-            Controls how the query should be performed.  Only applicable
-            when ``pores`` or ``throats`` are specified:
-
-            **'or', 'union', 'any'**: (default) Returns the labels that are
-            assigned to *any* of the given locations.
-
-            **'and', 'intersection', 'all'**: Labels that are present on *all*
-            the given locations.
-
-            **'xor', 'exclusive_or'** : Labels that are present on *only one*
-            of the given locations.
-
-            **'nor', 'none', 'not'**: Labels that are *not* present on any of
-            the given locations.
-
-            **'nand'**: Labels that are present on *all but one* of the given
-            locations
-
-            **'xnor'**: Labels that are present on *more than one* of the given
-            locations.  'nxor' is also accepted.
-
-        Returns
-        -------
-        A list containing the labels on the object.  If ``pores`` or
-        ``throats`` are given, the results are filtered according to the
-        specified ``mode``.
-
-        See Also
-        --------
-        props
-        keys
-
-        Notes
-        -----
-        Technically, *'nand'* and *'xnor'* should also return pores with *none*
-        of the labels but these are not included.  This makes the returned list
-        more useful.
-
-        Examples
-        --------
-        >>> import openpnm as op
-        >>> pn = op.network.Cubic(shape=[5, 5, 5])
-        >>> pn.labels(pores=[11, 12])
-        ['pore.all', 'pore.internal', 'pore.left', 'pore.surface']
-        """
-        # Short-circuit query when no pores or throats are given
-        if (np.size(pores) == 0) and (np.size(throats) == 0):
-            labels = PrintableList(self.keys(element=element, mode='labels'))
-        elif (np.size(pores) > 0) and (np.size(throats) > 0):
-            raise Exception('Cannot perform label query on pores and '
-                            + 'throats simultaneously')
-        elif np.size(pores) > 0:
-            labels = self._get_labels(element='pore', locations=pores,
-                                      mode=mode)
-        elif np.size(throats) > 0:
-            labels = self._get_labels(element='throat', locations=throats,
-                                      mode=mode)
-        return labels
-
-    def set_label(self, label, pores=None, throats=None, mode='add'):
-        r"""
-        Creates or updates a label array
-
-        Parameters
-        ----------
-        label : string
-                The label to apply to the specified locations
-        pores : array_like
-            A list of pore indices or a boolean mask of where given label
-            should be added or removed (see ``mode``)
-        throats : array_like
-            A list of throat indices or a boolean mask of where given label
-            should be added or removed (see ``mode``)
-        mode : string
-            Controls how the labels are handled.  Options are:
-
-            *'add'* - Adds the given label to the specified locations while
-            keeping existing labels (default)
-
-            *'overwrite'* - Removes existing label from all locations before
-            adding the label in the specified locations
-
-            *'remove'* - Removes the  given label from the specified locations
-            leaving the remainder intact.
-
-            *'purge'* - Removes the specified label from the object
-
-        """
-        if mode == 'purge':
-            if label.split('.')[0] in ['pore', 'throat']:
-                if label in self.labels():
-                    del self[label]
-                else:
-                    logger.warning(label + ' is not a label, skpping')
-            else:
-                self.set_label(label='pore.'+label, mode='purge')
-                self.set_label(label='throat.'+label, mode='purge')
-        else:
-            if label.split('.')[0] in ['pore', 'throat']:
-                label = label.split('.', 1)[1]
-            if pores is not None:
-                pores = self._parse_indices(pores)
-                if (mode == 'overwrite') or ('pore.'+label not in self.labels()):
-                    self['pore.' + label] = False
-                if mode in ['remove']:
-                    self['pore.' + label][pores] = False
-                else:
-                    self['pore.' + label][pores] = True
-            if throats is not None:
-                throats = self._parse_indices(throats)
-                if (mode == 'overwrite') or ('throat.'+label not in self.labels()):
-                    self['throat.' + label] = False
-                if mode in ['remove']:
-                    self['throat.' + label][throats] = False
-                else:
-                    self['throat.' + label][throats] = True
-            if pores is None and throats is None:
-                del self
-
-    def _get_indices(self, element, labels='all', mode='or'):
-        r"""
-        This is the actual method for getting indices, but should not be called
-        directly.  Use ``pores`` or ``throats`` instead.
-        """
-        # Parse and validate all input values.
-        element = self._parse_element(element, single=True)
-        labels = self._parse_labels(labels=labels, element=element)
-        if element+'.all' not in self.keys():
-            raise Exception('Cannot proceed without {}.all'.format(element))
-
-        # Begin computing label array
-        if mode in ['or', 'any', 'union']:
-            union = np.zeros_like(self[element+'.all'], dtype=bool)
-            for item in labels:  # Iterate over labels and collect all indices
-                union = union + self[element+'.'+item.split('.')[-1]]
-            ind = union
-        elif mode in ['and', 'all', 'intersection']:
-            intersect = np.ones_like(self[element+'.all'], dtype=bool)
-            for item in labels:  # Iterate over labels and collect all indices
-                intersect = intersect*self[element+'.'+item.split('.')[-1]]
-            ind = intersect
-        elif mode in ['xor', 'exclusive_or']:
-            xor = np.zeros_like(self[element+'.all'], dtype=int)
-            for item in labels:  # Iterate over labels and collect all indices
-                info = self[element+'.'+item.split('.')[-1]]
-                xor = xor + np.int8(info)
-            ind = (xor == 1)
-        elif mode in ['nor', 'not', 'none']:
-            nor = np.zeros_like(self[element+'.all'], dtype=int)
-            for item in labels:  # Iterate over labels and collect all indices
-                info = self[element+'.'+item.split('.')[-1]]
-                nor = nor + np.int8(info)
-            ind = (nor == 0)
-        elif mode in ['nand']:
-            nand = np.zeros_like(self[element+'.all'], dtype=int)
-            for item in labels:  # Iterate over labels and collect all indices
-                info = self[element+'.'+item.split('.')[-1]]
-                nand = nand + np.int8(info)
-            ind = (nand < len(labels)) * (nand > 0)
-        elif mode in ['xnor', 'nxor']:
-            xnor = np.zeros_like(self[element+'.all'], dtype=int)
-            for item in labels:  # Iterate over labels and collect all indices
-                info = self[element+'.'+item.split('.')[-1]]
-                xnor = xnor + np.int8(info)
-            ind = (xnor > 1)
-        else:
-            raise Exception('Unsupported mode: '+mode)
-        # Extract indices from boolean mask
-        ind = np.where(ind)[0]
-        ind = ind.astype(dtype=int)
-        return ind
-
-    def pores(self, labels='all', mode='or', asmask=False, target=None):
-        r"""
-        Returns pore indicies where given labels exist, according to the logic
-        specified by the ``mode`` argument.
-
-        Parameters
-        ----------
-        labels : string or list of strings
-            The label(s) whose pores locations are requested.  This argument
-            also accepts '*' for wildcard searches.
-
-        mode : string
-            Specifies how the query should be performed.  The options are:
-
-            **'or', 'union', 'any'** : (default) Pores with *one or more* of
-            the given labels are returned.
-
-            **'and', 'intersection', 'all'** : Pores with *all* of the given
-            labels are returned.
-
-            **'xor', 'exclusive_or'** : Pores with *only one* of the given
-            labels are returned.
-
-            **'nor', 'none', 'not'** : Pores with *none* of the given labels
-            are returned.
-
-            **'nand'** : Pores with *not all* of the given labels are
-            returned.
-
-            **'xnor'** : Pores with *more than one* of the given labels are
-            returned.
-
-        asmask : boolean
-            If ``True`` then a boolean array of length Np is returned with
-            ``True`` values indicating the pores that satisfy the query.
-
-        target : OpenPNM Base object
-            If given, the returned indices will be indexed relative to the
-            ``target`` object.  This can be used to determine how indices on
-            one object map onto another object.
-
-        Returns
-        -------
-        A Numpy array containing pore indices filtered by the logic specified
-        in ``mode``.
-
-        See Also
-        --------
-        throats
-        map_pores
-
-        Notes
-        -----
-        Technically, *nand* and *xnor* should also return pores with *none* of
-        the labels but these are not included.  This makes the returned list
-        more useful.
-
-        To perform more complex or compound queries, you can opt to receive
-        the result a a boolean mask (``asmask=True``), then manipulate the
-        arrays manually.
-
-        Examples
-        --------
-        >>> import openpnm as op
-        >>> pn = op.network.Cubic(shape=[5, 5, 5])
-        >>> Ps = pn.pores(labels=['top', 'back'], mode='union')
-        >>> Ps[:5]  # Look at first 5 pore indices
-        array([ 4,  9, 14, 19, 20])
-        >>> pn.pores(labels=['top', 'back'], mode='xnor')
-        array([ 24,  49,  74,  99, 124])
-        """
-        ind = self._get_indices(element='pore', labels=labels, mode=mode)
-        if target is not None:
-            ind = target.map_pores(pores=ind, origin=self, filtered=True)
-        if asmask:
-            if target is not None:
-                ind = target.tomask(pores=ind)
-            else:
-                ind = self.tomask(pores=ind)
-        return ind
+    def _N(self, element):
+        if element == 'pore':
+            N = self.project.network['pore.coords'].shape[0]
+        elif element == 'throat':
+            N = self.project.network['throat.conns'].shape[0]
+        return N
 
     @property
     def Ps(self):
-        r"""
-        A shortcut to get a list of all pores on the object
-        """
         return np.arange(0, self.Np)
-
-    def throats(self, labels='all', mode='or', asmask=False, target=None):
-        r"""
-        Returns throat locations where given labels exist, according to the
-        logic specified by the ``mode`` argument.
-
-        Parameters
-        ----------
-        labels : string or list of strings
-            The throat label(s) whose locations are requested.  If omitted,
-            'all' throat inidices are returned.  This argument also accepts
-            '*' for wildcard searches.
-
-        mode : string
-            Specifies how the query should be performed.  The options are:
-
-            **'or', 'union', 'any'** : (default) Throats with *one or more* of
-            the given labels are returned.
-
-            **'and', 'intersection', 'all'** : Throats with *all* of the given
-            labels are returned.
-
-            **'xor', 'exclusive_or'** : Throats with *only one* of the given
-            labels are returned.
-
-            **'nor', 'none', 'not'** : Throats with *none* of the given labels
-            are returned.
-
-            **'nand'** : Throats with *not all* of the given labels are
-            returned.
-
-            **'xnor'** : Throats with *more than one* of the given labels are
-            returned.
-
-        asmask : boolean
-            If ``True`` then a boolean array of length Nt is returned with
-            ``True`` values indicating the throats that satisfy the query.
-
-        target : OpenPNM Base object
-            If given, the returned indices will be indexed relative to the
-            ``target`` object.  This can be used to determine how indices on
-            one object map onto another object.
-
-        Returns
-        -------
-        A Numpy array containing throat indices filtered by the logic specified
-        in ``mode``.
-
-        See Also
-        --------
-        pores
-        map_throats
-
-        Examples
-        --------
-        >>> import openpnm as op
-        >>> pn = op.network.Cubic(shape=[3, 3, 3])
-        >>> Ts = pn.throats()
-        >>> Ts[0:5]  # Look at first 5 throat indices
-        array([0, 1, 2, 3, 4])
-
-        """
-        ind = self._get_indices(element='throat', labels=labels, mode=mode)
-        if target is not None:
-            ind = target.map_throats(throats=ind, origin=self, filtered=True)
-        if asmask:
-            if target is not None:
-                ind = target.tomask(throats=ind)
-            else:
-                ind = self.tomask(throats=ind)
-        return ind
 
     @property
     def Ts(self):
-        r"""
-        A shortcut to get a list of all throats on the object
-        """
         return np.arange(0, self.Nt)
-
-    def _map(self, ids, element, filtered):
-        ids = np.array(ids, dtype=np.int64)
-        locations = self._get_indices(element=element)
-        self_in_ids = np.isin(ids, self[element+'._id'], assume_unique=True)
-        ids_in_self = np.isin(self[element+'._id'], ids, assume_unique=True)
-        mask = np.zeros(shape=ids.shape, dtype=bool)
-        mask[self_in_ids] = True
-        ind = np.ones_like(mask, dtype=np.int64) * -1
-        ind[self_in_ids] = locations[ids_in_self]
-        if filtered:
-            return ind[mask]
-        t = namedtuple('index_map', ('indices', 'mask'))
-        return t(ind, mask)
-
-    def map_pores(self, pores, origin, filtered=True):
-        r"""
-        Given a list of pore on a target object, finds indices of those pores
-        on the calling object
-
-        Parameters
-        ----------
-        pores : array_like
-            The indices of the pores on the object specifiedin ``origin``
-
-        origin : OpenPNM Base object
-            The object corresponding to the indices given in ``pores``
-
-        filtered : boolean (default is ``True``)
-            If ``True`` then a ND-array of indices is returned with missing
-            indices removed, otherwise a named-tuple containing both the
-            ``indices`` and a boolean ``mask`` with ``False`` indicating
-            which locations were not found.
-
-        Returns
-        -------
-        Pore indices on the calling object corresponding to the same pores
-        on the ``origin`` object.  Can be an array or a tuple containing an
-        array and a mask, depending on the value of ``filtered``.
-
-        See Also
-        --------
-        pores
-        map_throats
-
-        """
-        ids = origin['pore._id'][pores]
-        return self._map(element='pore', ids=ids, filtered=filtered)
-
-    def map_throats(self, throats, origin, filtered=True):
-        r"""
-        Given a list of throats on a target object, finds indices of
-        those throats on the calling object
-
-        Parameters
-        ----------
-        throats : array_like
-            The indices of the throats on the object specified in ``origin``
-
-        origin : OpenPNM Base object
-            The object corresponding to the indices given in ``throats``
-
-        filtered : boolean (default is ``True``)
-            If ``True`` then a ND-array of indices is returned with missing
-            indices removed, otherwise a named-tuple containing both the
-            ``indices`` and a boolean ``mask`` with ``False`` indicating
-            which locations were not found.
-
-        Returns
-        -------
-        Throat indices on the calling object corresponding to the same throats
-        on the ``origin`` object.  Can be an array or a tuple containing an
-        array and a mask, depending on the value of ``filtered``.
-
-        See Also
-        --------
-        throats
-        map_pores
-
-        """
-        ids = origin['throat._id'][throats]
-        return self._map(element='throat', ids=ids, filtered=filtered)
 
     def _tomask(self, indices, element):
         r"""
@@ -1047,7 +489,7 @@ class Base(dict):
         mask[ind] = True
         return mask
 
-    def tomask(self, pores=None, throats=None):
+    def to_mask(self, pores=None, throats=None):
         r"""
         Convert a list of pore or throat indices into a boolean mask of the
         correct length
@@ -1090,7 +532,7 @@ class Base(dict):
             raise Exception('Cannot specify both pores and throats')
         return mask
 
-    def toindices(self, mask):
+    def to_indices(self, mask):
         r"""
         Convert a boolean mask to a list of pore or throat indices
 
@@ -1244,7 +686,7 @@ class Base(dict):
         sizes = [np.size(a) for a in arrs]
         # Convert int arrays to float IF NaNs are expected
         if temp_arr.dtype.name.startswith('int') and \
-           (np.any([i is None for i in arrs]) or np.sum(sizes) != N):
+            (np.any([i is None for i in arrs]) or np.sum(sizes) != N):
             temp_arr = temp_arr.astype(float)
             temp_arr.fill(np.nan)
 
@@ -1254,20 +696,6 @@ class Base(dict):
                 temp_arr[inds] = vals
             else:
                 temp_arr[inds] = dummy_val[atype[0]]
-
-        # Check if any arrays have units, if so then apply them to result
-        # Importing unyt significantly adds to our import time, we also
-        # currently don't use this package extensively, so we're not going
-        # to support it for now.
-
-        # if any([hasattr(a, 'units') for a in arrs]):
-        #     [a.convert_to_mks() for a in arrs if hasattr(a, 'units')]
-        #     units = [a.units.__str__() for a in arrs if hasattr(a, 'units')]
-        #     if len(units) > 0:
-        #         if len(set(units)) == 1:
-        #             temp_arr *= np.array([1]) * getattr(unyt, units[0])
-        #         else:
-        #             raise Exception('Units on the interleaved array are not equal')
 
         return temp_arr
 
@@ -1345,258 +773,6 @@ class Base(dict):
             P1, P2 = self['pore.' + prop][self.network.conns].T
             T = self.interpolate_data(propname='pore.'+prop, mode=mode)
         return np.vstack((P1, T, P2)).T
-
-    def filter_by_label(self, pores=[], throats=[], labels=None, mode='or'):
-        r"""
-        Returns which of the supplied pores (or throats) has the specified
-        label(s)
-
-        Parameters
-        ----------
-        pores, or throats : array_like
-            List of pores or throats to be filtered
-
-        labels : list of strings
-            The labels to apply as a filter
-
-        mode : string
-
-            Controls how the filter is applied.  Options include:
-
-            **'or', 'union', 'any'**: (default) Returns a list of the given
-            locations where *any* of the given labels exist.
-
-            **'and', 'intersection', 'all'**: Only locations where *all* the
-            given labels are found.
-
-            **'xor', 'exclusive_or'**: Only locations where exactly *one* of
-            the given labels are found.
-
-            **'nor', 'none', 'not'**: Only locations where *none* of the given
-            labels are found.
-
-            **'nand'** : Only locations with *some but not all* of the given
-            labels are returned.
-
-            **'xnor'** : Only locations with *more than one* of the given
-            labels are returned.
-
-        Returns
-        -------
-        A list of pores (or throats) that have been filtered according the
-        given criteria.  The returned list is a subset of the received list of
-        pores (or throats).
-
-        See Also
-        --------
-        pores
-        throats
-
-        Examples
-        --------
-        >>> import openpnm as op
-        >>> pn = op.network.Cubic(shape=[5, 5, 5])
-        >>> pn.filter_by_label(pores=[0, 1, 25, 32], labels='left')
-        array([0, 1])
-        >>> Ps = pn.pores(['top', 'bottom', 'back'], mode='or')
-        >>> pn.filter_by_label(pores=Ps, labels=['top', 'back'],
-        ...                    mode='and')
-        array([ 24,  49,  74,  99, 124])
-        """
-        # Convert inputs to locations and element
-        if (np.size(throats) > 0) and (np.size(pores) > 0):
-            raise Exception('Can only filter either pores OR labels')
-        if np.size(pores) > 0:
-            element = 'pore'
-            locations = self._parse_indices(pores)
-        elif np.size(throats) > 0:
-            element = 'throat'
-            locations = self._parse_indices(throats)
-        else:
-            return(np.array([], dtype=int))
-        labels = self._parse_labels(labels=labels, element=element)
-        labels = [element+'.'+item.split('.')[-1] for item in labels]
-        all_locs = self._get_indices(element=element, labels=labels, mode=mode)
-        mask = self._tomask(indices=all_locs, element=element)
-        ind = mask[locations]
-        return locations[ind]
-
-    def num_pores(self, labels='all', mode='or'):
-        r"""
-        Returns the number of pores of the specified labels
-
-        Parameters
-        ----------
-        labels : list of strings, optional
-            The pore labels that should be included in the count.
-            If not supplied, all pores are counted.
-
-        labels : list of strings
-            Label of pores to be returned
-
-        mode : string, optional
-            Specifies how the count should be performed.  The options are:
-
-            **'or', 'union', 'any'** : (default) Pores with *one or more* of
-            the given labels are counted.
-
-            **'and', 'intersection', 'all'** : Pores with *all* of the given
-            labels are counted.
-
-            **'xor', 'exclusive_or'** : Pores with *only one* of the given
-            labels are counted.
-
-            **'nor', 'none', 'not'** : Pores with *none* of the given labels
-            are counted.
-
-            **'nand'** : Pores with *some but not all* of the given labels are
-            counted.
-
-            **'xnor'** : Pores with *more than one* of the given labels are
-            counted.
-
-        Returns
-        -------
-        Np : int
-            Number of pores with the specified labels
-
-        See Also
-        --------
-        num_throats
-        count
-
-        Notes
-        -----
-        Technically, *'nand'* and *'xnor'* should also count pores with *none*
-        of the labels, however, to make the count more useful these are not
-        included.
-
-        Examples
-        --------
-        >>> import openpnm as op
-        >>> pn = op.network.Cubic(shape=[5, 5, 5])
-        >>> pn.num_pores()
-        125
-        >>> pn.num_pores(labels=['top'])
-        25
-        >>> pn.num_pores(labels=['top', 'front'], mode='or')
-        45
-        >>> pn.num_pores(labels=['top', 'front'], mode='xnor')
-        5
-
-        """
-        # Count number of pores of specified type
-        Ps = self._get_indices(labels=labels, mode=mode, element='pore')
-        Np = np.shape(Ps)[0]
-        return Np
-
-    @property
-    def Np(self):
-        r"""
-        A shortcut to query the total number of pores on the object'
-        """
-        return np.shape(self.get('pore.all'))[0]
-
-    def num_throats(self, labels='all', mode='union'):
-        r"""
-        Return the number of throats of the specified labels
-
-        Parameters
-        ----------
-        labels : list of strings, optional
-            The throat labels that should be included in the count.
-            If not supplied, all throats are counted.
-
-        mode : string, optional
-            Specifies how the count should be performed.  The options are:
-
-            **'or', 'union', 'any'** : (default) Throats with *one or more* of
-            the given labels are counted.
-
-            **'and', 'intersection', 'all'** : Throats with *all* of the given
-            labels are counted.
-
-            **'xor', 'exclusive_or'** : Throats with *only one* of the given
-            labels are counted.
-
-            **'nor', 'none', 'not'** : Throats with *none* of the given labels
-            are counted.
-
-            **'nand'** : Throats with *some but not all* of the given labels
-            are counted.
-
-            **'xnor'** : Throats with *more than one* of the given labels are
-            counted.
-
-        Returns
-        -------
-        Nt : int
-            Number of throats with the specified labels
-
-        See Also
-        --------
-        num_pores
-        count
-
-        Notes
-        -----
-        Technically, *'nand'* and *'xnor'* should also count throats with
-        *none* of the labels, however, to make the count more useful these are
-        not included.
-
-        """
-        # Count number of pores of specified type
-        Ts = self._get_indices(labels=labels, mode=mode, element='throat')
-        Nt = np.shape(Ts)[0]
-        return Nt
-
-    @property
-    def Nt(self):
-        r"""
-        A shortcut to query the total number of throats on the object'
-        """
-        return np.shape(self.get('throat.all'))[0]
-
-    def _count(self, element=None):
-        r"""
-        Returns a dictionary containing the number of pores and throats in
-        the network, stored under the keys 'pore' or 'throat'
-
-        Parameters
-        ----------
-        element : string, optional
-            Can be either 'pore' , 'pores', 'throat' or 'throats', which
-            specifies which count to return.
-
-        Returns
-        -------
-        A dictionary containing the number of pores and throats under the
-        'pore' and 'throat' key respectively.
-
-        See Also
-        --------
-        num_pores
-        num_throats
-
-        Notes
-        -----
-        The ability to send plurals is useful for some types of 'programmatic'
-        access.  For instance, the standard argument for locations is pores
-        or throats.  If these are bundled up in a **kwargs dict then you can
-        just use the dict key in count() without removing the 's'.
-
-        Examples
-        --------
-        >>> import openpnm as op
-        >>> pn = op.network.Cubic(shape=[5, 5, 5])
-        >>> pn._count('pore')
-        125
-        >>> pn._count('throat')
-        300
-        """
-        element = self._parse_element(element=element, single=True)
-        temp = np.size(super(Base, self).__getitem__(element+'.all'))
-        return temp
 
     def show_hist(self,
                   props=['pore.diameter', 'throat.diameter', 'throat.length'],
@@ -1922,3 +1098,694 @@ class Base(dict):
         if obj_type.lower() in mro:
             flag = True
         return flag
+
+
+class LabelMixin:
+    r"""
+    This class provides methods for treating boolean arrays as labels
+    """
+
+    def labels(self, pores=[], throats=[], element=None, mode='union'):
+        r"""
+        Returns a list of labels present on the object
+
+        Additionally, this function can return labels applied to a specified
+        set of pores or throats
+
+        Parameters
+        ----------
+        element : string
+            Controls whether pore or throat labels are returned.  If empty then
+            both are returned (default).
+
+        pores (or throats) : array_like
+            The pores (or throats) whose labels are sought.  If left empty a
+            list containing all pore and throat labels is returned.
+
+        mode : string, optional
+            Controls how the query should be performed.  Only applicable
+            when ``pores`` or ``throats`` are specified:
+
+            **'or', 'union', 'any'**: (default) Returns the labels that are
+            assigned to *any* of the given locations.
+
+            **'and', 'intersection', 'all'**: Labels that are present on *all*
+            the given locations.
+
+            **'xor', 'exclusive_or'** : Labels that are present on *only one*
+            of the given locations.
+
+            **'nor', 'none', 'not'**: Labels that are *not* present on any of
+            the given locations.
+
+            **'nand'**: Labels that are present on *all but one* of the given
+            locations
+
+            **'xnor'**: Labels that are present on *more than one* of the given
+            locations.  'nxor' is also accepted.
+
+        Returns
+        -------
+        A list containing the labels on the object.  If ``pores`` or
+        ``throats`` are given, the results are filtered according to the
+        specified ``mode``.
+
+        See Also
+        --------
+        props
+        keys
+
+        Notes
+        -----
+        Technically, *'nand'* and *'xnor'* should also return pores with *none*
+        of the labels but these are not included.  This makes the returned list
+        more useful.
+
+        Examples
+        --------
+        >>> import openpnm as op
+        >>> pn = op.network.Cubic(shape=[5, 5, 5])
+        >>> pn.labels(pores=[11, 12])
+        ['pore.all', 'pore.internal', 'pore.left', 'pore.surface']
+        """
+        # Short-circuit query when no pores or throats are given
+        if (np.size(pores) == 0) and (np.size(throats) == 0):
+            labels = PrintableList(self.keys(element=element, mode='labels'))
+        elif (np.size(pores) > 0) and (np.size(throats) > 0):
+            raise Exception('Cannot perform label query on pores and '
+                            + 'throats simultaneously')
+        elif np.size(pores) > 0:
+            labels = self._get_labels(element='pore', locations=pores,
+                                      mode=mode)
+        elif np.size(throats) > 0:
+            labels = self._get_labels(element='throat', locations=throats,
+                                      mode=mode)
+        return labels
+
+    def _get_labels(self, element, locations, mode):
+        r"""
+        This is the actual label getter method, but it should not be called
+        directly.  Use ``labels`` instead.
+        """
+        # Parse inputs
+        locations = self._parse_indices(locations)
+        element = self._parse_element(element=element)
+        # Collect list of all pore OR throat labels
+        labels = self.keys(mode='labels', element=element)
+        labels.sort()
+        labels = np.array(labels)  # Convert to ND-array for following checks
+        # Make an 2D array with locations in rows and labels in cols
+        arr = np.vstack([self[item][locations] for item in labels]).T
+        num_hits = np.sum(arr, axis=0)  # Number of locations with each label
+        if mode in ['or', 'union', 'any']:
+            temp = labels[num_hits > 0]
+        elif mode in ['and', 'intersection']:
+            temp = labels[num_hits == locations.size]
+        elif mode in ['xor', 'exclusive_or']:
+            temp = labels[num_hits == 1]
+        elif mode in ['nor', 'not', 'none']:
+            temp = labels[num_hits == 0]
+        elif mode in ['nand']:
+            temp = labels[num_hits == (locations.size - 1)]
+        elif mode in ['xnor', 'nxor']:
+            temp = labels[num_hits > 1]
+        else:
+            raise Exception('Unrecognized mode:'+str(mode))
+        return PrintableList(temp)
+
+    def set_label(self, label, pores=None, throats=None, mode='add'):
+        r"""
+        Creates or updates a label array
+
+        Parameters
+        ----------
+        label : string
+                The label to apply to the specified locations
+        pores : array_like
+            A list of pore indices or a boolean mask of where given label
+            should be added or removed (see ``mode``)
+        throats : array_like
+            A list of throat indices or a boolean mask of where given label
+            should be added or removed (see ``mode``)
+        mode : string
+            Controls how the labels are handled.  Options are:
+
+            *'add'* - Adds the given label to the specified locations while
+            keeping existing labels (default)
+
+            *'overwrite'* - Removes existing label from all locations before
+            adding the label in the specified locations
+
+            *'remove'* - Removes the  given label from the specified locations
+            leaving the remainder intact.
+
+            *'purge'* - Removes the specified label from the object
+
+        """
+        if mode == 'purge':
+            if label.split('.')[0] in ['pore', 'throat']:
+                if label in self.labels():
+                    del self[label]
+                else:
+                    logger.warning(label + ' is not a label, skpping')
+            else:
+                self.set_label(label='pore.'+label, mode='purge')
+                self.set_label(label='throat.'+label, mode='purge')
+        else:
+            if label.split('.')[0] in ['pore', 'throat']:
+                label = label.split('.', 1)[1]
+            if pores is not None:
+                pores = self._parse_indices(pores)
+                if (mode == 'overwrite') or ('pore.'+label not in self.labels()):
+                    self['pore.' + label] = False
+                if mode in ['remove']:
+                    self['pore.' + label][pores] = False
+                else:
+                    self['pore.' + label][pores] = True
+            if throats is not None:
+                throats = self._parse_indices(throats)
+                if (mode == 'overwrite') or ('throat.'+label not in self.labels()):
+                    self['throat.' + label] = False
+                if mode in ['remove']:
+                    self['throat.' + label][throats] = False
+                else:
+                    self['throat.' + label][throats] = True
+            if pores is None and throats is None:
+                del self
+
+    def pores(self, labels='all', mode='or', asmask=False, target=None):
+        r"""
+        Returns pore indicies where given labels exist, according to the logic
+        specified by the ``mode`` argument.
+
+        Parameters
+        ----------
+        labels : string or list of strings
+            The label(s) whose pores locations are requested.  This argument
+            also accepts '*' for wildcard searches.
+
+        mode : string
+            Specifies how the query should be performed.  The options are:
+
+            **'or', 'union', 'any'** : (default) Pores with *one or more* of
+            the given labels are returned.
+
+            **'and', 'intersection', 'all'** : Pores with *all* of the given
+            labels are returned.
+
+            **'xor', 'exclusive_or'** : Pores with *only one* of the given
+            labels are returned.
+
+            **'nor', 'none', 'not'** : Pores with *none* of the given labels
+            are returned.
+
+            **'nand'** : Pores with *not all* of the given labels are
+            returned.
+
+            **'xnor'** : Pores with *more than one* of the given labels are
+            returned.
+
+        asmask : boolean
+            If ``True`` then a boolean array of length Np is returned with
+            ``True`` values indicating the pores that satisfy the query.
+
+        target : OpenPNM Base object
+            If given, the returned indices will be indexed relative to the
+            ``target`` object.  This can be used to determine how indices on
+            one object map onto another object.
+
+        Returns
+        -------
+        A Numpy array containing pore indices filtered by the logic specified
+        in ``mode``.
+
+        See Also
+        --------
+        throats
+        map_pores
+
+        Notes
+        -----
+        Technically, *nand* and *xnor* should also return pores with *none* of
+        the labels but these are not included.  This makes the returned list
+        more useful.
+
+        To perform more complex or compound queries, you can opt to receive
+        the result a a boolean mask (``asmask=True``), then manipulate the
+        arrays manually.
+
+        Examples
+        --------
+        >>> import openpnm as op
+        >>> pn = op.network.Cubic(shape=[5, 5, 5])
+        >>> Ps = pn.pores(labels=['top', 'back'], mode='union')
+        >>> Ps[:5]  # Look at first 5 pore indices
+        array([ 4,  9, 14, 19, 20])
+        >>> pn.pores(labels=['top', 'back'], mode='xnor')
+        array([ 24,  49,  74,  99, 124])
+        """
+        ind = self._get_indices(element='pore', labels=labels, mode=mode)
+        if target is not None:
+            ind = target.map_pores(pores=ind, origin=self, filtered=True)
+        if asmask:
+            if target is not None:
+                ind = target.tomask(pores=ind)
+            else:
+                ind = self.tomask(pores=ind)
+        return ind
+
+    def throats(self, labels='all', mode='or', asmask=False, target=None):
+        r"""
+        Returns throat locations where given labels exist, according to the
+        logic specified by the ``mode`` argument.
+
+        Parameters
+        ----------
+        labels : string or list of strings
+            The throat label(s) whose locations are requested.  If omitted,
+            'all' throat inidices are returned.  This argument also accepts
+            '*' for wildcard searches.
+
+        mode : string
+            Specifies how the query should be performed.  The options are:
+
+            **'or', 'union', 'any'** : (default) Throats with *one or more* of
+            the given labels are returned.
+
+            **'and', 'intersection', 'all'** : Throats with *all* of the given
+            labels are returned.
+
+            **'xor', 'exclusive_or'** : Throats with *only one* of the given
+            labels are returned.
+
+            **'nor', 'none', 'not'** : Throats with *none* of the given labels
+            are returned.
+
+            **'nand'** : Throats with *not all* of the given labels are
+            returned.
+
+            **'xnor'** : Throats with *more than one* of the given labels are
+            returned.
+
+        asmask : boolean
+            If ``True`` then a boolean array of length Nt is returned with
+            ``True`` values indicating the throats that satisfy the query.
+
+        target : OpenPNM Base object
+            If given, the returned indices will be indexed relative to the
+            ``target`` object.  This can be used to determine how indices on
+            one object map onto another object.
+
+        Returns
+        -------
+        A Numpy array containing throat indices filtered by the logic specified
+        in ``mode``.
+
+        See Also
+        --------
+        pores
+        map_throats
+
+        Examples
+        --------
+        >>> import openpnm as op
+        >>> pn = op.network.Cubic(shape=[3, 3, 3])
+        >>> Ts = pn.throats()
+        >>> Ts[0:5]  # Look at first 5 throat indices
+        array([0, 1, 2, 3, 4])
+
+        """
+        ind = self._get_indices(element='throat', labels=labels, mode=mode)
+        if target is not None:
+            ind = target.map_throats(throats=ind, origin=self, filtered=True)
+        if asmask:
+            if target is not None:
+                ind = target.tomask(throats=ind)
+            else:
+                ind = self.tomask(throats=ind)
+        return ind
+
+    def _get_indices(self, element, labels='all', mode='or'):
+        r"""
+        This is the actual method for getting indices, but should not be called
+        directly.  Use ``pores`` or ``throats`` instead.
+        """
+        # Parse and validate all input values.
+        element = self._parse_element(element, single=True)
+        labels = self._parse_labels(labels=labels, element=element)
+        if element+'.all' not in self.keys():
+            raise Exception('Cannot proceed without {}.all'.format(element))
+
+        # Begin computing label array
+        if mode in ['or', 'any', 'union']:
+            union = np.zeros_like(self[element+'.all'], dtype=bool)
+            for item in labels:  # Iterate over labels and collect all indices
+                union = union + self[element+'.'+item.split('.')[-1]]
+            ind = union
+        elif mode in ['and', 'all', 'intersection']:
+            intersect = np.ones_like(self[element+'.all'], dtype=bool)
+            for item in labels:  # Iterate over labels and collect all indices
+                intersect = intersect*self[element+'.'+item.split('.')[-1]]
+            ind = intersect
+        elif mode in ['xor', 'exclusive_or']:
+            xor = np.zeros_like(self[element+'.all'], dtype=int)
+            for item in labels:  # Iterate over labels and collect all indices
+                info = self[element+'.'+item.split('.')[-1]]
+                xor = xor + np.int8(info)
+            ind = (xor == 1)
+        elif mode in ['nor', 'not', 'none']:
+            nor = np.zeros_like(self[element+'.all'], dtype=int)
+            for item in labels:  # Iterate over labels and collect all indices
+                info = self[element+'.'+item.split('.')[-1]]
+                nor = nor + np.int8(info)
+            ind = (nor == 0)
+        elif mode in ['nand']:
+            nand = np.zeros_like(self[element+'.all'], dtype=int)
+            for item in labels:  # Iterate over labels and collect all indices
+                info = self[element+'.'+item.split('.')[-1]]
+                nand = nand + np.int8(info)
+            ind = (nand < len(labels)) * (nand > 0)
+        elif mode in ['xnor', 'nxor']:
+            xnor = np.zeros_like(self[element+'.all'], dtype=int)
+            for item in labels:  # Iterate over labels and collect all indices
+                info = self[element+'.'+item.split('.')[-1]]
+                xnor = xnor + np.int8(info)
+            ind = (xnor > 1)
+        else:
+            raise Exception('Unsupported mode: '+mode)
+        # Extract indices from boolean mask
+        ind = np.where(ind)[0]
+        ind = ind.astype(dtype=int)
+        return ind
+
+    def filter_by_label(self, pores=[], throats=[], labels=None, mode='or'):
+        r"""
+        Returns which of the supplied pores (or throats) has the specified
+        label(s)
+
+        Parameters
+        ----------
+        pores, or throats : array_like
+            List of pores or throats to be filtered
+
+        labels : list of strings
+            The labels to apply as a filter
+
+        mode : string
+
+            Controls how the filter is applied.  Options include:
+
+            **'or', 'union', 'any'**: (default) Returns a list of the given
+            locations where *any* of the given labels exist.
+
+            **'and', 'intersection', 'all'**: Only locations where *all* the
+            given labels are found.
+
+            **'xor', 'exclusive_or'**: Only locations where exactly *one* of
+            the given labels are found.
+
+            **'nor', 'none', 'not'**: Only locations where *none* of the given
+            labels are found.
+
+            **'nand'** : Only locations with *some but not all* of the given
+            labels are returned.
+
+            **'xnor'** : Only locations with *more than one* of the given
+            labels are returned.
+
+        Returns
+        -------
+        A list of pores (or throats) that have been filtered according the
+        given criteria.  The returned list is a subset of the received list of
+        pores (or throats).
+
+        See Also
+        --------
+        pores
+        throats
+
+        Examples
+        --------
+        >>> import openpnm as op
+        >>> pn = op.network.Cubic(shape=[5, 5, 5])
+        >>> pn.filter_by_label(pores=[0, 1, 25, 32], labels='left')
+        array([0, 1])
+        >>> Ps = pn.pores(['top', 'bottom', 'back'], mode='or')
+        >>> pn.filter_by_label(pores=Ps, labels=['top', 'back'],
+        ...                    mode='and')
+        array([ 24,  49,  74,  99, 124])
+        """
+        # Convert inputs to locations and element
+        if (np.size(throats) > 0) and (np.size(pores) > 0):
+            raise Exception('Can only filter either pores OR labels')
+        if np.size(pores) > 0:
+            element = 'pore'
+            locations = self._parse_indices(pores)
+        elif np.size(throats) > 0:
+            element = 'throat'
+            locations = self._parse_indices(throats)
+        else:
+            return(np.array([], dtype=int))
+        labels = self._parse_labels(labels=labels, element=element)
+        labels = [element+'.'+item.split('.')[-1] for item in labels]
+        all_locs = self._get_indices(element=element, labels=labels, mode=mode)
+        mask = self._tomask(indices=all_locs, element=element)
+        ind = mask[locations]
+        return locations[ind]
+
+    def num_pores(self, labels='all', mode='or'):
+        r"""
+        Returns the number of pores of the specified labels
+
+        Parameters
+        ----------
+        labels : list of strings, optional
+            The pore labels that should be included in the count.
+            If not supplied, all pores are counted.
+
+        labels : list of strings
+            Label of pores to be returned
+
+        mode : string, optional
+            Specifies how the count should be performed.  The options are:
+
+            **'or', 'union', 'any'** : (default) Pores with *one or more* of
+            the given labels are counted.
+
+            **'and', 'intersection', 'all'** : Pores with *all* of the given
+            labels are counted.
+
+            **'xor', 'exclusive_or'** : Pores with *only one* of the given
+            labels are counted.
+
+            **'nor', 'none', 'not'** : Pores with *none* of the given labels
+            are counted.
+
+            **'nand'** : Pores with *some but not all* of the given labels are
+            counted.
+
+            **'xnor'** : Pores with *more than one* of the given labels are
+            counted.
+
+        Returns
+        -------
+        Np : int
+            Number of pores with the specified labels
+
+        See Also
+        --------
+        num_throats
+        count
+
+        Notes
+        -----
+        Technically, *'nand'* and *'xnor'* should also count pores with *none*
+        of the labels, however, to make the count more useful these are not
+        included.
+
+        Examples
+        --------
+        >>> import openpnm as op
+        >>> pn = op.network.Cubic(shape=[5, 5, 5])
+        >>> pn.num_pores()
+        125
+        >>> pn.num_pores(labels=['top'])
+        25
+        >>> pn.num_pores(labels=['top', 'front'], mode='or')
+        45
+        >>> pn.num_pores(labels=['top', 'front'], mode='xnor')
+        5
+
+        """
+        # Count number of pores of specified type
+        Ps = self._get_indices(labels=labels, mode=mode, element='pore')
+        Np = np.shape(Ps)[0]
+        return Np
+
+    def num_throats(self, labels='all', mode='union'):
+        r"""
+        Return the number of throats of the specified labels
+
+        Parameters
+        ----------
+        labels : list of strings, optional
+            The throat labels that should be included in the count.
+            If not supplied, all throats are counted.
+
+        mode : string, optional
+            Specifies how the count should be performed.  The options are:
+
+            **'or', 'union', 'any'** : (default) Throats with *one or more* of
+            the given labels are counted.
+
+            **'and', 'intersection', 'all'** : Throats with *all* of the given
+            labels are counted.
+
+            **'xor', 'exclusive_or'** : Throats with *only one* of the given
+            labels are counted.
+
+            **'nor', 'none', 'not'** : Throats with *none* of the given labels
+            are counted.
+
+            **'nand'** : Throats with *some but not all* of the given labels
+            are counted.
+
+            **'xnor'** : Throats with *more than one* of the given labels are
+            counted.
+
+        Returns
+        -------
+        Nt : int
+            Number of throats with the specified labels
+
+        See Also
+        --------
+        num_pores
+        count
+
+        Notes
+        -----
+        Technically, *'nand'* and *'xnor'* should also count throats with
+        *none* of the labels, however, to make the count more useful these are
+        not included.
+
+        """
+        # Count number of pores of specified type
+        Ts = self._get_indices(labels=labels, mode=mode, element='throat')
+        Nt = np.shape(Ts)[0]
+        return Nt
+
+
+class LegacyMixin:
+    r"""
+    This class contains wrappers for old functions which will be removed
+    """
+
+    def tomask(self, *args, **kwargs):
+        return self.to_mask(*args, **kwargs)
+
+    def toindices(self, *args, **kwargs):
+        return self.to_indices(*args, **kwargs)
+
+    def _count(self, element=None):
+        # element = self._parse_element(element=element, single=True)
+        # temp = np.size(super(Base, self).__getitem__(element+'.all'))
+        # return temp
+        return self._N(element)
+
+
+class MappingMixin:
+
+    def map_pores(self, pores, origin, filtered=True):
+        r"""
+        Given a list of pore on a target object, finds indices of those pores
+        on the calling object
+
+        Parameters
+        ----------
+        pores : array_like
+            The indices of the pores on the object specifiedin ``origin``
+
+        origin : OpenPNM Base object
+            The object corresponding to the indices given in ``pores``
+
+        filtered : boolean (default is ``True``)
+            If ``True`` then a ND-array of indices is returned with missing
+            indices removed, otherwise a named-tuple containing both the
+            ``indices`` and a boolean ``mask`` with ``False`` indicating
+            which locations were not found.
+
+        Returns
+        -------
+        Pore indices on the calling object corresponding to the same pores
+        on the ``origin`` object.  Can be an array or a tuple containing an
+        array and a mask, depending on the value of ``filtered``.
+
+        See Also
+        --------
+        pores
+        map_throats
+
+        """
+        ids = origin['pore._id'][pores]
+        return self._map(element='pore', ids=ids, filtered=filtered)
+
+    def map_throats(self, throats, origin, filtered=True):
+        r"""
+        Given a list of throats on a target object, finds indices of
+        those throats on the calling object
+
+        Parameters
+        ----------
+        throats : array_like
+            The indices of the throats on the object specified in ``origin``
+
+        origin : OpenPNM Base object
+            The object corresponding to the indices given in ``throats``
+
+        filtered : boolean (default is ``True``)
+            If ``True`` then a ND-array of indices is returned with missing
+            indices removed, otherwise a named-tuple containing both the
+            ``indices`` and a boolean ``mask`` with ``False`` indicating
+            which locations were not found.
+
+        Returns
+        -------
+        Throat indices on the calling object corresponding to the same throats
+        on the ``origin`` object.  Can be an array or a tuple containing an
+        array and a mask, depending on the value of ``filtered``.
+
+        See Also
+        --------
+        throats
+        map_pores
+
+        """
+        ids = origin['throat._id'][throats]
+        return self._map(element='throat', ids=ids, filtered=filtered)
+
+    def to_global(self, element, locs):
+        inds = self.locs(element)[locs]
+        return inds
+
+    def to_local(self, element, locs):
+        temp = -1*np.ones_like(self.domain._inds(element))
+        temp[self.locs(element)] = self._inds(element)
+        inds = temp[locs]
+        if np.any(inds == -1):
+            raise Exception(f'Some global indices not present on {self.name}')
+        return inds
+
+    def _map(self, ids, element, filtered):
+        ids = np.array(ids, dtype=np.int64)
+        locations = self._get_indices(element=element)
+        self_in_ids = np.isin(ids, self[element+'._id'], assume_unique=True)
+        ids_in_self = np.isin(self[element+'._id'], ids, assume_unique=True)
+        mask = np.zeros(shape=ids.shape, dtype=bool)
+        mask[self_in_ids] = True
+        ind = np.ones_like(mask, dtype=np.int64) * -1
+        ind[self_in_ids] = locations[ids_in_self]
+        if filtered:
+            return ind[mask]
+        t = namedtuple('index_map', ('indices', 'mask'))
+        return t(ind, mask)

--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -839,28 +839,6 @@ class Base(dict):
         plt.rcParams['font.size'] = temp
         plt.tight_layout(h_pad=0.9, w_pad=0.9)
 
-    def check_data_health(self):
-        r"""
-        Check the health of pore and throat data arrays.
-
-        Returns
-        -------
-        health: HealthDict object
-            A  basic dictionary with an added ``health`` attribute that is
-            ``True`` if all entries in the dict are deemed healthy
-            (empty lists), or ``False`` otherwise.
-
-        Examples
-        --------
-        >>> import openpnm
-        >>> pn = openpnm.network.Cubic(shape=[5, 5, 5])
-        >>> h = pn.check_data_health()
-        >>> h.health
-        True
-        """
-        health = self.project.check_data_health(obj=self)
-        return health
-
     def _parse_indices(self, indices):
         r"""
         This private method accepts a list of pores or throats and returns a
@@ -1694,6 +1672,10 @@ class LegacyMixin:
         # temp = np.size(super(Base, self).__getitem__(element+'.all'))
         # return temp
         return self._N(element)
+
+    def check_data_health(self):
+        health = self.project.check_data_health(obj=self)
+        return health
 
 
 class MappingMixin:

--- a/openpnm/core/Base.py
+++ b/openpnm/core/Base.py
@@ -73,7 +73,7 @@ class Base(dict):
             return
         # Check 1: If value is a dictionary, break it into constituent arrays
         # and recursively call __setitem__ on each
-        if hasattr(value, 'keys'):
+        if isinstance(value, dict):
             for item in value.keys():
                 prop = item.replace('pore.', '').replace('throat.', '')
                 self.__setitem__(key+'.'+prop, value[item])
@@ -81,8 +81,8 @@ class Base(dict):
 
         # Check 3: Enforce correct dict naming
         element = key.split('.')[0]
-        if element not in ['pore', 'throat']:
-            raise Exception('All keys must start with either pore or throat')
+        if element not in ['pore', 'throat', 'param']:
+            raise Exception('All keys must start with either pore, throat, or param')
 
         # Check 2: If adding a new key, make sure it has no conflicts
         if self.project:
@@ -466,6 +466,8 @@ class Base(dict):
             N = self.project.network['pore.coords'].shape[0]
         elif element == 'throat':
             N = self.project.network['throat.conns'].shape[0]
+        elif element == 'param':
+            N = 1
         return N
 
     @property
@@ -1433,8 +1435,8 @@ class LabelMixin:
         # Parse and validate all input values.
         element = self._parse_element(element, single=True)
         labels = self._parse_labels(labels=labels, element=element)
-        if element+'.all' not in self.keys():
-            raise Exception('Cannot proceed without {}.all'.format(element))
+        # if element+'.all' not in self.keys():
+        #     raise Exception('Cannot proceed without {}.all'.format(element))
 
         # Begin computing label array
         if mode in ['or', 'any', 'union']:

--- a/openpnm/core/__init__.py
+++ b/openpnm/core/__init__.py
@@ -103,5 +103,5 @@ and run.
 """
 
 from .ModelsMixin import ModelsMixin, ModelsDict
-from .Base import Base
+from .Base import *
 from .Subdomain import Subdomain

--- a/openpnm/geometry/GenericGeometry.py
+++ b/openpnm/geometry/GenericGeometry.py
@@ -1,10 +1,10 @@
-from openpnm.core import Subdomain, ModelsMixin
+from openpnm.core import Subdomain, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin
 from openpnm.utils import Workspace, logging
 logger = logging.getLogger(__name__)
 ws = Workspace()
 
 
-class GenericGeometry(Subdomain, ModelsMixin):
+class GenericGeometry(Subdomain, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin):
     r"""
     This generic class is meant as a starter for custom Geometry objects
 
@@ -66,21 +66,13 @@ class GenericGeometry(Subdomain, ModelsMixin):
 
     """
 
-    def __init__(self, network=None, project=None, pores=[], throats=[],
-                 settings={}, **kwargs):
+    def __init__(self, pores=[], throats=[], settings={}, **kwargs):
         # Define some default settings
         self.settings.update({'prefix': 'geo'})
         # Overwrite with user supplied settings, if any
         self.settings.update(settings)
 
-        # Deal with network or project arguments
-        if network is not None:
-            if project is not None:
-                assert network is project.network
-            else:
-                project = network.project
-
-        super().__init__(project=project, **kwargs)
+        super().__init__( **kwargs)
 
         network = self.project.network
         if network:

--- a/openpnm/geometry/GenericGeometry.py
+++ b/openpnm/geometry/GenericGeometry.py
@@ -72,7 +72,7 @@ class GenericGeometry(Subdomain, LabelMixin, MappingMixin, LegacyMixin, ModelsMi
         # Overwrite with user supplied settings, if any
         self.settings.update(settings)
 
-        super().__init__( **kwargs)
+        super().__init__(**kwargs)
 
         network = self.project.network
         if network:

--- a/openpnm/geometry/StickAndBall.py
+++ b/openpnm/geometry/StickAndBall.py
@@ -79,51 +79,51 @@ class StickAndBall(GenericGeometry):
                        iters=10)
 
         self.add_model(propname='pore.diameter',
-                       model=mods.misc.product,
-                       props=['pore.max_size', 'pore.seed'])
+                        model=mods.misc.product,
+                        props=['pore.max_size', 'pore.seed'])
 
         self.add_model(propname='pore.area',
-                       model=mods.geometry.pore_cross_sectional_area.sphere,
-                       pore_diameter='pore.diameter')
+                        model=mods.geometry.pore_cross_sectional_area.sphere,
+                        pore_diameter='pore.diameter')
 
         self.add_model(propname='pore.volume',
-                       model=mods.geometry.pore_volume.sphere,
-                       pore_diameter='pore.diameter')
+                        model=mods.geometry.pore_volume.sphere,
+                        pore_diameter='pore.diameter')
 
         self.add_model(propname='throat.max_size',
-                       model=mods.misc.from_neighbor_pores,
-                       mode='min',
-                       prop='pore.diameter')
+                        model=mods.misc.from_neighbor_pores,
+                        mode='min',
+                        prop='pore.diameter')
 
         self.add_model(propname='throat.diameter',
-                       model=mods.misc.scaled,
-                       factor=0.5,
-                       prop='throat.max_size')
+                        model=mods.misc.scaled,
+                        factor=0.5,
+                        prop='throat.max_size')
 
         self.add_model(propname='throat.endpoints',
-                       model=mods.geometry.throat_endpoints.spherical_pores,
-                       pore_diameter='pore.diameter',
-                       throat_diameter='throat.diameter')
+                        model=mods.geometry.throat_endpoints.spherical_pores,
+                        pore_diameter='pore.diameter',
+                        throat_diameter='throat.diameter')
 
         self.add_model(propname='throat.length',
-                       model=mods.geometry.throat_length.piecewise,
-                       throat_endpoints='throat.endpoints')
+                        model=mods.geometry.throat_length.piecewise,
+                        throat_endpoints='throat.endpoints')
 
         self.add_model(propname='throat.surface_area',
-                       model=mods.geometry.throat_surface_area.cylinder,
-                       throat_diameter='throat.diameter',
-                       throat_length='throat.length')
+                        model=mods.geometry.throat_surface_area.cylinder,
+                        throat_diameter='throat.diameter',
+                        throat_length='throat.length')
 
         self.add_model(propname='throat.volume',
-                       model=mods.geometry.throat_volume.cylinder,
-                       throat_diameter='throat.diameter',
-                       throat_length='throat.length')
+                        model=mods.geometry.throat_volume.cylinder,
+                        throat_diameter='throat.diameter',
+                        throat_length='throat.length')
 
         self.add_model(propname='throat.area',
-                       model=mods.geometry.throat_cross_sectional_area.cylinder,
-                       throat_diameter='throat.diameter')
+                        model=mods.geometry.throat_cross_sectional_area.cylinder,
+                        throat_diameter='throat.diameter')
 
         self.add_model(propname='throat.conduit_lengths',
-                       model=mods.geometry.throat_length.conduit_lengths,
-                       throat_endpoints='throat.endpoints',
-                       throat_length='throat.length')
+                        model=mods.geometry.throat_length.conduit_lengths,
+                        throat_endpoints='throat.endpoints',
+                        throat_length='throat.length')

--- a/openpnm/network/GenericNetwork.py
+++ b/openpnm/network/GenericNetwork.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sprs
 import scipy.spatial as sptl
-from openpnm.core import Base, ModelsMixin
+from openpnm.core import Base, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin
 from openpnm import topotools
 from openpnm.utils import Workspace, logging
 import openpnm.models.topology as tm
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 ws = Workspace()
 
 
-class GenericNetwork(Base, ModelsMixin):
+class GenericNetwork(Base, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin):
     r"""
     This generic class contains the main functionality used by all networks
 

--- a/openpnm/phases/GenericPhase.py
+++ b/openpnm/phases/GenericPhase.py
@@ -1,4 +1,4 @@
-from openpnm.core import Base, ModelsMixin
+from openpnm.core import Base, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin
 from openpnm.utils import Workspace, logging, Docorator
 from numpy import ones
 import openpnm.models as mods
@@ -9,7 +9,7 @@ ws = Workspace()
 
 @docstr.get_sections(base='GenericPhase', sections=['Parameters'])
 @docstr.dedent
-class GenericPhase(Base, ModelsMixin):
+class GenericPhase(Base, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin):
     r"""
     This generic class is meant as a starter for custom Phase objects
 

--- a/openpnm/physics/GenericPhysics.py
+++ b/openpnm/physics/GenericPhysics.py
@@ -1,11 +1,11 @@
 import numpy as np
-from openpnm.core import Subdomain, ModelsMixin
+from openpnm.core import Subdomain, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin
 from openpnm.utils import Workspace, logging
 logger = logging.getLogger(__name__)
 ws = Workspace()
 
 
-class GenericPhysics(Subdomain, ModelsMixin):
+class GenericPhysics(Subdomain, LabelMixin, MappingMixin, LegacyMixin, ModelsMixin):
     r"""
     This generic class is meant as a starter for custom Physics objects
 

--- a/openpnm/physics/Standard.py
+++ b/openpnm/physics/Standard.py
@@ -28,23 +28,14 @@ class Standard(GenericPhysics):
 
     """
 
-    def __init__(self, project=None, network=None, phase=None,
-                 geometry=None, settings={}, **kwargs):
+    def __init__(self, phase=None, geometry=None, settings={}, **kwargs):
 
         # Define some default settings
         self.settings.update({'prefix': 'phys'})
         # Overwrite with user supplied settings, if any
         self.settings.update(settings)
 
-        # Deal with network or project arguments
-        if network is not None:
-            if project is not None:
-                assert network is project.network
-            else:
-                project = network.project
-
-        super().__init__(project=project, phase=phase, geometry=geometry,
-                         **kwargs)
+        super().__init__(phase=phase, geometry=geometry, **kwargs)
 
         self.add_model(propname='throat.flow_shape_factors',
                        model=mods.flow_shape_factors.conical_frustum_and_stick)


### PR DESCRIPTION
After closing PR #2036, I now propose more subtle refactoring of Base.  This PR breaks the Base class into several mixins that can be mixed and matched. For instance, algorithms don't need the ability to look up pores based on labels.  All label-related functions are now in the LabelMixin class which is no long inherited by GenericAlgorithm.  

There are also several other changes that are being made, like renaming ``tomask`` to ``to_mask``.  This is just for consistency with other packages like pandas which has functions like ``to_csv``.  This new ``to_mask`` function will also accept additional arguments (i.e. ``relative=True/False``).  To maintain compatibility with current code, I have create a LegacyMixin, which has the old functions and names.  We can eventually remove this mixin but it allows for a smoother transition to the new code.