### PR TITLE
Fix _xdmf file to show pore coords in Paraview

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@ import numpy as np
 import openpnm as op
 from openpnm.models.physics import source_terms
 
-# %% Initialization: create Workspace and project objects.
+# %% Initialization: Create Workspace and project objects.
 ws = op.Workspace()
 ws.settings.loglevel = 50
 np.random.seed(9)

--- a/openpnm/io/_xdmf.py
+++ b/openpnm/io/_xdmf.py
@@ -127,7 +127,8 @@ class XDMF(GenericIO):
                     ):
                         attr_type = 'Scalar'
                         shape = D[item].shape
-                        dims = (''.join([str(i) + ' ' for i in list(shape)[::-1]]))
+                        #dims = (''.join([str(i) + ' ' for i in list(shape)[::-1]]))
+                        dims = (' '.join([str(i) for i in shape]))
                         if '@' in item:
                             item = item.split('@')[0]+'@t'
                             hdf_loc = fname_hdf + ":" + item

--- a/openpnm/io/_xdmf.py
+++ b/openpnm/io/_xdmf.py
@@ -127,7 +127,6 @@ class XDMF(GenericIO):
                     ):
                         attr_type = 'Scalar'
                         shape = D[item].shape
-                        #dims = (''.join([str(i) + ' ' for i in list(shape)[::-1]]))
                         dims = (' '.join([str(i) for i in shape]))
                         if '@' in item:
                             item = item.split('@')[0]+'@t'
@@ -227,7 +226,7 @@ def create_data_item(value, Dimensions, **attribs):
     element = ET.Element('DataItem')
     element.attrib.update({'ItemType': "Uniform",
                            'Format': "XML",
-                           'DatarType': "Float",
+                           'DataType': "Float",
                            'Precision': "4",
                            'Rank': "1",
                            'Dimensions': Dimensions,


### PR DESCRIPTION
This PR closes #2123. The network was shown in correct xyz order in Paraveiw. The problem was the pore.coords values were all zero. 
Sample code for testing:
```python
import openpnm  as op
import numpy as np
np.random.seed(5)
net = op.network.Cubic(shape=[2, 2, 2])
geo=op.geometry.SpheresAndCylinders(network=net, pores=net.Ps, throats=net.Ts)
op.io.to_xdmf(network=net, filename='test')
```
Problem in pore coords:
![image](https://user-images.githubusercontent.com/43128873/146796762-4924ec6d-146b-4732-b46f-99252a981b06.png)

Solved:
![image](https://user-images.githubusercontent.com/43128873/146796811-7edecbeb-839a-4553-ab6d-1918aa8f2014.png)

