### PR TITLE
Add voxel output

### DIFF
--- a/openpnm/models/topology/topology.py
+++ b/openpnm/models/topology/topology.py
@@ -36,10 +36,10 @@ def distance_to_nearest_neighbor(target):
     cn = network['throat.conns']
     C1 = network['pore.coords'][cn[:, 0]]
     C2 = network['pore.coords'][cn[:, 1]]
-    values = _norm(C1 - C2, axis=1)
+    D = _norm(C1 - C2, axis=1)
     im = network.create_incidence_matrix()
     values = _np.ones((network.Np, ))*_np.inf
-    _np.minimum.at(values, im.row, values[im.col])
+    _np.minimum.at(values, im.row, D[im.col])
     return _np.array(values)
 
 
@@ -52,10 +52,10 @@ def distance_to_furthest_neighbor(target):
     cn = network['throat.conns'][throats]
     C1 = network['pore.coords'][cn[:, 0]]
     C2 = network['pore.coords'][cn[:, 1]]
-    values = _norm(C1 - C2, axis=1)
+    D = _norm(C1 - C2, axis=1)
     im = network.create_incidence_matrix()
     values = _np.zeros((network.Np, ))
-    _np.maximum.at(values, im.row, values[im.col])
+    _np.maximum.at(values, im.row, D[im.col])
     return _np.array(values)
 
 

--- a/openpnm/topotools/__init__.py
+++ b/openpnm/topotools/__init__.py
@@ -64,5 +64,6 @@ from .plottools import plot_connections
 from .plottools import plot_coordinates
 from .plottools import plot_networkx
 from .plottools import plot_network_jupyter
+from .plottools import generate_voxel_image
 
 from . import generators

--- a/openpnm/topotools/plottools.py
+++ b/openpnm/topotools/plottools.py
@@ -767,7 +767,7 @@ def _generate_voxel_image(network, pore_shape, throat_shape, max_dim=200):
     # Distance bounding box from the network by a fixed amount
     delta = network["pore.diameter"].mean() / 2
     if isinstance(network, op.network.Cubic):
-        delta = network._spacing.mean() / 2
+        delta = op.topotools.get_spacing(network).mean() / 2
 
     # Shift everything to avoid out-of-bounds
     extra_clearance = int(max_dim * 0.05)

--- a/openpnm/topotools/plottools.py
+++ b/openpnm/topotools/plottools.py
@@ -1,5 +1,6 @@
 import numpy as np
 import openpnm as op
