### PR TITLE
Fix the throat lens calculations

### DIFF
--- a/openpnm/models/geometry/throat_volume.py
+++ b/openpnm/models/geometry/throat_volume.py
@@ -210,8 +210,8 @@ def pendular_ring(target, throat_diameter='throat.diameter',
     """
     network = target.network
     conns = network['throat.conns']
-    Rp = target[pore_diameter]
-    Rt = target[throat_diameter]
+    Rp = target[pore_diameter]/2
+    Rt = target[throat_diameter]/2
     a = _np.atleast_2d(Rt).T
     q = _np.arcsin(a/Rp[conns])
     b = Rp[conns]*_np.cos(q)

--- a/openpnm/models/geometry/throat_volume.py
+++ b/openpnm/models/geometry/throat_volume.py
@@ -163,8 +163,8 @@ def lens(target, throat_diameter='throat.diameter',
     """
     network = target.network
     conns = network['throat.conns']
-    Rp = target[pore_diameter]
-    Rt = target[throat_diameter]
+    Rp = target[pore_diameter]/2
+    Rt = target[throat_diameter]/2
     a = _np.atleast_2d(Rt).T
     q = _np.arcsin(a/Rp[conns])
     b = Rp[conns]*_np.cos(q)

--- a/tests/unit/models/geometry/ThroatVolumeTest.py
+++ b/tests/unit/models/geometry/ThroatVolumeTest.py
@@ -26,13 +26,13 @@ class ThroatVolumeTest:
         net.add_model(propname='throat.lens_volume',
                       model=mod)
         Vlens = net['throat.lens_volume']
-        assert np.isclose(Vlens, 2*0.006733852203712552)
+        assert np.isclose(Vlens, 2*0.00084173)
         mod = op.models.geometry.throat_volume.pendular_ring
         net.add_model(propname='throat.ring_volume',
                       model=mod)
-        Vcyl = 2*(0.01315292522620208)
+        Vcyl = 2*(0.00164412)
         Vring = net['throat.ring_volume']
-        assert np.isclose(Vcyl - Vring, 2*0.006733852203712552)
+        assert np.isclose(Vcyl - Vring, 2*0.00084173)
 
     def test_cylinder(self):
         self.geo.add_model(propname='throat.volume',


### PR DESCRIPTION
This PR closes #1855. The formula has been corrected and confirmed with a simple example. 
![image](https://user-images.githubusercontent.com/43128873/142877171-3557a577-5fa7-436d-a6b9-42e951d6efaa.png)

Problem description:
```python
# running on dev
import openpnm as op
import numpy as np
from openpnm import models as mods
import pandas as pd
shape=[5,5,5]
np.random.seed(50)
net = op.network.Cubic(shape=shape)
geo = op.geometry.SpheresAndCylinders(network=net, pores=net.Ps, throats=net.Ts)
geo.add_model(propname='pore.max_size',
             model=mods.geometry.pore_size.largest_sphere,
             iters=10)
lens_vol=op.models.geometry.throat_volume.lens(net)
print('lens vol for thorat 1 is',lens_vol[0])
# lens vol for thorat 1 is 0.0027829934355781383

#% Hand calculation : check for one pair of pore and throats
def calc_cap(R,Rt):
    cos_theta=np.sqrt(R**2-Rt**2)/R
    h=R-R*cos_theta
    vol=(np.pi*h**2/3)*(3*R-h)
    return vol
Rt=net['throat.diameter'][0]/2
Rp1=net['pore.diameter'][0]/2
Rp2=net['pore.diameter'][1]/2
vols=calc_cap(Rp1,Rt)+calc_cap(Rp2,Rt)
print('lens vol for throat 1 is calculate',vols)
#lens vol for throat 1 is calculate 0.000347874179447267
```
Problem fixed:
```python
# running on throat_lens branch:
import openpnm as op
import numpy as np
from openpnm import models as mods
import pandas as pd
shape=[5,5,5]
np.random.seed(50)
net = op.network.Cubic(shape=shape)
geo = op.geometry.SpheresAndCylinders(network=net, pores=net.Ps, throats=net.Ts)
geo.add_model(propname='pore.max_size',
             model=mods.geometry.pore_size.largest_sphere,
             iters=10)
lens_vol=op.models.geometry.throat_volume.lens(net)
print('lens vol for thorat 1 is',lens_vol[0])
# lens vol for thorat 1 is 0.0003478741794472673
```
The problem is fixed for both lens and pendular ring calculations.