### PR TITLE
Replace pore surface area for loop with numpy unbuffered operation

### DIFF
--- a/openpnm/models/geometry/pore_surface_area/_funcs.py
+++ b/openpnm/models/geometry/pore_surface_area/_funcs.py
@@ -73,8 +73,7 @@ def circle(
 
     """
     network = target.project.network
-    R = target[pore_diameter] / 2
-    value = 2 * _np.pi * R
+    value = _np.pi * target[pore_diameter]
     Tca = network[throat_cross_sectional_area]
     _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
@@ -100,7 +99,7 @@ def cube(
     """
     network = target.project.network
     D = target[pore_diameter]
-    value = 6 * D**2
+    value = 6.0 * D**2
     Tca = network[throat_cross_sectional_area]
     _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
@@ -126,7 +125,7 @@ def square(
     """
     network = target.project.network
     D = target[pore_diameter]
-    value = 4 * D
+    value = 4.0 * D
     Tca = network[throat_cross_sectional_area]
     _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value

--- a/openpnm/models/geometry/pore_surface_area/_funcs.py
+++ b/openpnm/models/geometry/pore_surface_area/_funcs.py
@@ -46,6 +46,7 @@ def sphere(
     value = 4 * _np.pi * R**2
     Tca = network[throat_cross_sectional_area]
     _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    value = value[network.pores(target.name)]
     return value
 
 
@@ -76,6 +77,7 @@ def circle(
     value = _np.pi * network[pore_diameter]
     Tca = network[throat_cross_sectional_area]
     _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    value = value[network.pores(target.name)]
     return value
 
 
@@ -102,6 +104,7 @@ def cube(
     value = 6.0 * D**2
     Tca = network[throat_cross_sectional_area]
     _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    value = value[network.pores(target.name)]
     return value
 
 
@@ -128,4 +131,5 @@ def square(
     value = 4.0 * D
     Tca = network[throat_cross_sectional_area]
     _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    value = value[network.pores(target.name)]
     return value

--- a/openpnm/models/geometry/pore_surface_area/_funcs.py
+++ b/openpnm/models/geometry/pore_surface_area/_funcs.py
@@ -44,8 +44,8 @@ def sphere(
     network = target.project.network
     R = target[pore_diameter] / 2
     value = 4 * _np.pi * R**2
-    Tca = network[throat_cross_sectional_area]
-    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    Tca = network[throat_cross_sectional_area][target.Ts]
+    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -74,8 +74,8 @@ def circle(
     """
     network = target.project.network
     value = _np.pi * target[pore_diameter]
-    Tca = network[throat_cross_sectional_area]
-    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    Tca = network[throat_cross_sectional_area][target.Ts]
+    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -100,8 +100,8 @@ def cube(
     network = target.project.network
     D = target[pore_diameter]
     value = 6.0 * D**2
-    Tca = network[throat_cross_sectional_area]
-    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    Tca = network[throat_cross_sectional_area][target.Ts]
+    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -126,6 +126,6 @@ def square(
     network = target.project.network
     D = target[pore_diameter]
     value = 4.0 * D
-    Tca = network[throat_cross_sectional_area]
-    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
+    Tca = network[throat_cross_sectional_area][target.Ts]
+    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
     return value

--- a/openpnm/models/geometry/pore_surface_area/_funcs.py
+++ b/openpnm/models/geometry/pore_surface_area/_funcs.py
@@ -42,10 +42,10 @@ def sphere(
 
     """
     network = target.project.network
-    R = target[pore_diameter] / 2
+    R = network[pore_diameter] / 2
     value = 4 * _np.pi * R**2
-    Tca = network[throat_cross_sectional_area][target.Ts]
-    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -73,9 +73,9 @@ def circle(
 
     """
     network = target.project.network
-    value = _np.pi * target[pore_diameter]
-    Tca = network[throat_cross_sectional_area][target.Ts]
-    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
+    value = _np.pi * network[pore_diameter]
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -98,10 +98,10 @@ def cube(
 
     """
     network = target.project.network
-    D = target[pore_diameter]
+    D = network[pore_diameter]
     value = 6.0 * D**2
-    Tca = network[throat_cross_sectional_area][target.Ts]
-    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -124,8 +124,8 @@ def square(
 
     """
     network = target.project.network
-    D = target[pore_diameter]
+    D = network[pore_diameter]
     value = 4.0 * D
-    Tca = network[throat_cross_sectional_area][target.Ts]
-    _np.subtract.at(value, network.conns[target.Ts].flatten(), _np.repeat(Tca, repeats=2))
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value

--- a/openpnm/models/geometry/pore_surface_area/_funcs.py
+++ b/openpnm/models/geometry/pore_surface_area/_funcs.py
@@ -43,10 +43,9 @@ def sphere(
     """
     network = target.project.network
     R = target[pore_diameter] / 2
-    Asurf = 4 * _np.pi * R**2
-    Tn = network.find_neighbor_throats(pores=target.Ps, flatten=False)
-    Tsurf = _np.array([network[throat_cross_sectional_area][Ts].sum() for Ts in Tn])
-    value = Asurf - Tsurf
+    value = 4 * _np.pi * R**2
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -75,10 +74,9 @@ def circle(
     """
     network = target.project.network
     R = target[pore_diameter] / 2
-    Asurf = 2 * _np.pi * R
-    Tn = network.find_neighbor_throats(pores=target.Ps, flatten=False)
-    Tsurf = _np.array([network[throat_cross_sectional_area][Ts].sum() for Ts in Tn])
-    value = Asurf - Tsurf
+    value = 2 * _np.pi * R
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -102,9 +100,9 @@ def cube(
     """
     network = target.project.network
     D = target[pore_diameter]
-    Tn = network.find_neighbor_throats(pores=target.Ps, flatten=False)
-    Tsurf = _np.array([network[throat_cross_sectional_area][Ts].sum() for Ts in Tn])
-    value = 6 * D**2 - Tsurf
+    value = 6 * D**2
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value
 
 
@@ -128,7 +126,7 @@ def square(
     """
     network = target.project.network
     D = target[pore_diameter]
-    Tn = network.find_neighbor_throats(pores=target.Ps, flatten=False)
-    Tsurf = _np.array([network[throat_cross_sectional_area][Ts].sum() for Ts in Tn])
-    value = 4 * D - Tsurf
+    value = 4 * D
+    Tca = network[throat_cross_sectional_area]
+    _np.subtract.at(value, network.conns.flatten(), _np.repeat(Tca, repeats=2))
     return value

--- a/tests/unit/models/geometry/PoreSurfaceAreaTest.py
+++ b/tests/unit/models/geometry/PoreSurfaceAreaTest.py
@@ -49,7 +49,7 @@ class PoreSurfaceAreaTest:
         b = np.unique(self.geo['pore.surface_area'])
         assert_allclose(a, b)
 
-    def test_circle_partial_geom(self):
+    def test_circle_multi_geom(self):
         self.net = op.network.Cubic(shape=[10, 1, 1], spacing=1.0)
         self.geo1 = op.geometry.GenericGeometry(network=self.net,
                                                 pores=self.net.Ps[0:3],
@@ -67,9 +67,14 @@ class PoreSurfaceAreaTest:
         self.geo1.add_model(propname='pore.surface_area',
                             model=mods.circle,
                             regen_mode='normal')
-        a = np.array([2.84, 2.54, 2.54])
-        b = np.unique(self.geo1['pore.surface_area'])
+        a = np.array([2.84159265, 2.54159265, 2.54159265])
+        b = self.geo1['pore.surface_area']
+        c = np.array([2.74159265, 2.94159265, 2.94159265,
+                      2.94159265, 2.94159265, 2.94159265,
+                      3.04159265])
+        d = self.geo2['pore.surface_area']
         assert_allclose(a, b)
+        assert_allclose(c, d)
 
 
 if __name__ == '__main__':

--- a/tests/unit/models/geometry/PoreSurfaceAreaTest.py
+++ b/tests/unit/models/geometry/PoreSurfaceAreaTest.py
@@ -53,15 +53,22 @@ class PoreSurfaceAreaTest:
         self.net = op.network.Cubic(shape=[10, 1, 1], spacing=1.0)
         self.geo1 = op.geometry.GenericGeometry(network=self.net,
                                                 pores=self.net.Ps[0:3],
-                                                throats=self.net.Ts[0:2])
-
+                                                throats=self.net.Ts[0:3])
+        self.geo2 = op.geometry.GenericGeometry(network=self.net,
+                                                pores=self.net.Ps[3:],
+                                                throats=self.net.Ts[3:])
         self.geo1['pore.diameter'] = 1
-        self.geo1['throat.cross_sectional_area'] = 0.1
+        self.geo1['throat.cross_sectional_area'] = 0.3
+        self.geo2['pore.diameter'] = 1
+        self.geo2['throat.cross_sectional_area'] = 0.1
+        self.geo2.add_model(propname='pore.surface_area',
+                            model=mods.circle,
+                            regen_mode='normal')
         self.geo1.add_model(propname='pore.surface_area',
                             model=mods.circle,
                             regen_mode='normal')
-        a = np.array([3.4, 3.5, 3.6, 3.7])
-        b = np.unique(self.geo['pore.surface_area'])
+        a = np.array([2.84, 2.54, 2.54])
+        b = np.unique(self.geo1['pore.surface_area'])
         assert_allclose(a, b)
 
 

--- a/tests/unit/models/geometry/PoreSurfaceAreaTest.py
+++ b/tests/unit/models/geometry/PoreSurfaceAreaTest.py
@@ -49,6 +49,21 @@ class PoreSurfaceAreaTest:
         b = np.unique(self.geo['pore.surface_area'])
         assert_allclose(a, b)
 
+    def test_circle_partial_geom(self):
+        self.net = op.network.Cubic(shape=[10, 1, 1], spacing=1.0)
+        self.geo1 = op.geometry.GenericGeometry(network=self.net,
+                                                pores=self.net.Ps[0:3],
+                                                throats=self.net.Ts[0:2])
+
+        self.geo1['pore.diameter'] = 1
+        self.geo1['throat.cross_sectional_area'] = 0.1
+        self.geo1.add_model(propname='pore.surface_area',
+                            model=mods.circle,
+                            regen_mode='normal')
+        a = np.array([3.4, 3.5, 3.6, 3.7])
+        b = np.unique(self.geo['pore.surface_area'])
+        assert_allclose(a, b)
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
This PR closes #2327. We use [numpy.subtract.at](https://numpy.org/doc/stable/reference/generated/numpy.ufunc.at.html) to perform in place subtraction.
- [x] Update surface area functions
- [x] Tests check
- [x] Check for multi-geom networks