+from tqdm import tqdm
 
 
 def plot_connections(network,
@@ -730,3 +731,151 @@ def plot_network_jupyter(network,
     data = [trace_edges, trace_nodes]
     fig = go.Figure(data=data, layout=layout)
     return fig
+
+
+def _generate_voxel_image(network, pore_shape, throat_shape, max_dim=200):
+    r"""
+    Generates a 3d numpy array from an OpenPNM network
+
+    Parameters
+    ----------
+    network : OpenPNM GenericNetwork
+        Network from which voxel image is to be generated
+    pore_shape : str
+        Shape of pores in the network, valid choices are "sphere", "cube"
+    throat_shape : str
+        Shape of throats in the network, valid choices are "cylinder", "cuboid"
+    max_dim : int
+        Number of voxels in the largest dimension of the network
+
+    Returns
+    -------
+    im : ndarray
+        Voxelated image corresponding to the given pore network model
+
+    Notes
+    -----
+    (1) The generated voxel image is labeled with 0s, 1s and 2s signifying
+    solid phase, pores, and throats respectively.
+
+    """
+    from skimage.morphology import cube, ball
+    from porespy.tools import overlay, insert_cylinder
+    xyz = network["pore.coords"]
+    cn = network["throat.conns"]
+
+    # Distance bounding box from the network by a fixed amount
+    delta = network["pore.diameter"].mean() / 2
+    if isinstance(network, op.network.Cubic):
+        delta = network._spacing.mean() / 2
+
+    # Shift everything to avoid out-of-bounds
+    extra_clearance = int(max_dim * 0.05)
+
+    # Transform points to satisfy origin at (0, 0, 0)
+    xyz0 = xyz.min(axis=0) - delta
+    xyz += -xyz0
+    res = (xyz.ptp(axis=0).max() + 2 * delta) / max_dim
+    shape = np.rint((xyz.max(axis=0) + delta) / res).astype(int) + 2 * extra_clearance
+
+    # Transforming from real coords to matrix coords
+    xyz = np.rint(xyz / res).astype(int) + extra_clearance
+    pore_radi = np.rint(network["pore.diameter"] * 0.5 / res).astype(int)
+    throat_radi = np.rint(network["throat.diameter"] * 0.5 / res).astype(int)
+
+    im_pores = np.zeros(shape, dtype=np.uint8)
+    im_throats = np.zeros_like(im_pores)
+
+    if pore_shape == "cube":
+        pore_elem = cube
+        rp = pore_radi * 2 + 1  # +1 since num_voxel must be odd
+        rp_max = int(2 * round(delta / res)) + 1
+    if pore_shape == "sphere":
+        pore_elem = ball
+        rp = pore_radi
+        rp_max = int(round(delta / res))
+    if throat_shape == "cuboid":
+        raise Exception("Not yet implemented, try 'cylinder'.")
+
+    # Generating voxels for pores
+    for i, pore in enumerate(tqdm(network.Ps)):
+        elem = pore_elem(rp[i])
+        try:
+            im_pores = overlay(im1=im_pores, im2=elem, c=xyz[i])
+        except ValueError:
+            elem = pore_elem(rp_max)
+            im_pores = overlay(im1=im_pores, im2=elem, c=xyz[i])
+    # Get rid of pore overlaps
+    im_pores[im_pores > 0] = 1
+
+    # Generating voxels for throats
+    for i, throat in enumerate(tqdm(network.Ts)):
+        try:
+            im_throats = insert_cylinder(
+                im_throats, r=throat_radi[i], xyz0=xyz[cn[i, 0]], xyz1=xyz[cn[i, 1]])
+        except ValueError:
+            im_throats = insert_cylinder(
+                im_throats, r=rp_max, xyz0=xyz[cn[i, 0]], xyz1=xyz[cn[i, 1]])
+    # Get rid of throat overlaps
+    im_throats[im_throats > 0] = 1
+
+    # Subtract pore-throat overlap from throats
+    im_throats = (im_throats.astype(bool) * ~im_pores.astype(bool)).astype(np.uint8)
+    im = im_pores * 1 + im_throats * 2
+
+    return im[extra_clearance:-extra_clearance,
+              extra_clearance:-extra_clearance,
+              extra_clearance:-extra_clearance]
+
+
+def generate_voxel_image(network, pore_shape="sphere", throat_shape="cylinder",
+                         max_dim=None, rtol=0.1):
+    r"""
+    Generate a voxel image from an OpenPNM network object
+
+    Parameters
+    ----------
+    network : OpenPNM GenericNetwork
+        Network from which voxel image is to be generated
+    pore_shape : str
+        Shape of pores in the network, valid choices are "sphere", "cube"
+    throat_shape : str
+        Shape of throats in the network, valid choices are "cylinder", "cuboid"
+    max_dim : int
+        Number of voxels in the largest dimension of the network
+    rtol : float
+        Stopping criteria for finding the smallest voxel image such that
+        further increasing the number of voxels in each dimension by 25% would
+        improve the predicted porosity of the image by less that ``rtol``
+
+    Returns
+    -------
+    im : ndarray
+        Voxelated image corresponding to the given pore network model
+
+    Notes
+    -----
+    (1) The generated voxelated image is labeled with 0s, 1s and 2s signifying
+    solid phase, pores, and throats respectively.
+
+    (2) If max_dim is not provided, the method calculates it such that the
+    further increasing it doesn't change porosity by much.
+
+    """
+    # If max_dim is provided, generate voxel image using max_dim
+    if max_dim is not None:
+        return _generate_voxel_image(
+            network, pore_shape, throat_shape, max_dim=max_dim)
+    max_dim = 200
+    # If max_dim is not provided, find best max_dim that predicts porosity
+    err = 100
+    eps_old = 200
+    while err > rtol:
+        im = _generate_voxel_image(
+            network, pore_shape, throat_shape, max_dim=max_dim)
+        eps = im.astype(bool).sum() / np.prod(im.shape)
+        err = abs(1 - eps / eps_old)
+        eps_old = eps
+        max_dim = int(max_dim * 1.25)
+    return im
+

--- a/openpnm/topotools/plottools.py
+++ b/openpnm/topotools/plottools.py
@@ -767,7 +767,10 @@ def _generate_voxel_image(network, pore_shape, throat_shape, max_dim=200):
     # Distance bounding box from the network by a fixed amount
     delta = network["pore.diameter"].mean() / 2
     if isinstance(network, op.network.Cubic):
-        delta = op.topotools.get_spacing(network).mean() / 2
+        try:
+            delta = op.topotools.get_spacing(network).mean() / 2
+        except AttributeError:
+            delta = network.spacing.mean() / 2
 
     # Shift everything to avoid out-of-bounds
     extra_clearance = int(max_dim * 0.05)

--- a/tests/unit/models/topology/TestTopologyModels.py
+++ b/tests/unit/models/topology/TestTopologyModels.py
@@ -78,7 +78,6 @@ class TopologyModelsTest:
         pn.regenerate_models()
         assert np.all(pn['pore.cluster_size'] == [1, 3, 3, 3, 2, 2])
 
-
     def test_duplicate_throats(self):
         pn = op.network.Cubic(shape=[6, 1, 1])
         op.topotools.extend(network=pn, throat_conns=[[0, 1]])

--- a/tests/unit/topotools/PlotToolsTest.py
+++ b/tests/unit/topotools/PlotToolsTest.py
@@ -61,6 +61,16 @@ class PlotToolsTest:
         with pytest.raises(Exception):
             op.topotools.plot_networkx(pn)
 
+    def test_generate_voxel_image(self):
+        pn = op.network.Cubic(shape=[5, 5, 1])
+        geo = op.geometry.SpheresAndCylinders(network=pn,
+                                              pores=pn.Ps, throats=pn.Ts)
+        im = op.topotools.generate_voxel_image(network=pn,
+                                               pore_shape='sphere',
+                                               throat_shape='cylinder',
+                                               max_dim=500)
+        assert im.shape == (500, 500, 100)
+
 
 if __name__ == '__main__':
 

--- a/tests/unit/topotools/PlotToolsTest.py
+++ b/tests/unit/topotools/PlotToolsTest.py
@@ -69,7 +69,7 @@ class PlotToolsTest:
                                                pore_shape='sphere',
                                                throat_shape='cylinder',
                                                max_dim=500)
-        assert im.shape == (500, 500, 100)
+        assert im.shape[0] == 500
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moved this over from porespy...it makes more sense to have it in openpnm I think.  This was actually motivated by the fact that the function uses ``net.shape`` which is now deprecated in openpnm.