### PR TITLE
TransientIonicConductance passes phase object to super. __init__()

### DIFF
--- a/openpnm/algorithms/_transient_ionic_conduction.py
+++ b/openpnm/algorithms/_transient_ionic_conduction.py
@@ -23,5 +23,5 @@ class TransientIonicConduction(TransientReactiveTransport,
 
     def __init__(self, phase, settings=None, **kwargs):
         self.settings = SettingsAttr(TransientIonicConductionSettings, settings)
-        super().__init__(settings=self.settings, **kwargs)
+        super().__init__(phase, settings=self.settings, **kwargs)
         self.settings['phase'] = phase.name

--- a/openpnm/algorithms/_transient_ionic_conduction.py
+++ b/openpnm/algorithms/_transient_ionic_conduction.py
@@ -21,7 +21,6 @@ class TransientIonicConduction(TransientReactiveTransport,
     of pure diffusion and advection-diffusion problems.
     """
 
-    def __init__(self, phase, settings=None, **kwargs):
+    def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(TransientIonicConductionSettings, settings)
-        super().__init__(phase, settings=self.settings, **kwargs)
-        self.settings['phase'] = phase.name
+        super().__init__(settings=self.settings, **kwargs)


### PR DESCRIPTION
fixes #2310 