### PR TITLE
Changing regenerate model to work with models without 'regen_mode' key

### DIFF
--- a/openpnm/core/_models.py
+++ b/openpnm/core/_models.py
@@ -346,8 +346,11 @@ class ModelsMixin:
         if propnames is None:  # If no props given, then regenerate them all
             propnames = self.models.dependency_list()
             # If some props are to be excluded, remove them from list
-            exclude.extend([k for k, v in self.models.items()
-                            if v['regen_mode'] == 'explicit'])
+            for k, v in self.models.items():
+                if 'regen_mode' not in v:
+                    pass
+                elif v['regen_mode'] == 'explicit':
+                    exclude.extend([k])
             propnames = [i for i in propnames if i not in exclude]
         # Re-order given propnames according to dependency tree
         self_models = self.models.dependency_list()


### PR DESCRIPTION
This PR closes #2235. 
If the model for any reason does not have 'regen_mode' in its keys, the regenerate_models counts it as a regen='normal' and runs the model to update its associated property. If the regen_mode is already in the model keys (which by default is 'normal'), the regenerate_models follows that already defined mode.
An example where 'regen_mode' is not in model key would be the new collection of models. But we can recreate the same example problem:
``` python
import numpy as np
import openpnm as op
np.random.seed(10)
shape=[10, 10, 10]
pn = op.network.Cubic(shape)
geo = op.geometry.SpheresAndCylinders(network=pn, pores=pn.Ps, throats=pn.Ts)
geo.models['pore.diameter'].pop('regen_mode')
geo.regenerate_models()
#KeyError: 'regen_mode'
```
Fixed:
``` python
import numpy as np
import openpnm as op
np.random.seed(10)
shape=[10, 10, 10]
pn = op.network.Cubic(shape)
geo = op.geometry.SpheresAndCylinders(network=pn, pores=pn.Ps, throats=pn.Ts)
geo.models['pore.diameter'].pop('regen_mode')
print(geo['pore.diameter'].mean())
# 0.4460026112474829
geo['pore.seed']=0.5
geo.regenerate_models()
print(geo['pore.diameter'].mean())
# 0.4525925641219549
```