### PR TITLE
Remove prefix from settings

### DIFF
--- a/openpnm/algorithms/_advection_diffusion.py
+++ b/openpnm/algorithms/_advection_diffusion.py
@@ -29,7 +29,6 @@ class AdvectionDiffusionSettings:
         algorithm.
 
     """
-    name = 'ad_01'
     quantity = 'pore.concentration'
     conductance = 'throat.ad_dif_conductance'
     diffusive_conductance = 'throat.diffusive_conductance'
@@ -44,6 +43,8 @@ class AdvectionDiffusion(ReactiveTransport):
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(AdvectionDiffusionSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'ad_01'
         super().__init__(settings=self.settings, **kwargs)
 
     @docstr.dedent

--- a/openpnm/algorithms/_advection_diffusion.py
+++ b/openpnm/algorithms/_advection_diffusion.py
@@ -29,7 +29,7 @@ class AdvectionDiffusionSettings:
         algorithm.
 
     """
-    prefix = 'ad'
+    name = 'ad_01'
     quantity = 'pore.concentration'
     conductance = 'throat.ad_dif_conductance'
     diffusive_conductance = 'throat.diffusive_conductance'

--- a/openpnm/algorithms/_drainage.py
+++ b/openpnm/algorithms/_drainage.py
@@ -53,6 +53,8 @@ class Drainage(GenericAlgorithm):
 
     def __init__(self, phase, settings=None, **kwargs):
         self.settings = SettingsAttr(DrainageSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'drainage_01'
         super().__init__(settings=self.settings, **kwargs)
         self.settings['phase'] = phase.name
         self.reset()

--- a/openpnm/algorithms/_fickian_diffusion.py
+++ b/openpnm/algorithms/_fickian_diffusion.py
@@ -16,7 +16,7 @@ class FickianDiffusionSettings():
     %(ReactiveTransportSettings.parameters)s
 
     """
-    prefix = 'fick'
+    name = 'fick_01'
     quantity = 'pore.concentration'
     conductance = 'throat.diffusive_conductance'
 

--- a/openpnm/algorithms/_fickian_diffusion.py
+++ b/openpnm/algorithms/_fickian_diffusion.py
@@ -1,8 +1,11 @@
 import logging
 from openpnm.algorithms import ReactiveTransport
 from openpnm.utils import Docorator, SettingsAttr
+
+
 docstr = Docorator()
 logger = logging.getLogger(__name__)
+
 
 __all__ = ['FickianDiffusion']
 
@@ -16,7 +19,6 @@ class FickianDiffusionSettings():
     %(ReactiveTransportSettings.parameters)s
 
     """
-    name = 'fick_01'
     quantity = 'pore.concentration'
     conductance = 'throat.diffusive_conductance'
 
@@ -49,4 +51,6 @@ class FickianDiffusion(ReactiveTransport):
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(FickianDiffusionSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'fick_01'
         super().__init__(settings=self.settings, **kwargs)

--- a/openpnm/algorithms/_fourier_conduction.py
+++ b/openpnm/algorithms/_fourier_conduction.py
@@ -12,6 +12,8 @@ __all__ = ['FourierConduction']
 
 @docstr.dedent
 class FourierConductionSettings:
+    r'''
+    '''
     quantity = 'pore.temperature'
     conductance = 'throat.thermal_conductance'
 

--- a/openpnm/algorithms/_fourier_conduction.py
+++ b/openpnm/algorithms/_fourier_conduction.py
@@ -1,12 +1,16 @@
 import logging
 from openpnm.algorithms import ReactiveTransport
 from openpnm.utils import Docorator, SettingsAttr
+
+
 logger = logging.getLogger(__name__)
 docstr = Docorator()
+
 
 __all__ = ['FourierConduction']
 
 
+@docstr.dedent
 class FourierConductionSettings:
     quantity = 'pore.temperature'
     conductance = 'throat.thermal_conductance'
@@ -14,10 +18,12 @@ class FourierConductionSettings:
 
 class FourierConduction(ReactiveTransport):
     r"""
-    A subclass of GenericLinearTransport to simulate heat conduction.
+    A subclass of GenericLinearTransport to simulate heat conduction
 
     """
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(FourierConductionSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'fourier_01'
         super().__init__(settings=self.settings, **kwargs)

--- a/openpnm/algorithms/_generic_algorithm.py
+++ b/openpnm/algorithms/_generic_algorithm.py
@@ -39,7 +39,8 @@ class GenericAlgorithm(Domain):
     """
 
     def __init__(self, network, settings=None, **kwargs):
-        self.settings = SettingsAttr(GenericAlgorithmSettings, settings)
+        self._settings = SettingsAttr(GenericAlgorithmSettings)
+        self.settings._update(settings)
         if 'name' not in kwargs.keys():
             kwargs['name'] = 'alg_01'
         super().__init__(network=network, settings=self.settings, **kwargs)

--- a/openpnm/algorithms/_generic_algorithm.py
+++ b/openpnm/algorithms/_generic_algorithm.py
@@ -21,8 +21,6 @@ class GenericAlgorithmSettings:
     %(BaseSettings.parameters)s
 
     """
-    prefix = 'alg'
-    name = ''
 
 
 @docstr.get_sections(base='GenericAlgorithm', sections=['Parameters'])
@@ -42,6 +40,8 @@ class GenericAlgorithm(Domain):
 
     def __init__(self, network, settings=None, **kwargs):
         self.settings = SettingsAttr(GenericAlgorithmSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'alg_01'
         super().__init__(network=network, settings=self.settings, **kwargs)
         self['pore.all'] = np.ones(network.Np, dtype=bool)
         self['throat.all'] = np.ones(network.Nt, dtype=bool)

--- a/openpnm/algorithms/_generic_transport.py
+++ b/openpnm/algorithms/_generic_transport.py
@@ -37,7 +37,6 @@ class GenericTransportSettings:
         If ``True``, A matrix is cached and rather than getting rebuilt.
 
     """
-    name = 'transport_01'
     phase = ''
     quantity = ''
     conductance = ''
@@ -68,6 +67,8 @@ class GenericTransport(GenericAlgorithm, BCsMixin):
 
     def __init__(self, phase, settings=None, **kwargs):
         self.settings = SettingsAttr(GenericTransportSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'trans_01'
         super().__init__(settings=self.settings, **kwargs)
         self.settings['phase'] = phase.name
         self['pore.bc_rate'] = np.nan

--- a/openpnm/algorithms/_generic_transport.py
+++ b/openpnm/algorithms/_generic_transport.py
@@ -37,7 +37,7 @@ class GenericTransportSettings:
         If ``True``, A matrix is cached and rather than getting rebuilt.
 
     """
-    prefix = 'transport'
+    name = 'transport_01'
     phase = ''
     quantity = ''
     conductance = ''

--- a/openpnm/algorithms/_invasion_percolation.py
+++ b/openpnm/algorithms/_invasion_percolation.py
@@ -56,8 +56,11 @@ class InvasionPercolation(GenericAlgorithm):
     structure is very efficient at this.
 
     """
+
     def __init__(self, phase, settings=None, **kwargs):
         self.settings = SettingsAttr(IPSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'invasion_01'
         super().__init__(settings=self.settings, **kwargs)
         self.settings['phase'] = phase.name
         self['pore.invasion_sequence'] = -1

--- a/openpnm/algorithms/_ionic_conduction.py
+++ b/openpnm/algorithms/_ionic_conduction.py
@@ -41,6 +41,8 @@ class IonicConduction(ReactiveTransport):
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(IonicConductionSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'ionic_01'
         super().__init__(settings=self.settings, **kwargs)
 
     def _charge_conservation_eq_source_term(self, e_alg):

--- a/openpnm/algorithms/_mixed_ip.py
+++ b/openpnm/algorithms/_mixed_ip.py
@@ -78,6 +78,8 @@ class MixedInvasionPercolation(GenericAlgorithm):
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(MixedIPSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'mixed_IP_01'
         super().__init__(settings=self.settings, **kwargs)
 
     def setup(

--- a/openpnm/algorithms/_mixed_ip_coop.py
+++ b/openpnm/algorithms/_mixed_ip_coop.py
@@ -53,6 +53,8 @@ class MixedInvasionPercolationCoop(MixedInvasionPercolation):
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(MixedIPCoopSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'mixed_IP_coop_01'
         super().__init__(settings=self.settings, **kwargs)
 
     def setup(

--- a/openpnm/algorithms/_ohmic_conduction.py
+++ b/openpnm/algorithms/_ohmic_conduction.py
@@ -1,8 +1,11 @@
 import logging
 from openpnm.algorithms import ReactiveTransport
 from openpnm.utils import Docorator, SettingsAttr
+
+
 docstr = Docorator()
 logger = logging.getLogger(__name__)
+
 
 __all__ = ['OhmicConduction']
 
@@ -31,4 +34,6 @@ class OhmicConduction(ReactiveTransport):
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(OhmicConductionSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'ohmic_01'
         super().__init__(settings=self.settings, **kwargs)

--- a/openpnm/algorithms/_reactive_transport.py
+++ b/openpnm/algorithms/_reactive_transport.py
@@ -39,7 +39,6 @@ class ReactiveTransportSettings:
         Relative tolerance for the solution vector
 
     """
-    name = 'react_trans_01'
     relaxation_factor = 1.0
     sources = TypedList(types=[str])
     newton_maxiter = 5000
@@ -66,6 +65,8 @@ class ReactiveTransport(GenericTransport):
 
     def __init__(self, phase, settings=None, **kwargs):
         self.settings = SettingsAttr(ReactiveTransportSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'react_trans_01'
         super().__init__(phase=phase, settings=self.settings, **kwargs)
         self.settings['phase'] = phase.name
 

--- a/openpnm/algorithms/_reactive_transport.py
+++ b/openpnm/algorithms/_reactive_transport.py
@@ -39,7 +39,7 @@ class ReactiveTransportSettings:
         Relative tolerance for the solution vector
 
     """
-    prefix = 'react_trans'
+    name = 'react_trans_01'
     relaxation_factor = 1.0
     sources = TypedList(types=[str])
     newton_maxiter = 5000

--- a/openpnm/algorithms/_stokes_flow.py
+++ b/openpnm/algorithms/_stokes_flow.py
@@ -10,7 +10,7 @@ __all__ = ['StokesFlow']
 
 
 class StokesFlowSettings:
-    prefix = 'stokes'
+    name = 'stokes_01'
     quantity = 'pore.pressure'
     conductance = 'throat.hydraulic_conductance'
 

--- a/openpnm/algorithms/_stokes_flow.py
+++ b/openpnm/algorithms/_stokes_flow.py
@@ -10,7 +10,6 @@ __all__ = ['StokesFlow']
 
 
 class StokesFlowSettings:
-    name = 'stokes_01'
     quantity = 'pore.pressure'
     conductance = 'throat.hydraulic_conductance'
 
@@ -22,4 +21,6 @@ class StokesFlow(ReactiveTransport):
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(StokesFlowSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'stokes_01'
         super().__init__(settings=deepcopy(self.settings), **kwargs)

--- a/openpnm/algorithms/_transient_advection_diffusion.py
+++ b/openpnm/algorithms/_transient_advection_diffusion.py
@@ -16,7 +16,7 @@ class TransientAdvectionDiffusionSettings:
     %(TransientReactiveTransportSettings.parameters)s
 
     """
-    prefix = 'trans_ad'
+    name = 'trans_ad_01'
 
 
 class TransientAdvectionDiffusion(TransientReactiveTransport,

--- a/openpnm/algorithms/_transient_advection_diffusion.py
+++ b/openpnm/algorithms/_transient_advection_diffusion.py
@@ -16,7 +16,6 @@ class TransientAdvectionDiffusionSettings:
     %(TransientReactiveTransportSettings.parameters)s
 
     """
-    name = 'trans_ad_01'
 
 
 class TransientAdvectionDiffusion(TransientReactiveTransport,
@@ -28,4 +27,6 @@ class TransientAdvectionDiffusion(TransientReactiveTransport,
 
     def __init__(self, phase, settings=None, **kwargs):
         self.settings = SettingsAttr(TransientAdvectionDiffusionSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'trans_ad_01'
         super().__init__(phase=phase, settings=self.settings, **kwargs)

--- a/openpnm/algorithms/_transient_fickian_diffusion.py
+++ b/openpnm/algorithms/_transient_fickian_diffusion.py
@@ -11,4 +11,6 @@ class TransientFickianDiffusion(TransientReactiveTransport, FickianDiffusion):
     """
 
     def __init__(self, **kwargs):
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'trans_fick_01'
         super().__init__(**kwargs)

--- a/openpnm/algorithms/_transient_ionic_conduction.py
+++ b/openpnm/algorithms/_transient_ionic_conduction.py
@@ -24,4 +24,6 @@ class TransientIonicConduction(TransientReactiveTransport,
 
     def __init__(self, settings=None, **kwargs):
         self.settings = SettingsAttr(TransientIonicConductionSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'trans_ionic_01'
         super().__init__(settings=self.settings, **kwargs)

--- a/openpnm/algorithms/_transient_reactive_transport.py
+++ b/openpnm/algorithms/_transient_reactive_transport.py
@@ -44,6 +44,8 @@ class TransientReactiveTransport(ReactiveTransport):
 
     def __init__(self, phase, settings=None, **kwargs):
         self.settings = SettingsAttr(TransientReactiveTransportSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'trans_react_01'
         super().__init__(phase=phase, settings=self.settings, **kwargs)
         self.settings['phase'] = phase.name
         self["pore.ic"] = np.nan

--- a/openpnm/core/_base.py
+++ b/openpnm/core/_base.py
@@ -20,8 +20,6 @@ class BaseSettings:
 
     Parameters
     ----------
-    prefix : str
-        The default prefix to use when generating a name
     name : str
         The name of the object, which will be generated if not given
     uuid : str

--- a/openpnm/core/_base2.py
+++ b/openpnm/core/_base2.py
@@ -38,9 +38,7 @@ class Base2(dict):
         self.settings._update(settings)
         self.settings['uuid'] = str(uuid.uuid4())
         # Add parameters attr
-        self._params = PrintableDict()
-        self._params._key = "Parameters"
-        self._params._value = "Values"
+        self._params = PrintableDict(key="Parameters", value="Value")
         # Associate with project
         if network is None:
             project = ws.new_project()

--- a/openpnm/core/_base2.py
+++ b/openpnm/core/_base2.py
@@ -241,7 +241,7 @@ class Base2(dict):
 
     def _set_name(self, name, validate=True):
         if not hasattr(self, '_name'):
-            self._name = None
+            self._name = ''
         old_name = self._name
         if name == old_name:
             return

--- a/openpnm/core/_base2.py
+++ b/openpnm/core/_base2.py
@@ -22,13 +22,10 @@ class BaseSettings:
 
     Parameters
     ----------
-    prefix : str
-        The default prefix to use when generating a name
     name : str
         The name of the object, which will be generated if not given
 
     """
-    prefix = 'base'
     name = ''
 
 
@@ -40,7 +37,7 @@ class Base2(dict):
         instance._settings_docs = None
         return instance
 
-    def __init__(self, project=None, network=None, settings=None, name=None):
+    def __init__(self, project=None, network=None, settings=None, name='obj'):
         super().__init__()
         self.settings = SettingsAttr(BaseSettings, settings)
         if project is None:
@@ -48,11 +45,9 @@ class Base2(dict):
                 project = ws.new_project()
             else:
                 project = network.project
-        project.extend(self)
-        if name is None:
-            name = project._generate_name(self)
-        project._validate_name(name)
+        name = project._generate_name(name)
         self.settings['name'] = name
+        project.extend(self)
         # Add parameters attr
         self._params = PrintableDict()
         self._params._key = "Parameters"
@@ -252,10 +247,7 @@ class Base2(dict):
         old_name = self.settings['name']
         if name == old_name:
             return
-        if name is None:
-            name = self.project._generate_name(self)
-        if validate:
-            self.project._validate_name(name)
+        name = self.project._generate_name(name)
         self.settings['name'] = name
         if self.Np is not None:
             self['pore.'+name] = np.ones([self.Np, ], dtype=bool)

--- a/openpnm/core/_base2.py
+++ b/openpnm/core/_base2.py
@@ -44,9 +44,8 @@ class Base2(dict):
             project = ws.new_project()
         else:
             project = network.project
-        name = project._generate_name(name)
-        self.settings['name'] = name
         project.extend(self)
+        self.name = name
         # Add parameters attr
         self._params = PrintableDict()
         self._params._key = "Parameters"

--- a/openpnm/core/_base2.py
+++ b/openpnm/core/_base2.py
@@ -4,6 +4,7 @@ from openpnm.utils import Workspace, SettingsAttr, PrintableList, PrintableDict
 from openpnm.utils import parse_mode
 from copy import deepcopy
 import inspect
+import uuid
 import numpy.lib.recfunctions as rf
 
 
@@ -22,34 +23,31 @@ class BaseSettings:
 
     Parameters
     ----------
-    name : str
-        The name of the object, which will be generated if not given
+    uuid : str
+        A universally unique identifier for the object to keep things straight
 
     """
-    name = 'obj'
 
 
 class Base2(dict):
 
-    def __new__(cls, *args, **kwargs):
-        instance = super().__new__(cls, *args, **kwargs)
-        instance._settings = None
-        instance._settings_docs = None
-        return instance
-
     def __init__(self, network=None, settings=None, name='obj'):
         super().__init__()
-        self.settings = SettingsAttr(BaseSettings, settings)
+        # Add settings attribute
+        self._settings = SettingsAttr(BaseSettings)
+        self.settings._update(settings)
+        self.settings['uuid'] = str(uuid.uuid4())
+        # Add parameters attr
+        self._params = PrintableDict()
+        self._params._key = "Parameters"
+        self._params._value = "Values"
+        # Associate with project
         if network is None:
             project = ws.new_project()
         else:
             project = network.project
         project.extend(self)
         self.name = name
-        # Add parameters attr
-        self._params = PrintableDict()
-        self._params._key = "Parameters"
-        self._params._value = "Values"
 
     def __eq__(self, other):
         return hex(id(self)) == hex(id(other))
@@ -242,11 +240,13 @@ class Base2(dict):
             return PrintableList(vals)
 
     def _set_name(self, name, validate=True):
-        old_name = self.settings['name']
+        if not hasattr(self, '_name'):
+            self._name = None
+        old_name = self._name
         if name == old_name:
             return
         name = self.project._generate_name(name)
-        self.settings['name'] = name
+        self._name = name
         if self.Np is not None:
             self['pore.'+name] = np.ones([self.Np, ], dtype=bool)
         if self.Nt is not None:
@@ -254,7 +254,7 @@ class Base2(dict):
 
     def _get_name(self):
         try:
-            return self.settings['name']
+            return self._name
         except AttributeError:
             return None
 
@@ -269,14 +269,14 @@ class Base2(dict):
 
     def _set_settings(self, settings):
         self._settings = deepcopy(settings)
-        if (self._settings_docs is None) and (settings.__doc__ is not None):
-            self._settings_docs = settings.__doc__
+        # if (self._settings_docs is None) and (settings.__doc__ is not None):
+        #     self._settings_docs = settings.__doc__
 
     def _get_settings(self):
         if self._settings is None:
             self._settings = SettingsAttr()
-        if self._settings_docs is not None:
-            self._settings.__dict__['__doc__'] = self._settings_docs
+        # if self._settings_docs is not None:
+        #     self._settings.__dict__['__doc__'] = self._settings_docs
         return self._settings
 
     def _del_settings(self):

--- a/openpnm/core/_base2.py
+++ b/openpnm/core/_base2.py
@@ -26,7 +26,7 @@ class BaseSettings:
         The name of the object, which will be generated if not given
 
     """
-    name = ''
+    name = 'obj'
 
 
 class Base2(dict):
@@ -37,14 +37,13 @@ class Base2(dict):
         instance._settings_docs = None
         return instance
 
-    def __init__(self, project=None, network=None, settings=None, name='obj'):
+    def __init__(self, network=None, settings=None, name='obj'):
         super().__init__()
         self.settings = SettingsAttr(BaseSettings, settings)
-        if project is None:
-            if network is None:
-                project = ws.new_project()
-            else:
-                project = network.project
+        if network is None:
+            project = ws.new_project()
+        else:
+            project = network.project
         name = project._generate_name(name)
         self.settings['name'] = name
         project.extend(self)

--- a/openpnm/metrics/_absolute_permeability.py
+++ b/openpnm/metrics/_absolute_permeability.py
@@ -17,8 +17,6 @@ class AbsolutePermeabilitySettings:
     Defines the settings for AbsolutePermeablity
 
     ----------
-    prefix : str
-        The default prefix to use when generating a name
     inlet : str
         The pore labels for flow inlet.
     outlet : str
@@ -29,7 +27,7 @@ class AbsolutePermeabilitySettings:
         The length of the network relative to the inlet and outlet
 
     """
-    prefix = 'perm'
+    name = 'perm_01'
     inlet = 'left'
     outlet = 'right'
     area = None

--- a/openpnm/metrics/_effective_diffusivity.py
+++ b/openpnm/metrics/_effective_diffusivity.py
@@ -17,8 +17,6 @@ class EffectiveDiffusivitySettings:
     Defines the settings for EffectiveDiffusivity
 
     ----------
-    prefix : str
-        The default prefix to use when generating a name
     inlet : str
         The pore labels for diffusion inlet.
     outlet : str
@@ -29,7 +27,7 @@ class EffectiveDiffusivitySettings:
         The length of the network relative to the inlet and outlet
 
     """
-    prefix = 'edif'
+    name = 'deff_01'
     inlet = 'left'
     outlet = 'right'
     area = None

--- a/openpnm/metrics/_formation_factor.py
+++ b/openpnm/metrics/_formation_factor.py
@@ -17,8 +17,6 @@ class FormationFactorSettings:
     Defines the settings for FormationFactor
 
     ----------
-    prefix : str
-        The default prefix to use when generating a name
     inlet : str
         The pore labels for diffusion inlet.
     outlet : str
@@ -29,7 +27,7 @@ class FormationFactorSettings:
         The length of the network relative to the inlet and outlet
 
     """
-    prefix = 'ff'
+    name = 'ff_01'
     inlet = 'left'
     outlet = 'right'
     area = None

--- a/openpnm/metrics/_mercury_intrusion.py
+++ b/openpnm/metrics/_mercury_intrusion.py
@@ -40,9 +40,9 @@ class MercuryIntrusion(OrdinaryPercolation):
 
     """
 
-    def __init__(self, network, settings=None, **kwargs):
+    def __init__(self, network, **kwargs):
         hg = Mercury(network=network)
-        super().__init__(network=network, phase=hg, settings=self.settings, **kwargs)
+        super().__init__(network=network, phase=hg, **kwargs)
         self.settings['phase'] = hg.name
         mod = models.physics.capillary_pressure.washburn
         hg.add_model(propname='throat.entry_pressure', model=mod)

--- a/openpnm/network/_generic.py
+++ b/openpnm/network/_generic.py
@@ -21,7 +21,6 @@ class NetworkSettings:
     ----------
     %(BaseSettings.parameters)s
     """
-    prefix = 'net'
 
 
 @docstr.get_sections(base='GenericNetwork', sections=['Parameters'])
@@ -94,6 +93,8 @@ class GenericNetwork(Domain):
 
     def __init__(self, conns=None, coords=None, settings=None, **kwargs):
         self.settings = SettingsAttr(NetworkSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'net'
         super().__init__(settings=self.settings, **kwargs)
 
         self._am = {}

--- a/openpnm/phase/_generic.py
+++ b/openpnm/phase/_generic.py
@@ -19,7 +19,6 @@ class PhaseSettings:
     ----------
     %(BaseSettings.parameters)s
     """
-    prefix = 'phase'
 
 
 @docstr.get_sections(base='GenericPhase', sections=['Parameters'])
@@ -38,6 +37,8 @@ class GenericPhase(Domain):
 
     def __init__(self, network, settings=None, **kwargs):
         self.settings = SettingsAttr(PhaseSettings, settings)
+        if 'name' not in kwargs.keys():
+            kwargs['name'] = 'phase_01'
         super().__init__(network=network, settings=self.settings, **kwargs)
 
         self['pore.all'] = np.ones([network.Np, ], dtype=bool)

--- a/openpnm/phase/mixtures/_generic_mixture.py
+++ b/openpnm/phase/mixtures/_generic_mixture.py
@@ -23,7 +23,7 @@ class GenericMixtureSettings:
     """
 
     components = []
-    prefix = 'mix'
+    name = 'mix_01'
 
 
 @docstr.get_sections(base='GenericMixture', sections=['Parameters'])

--- a/openpnm/phase/mixtures/_ideal_gas.py
+++ b/openpnm/phase/mixtures/_ideal_gas.py
@@ -20,7 +20,7 @@ class IdealGas(GenericMixture):
     """
 
     def __init__(self, settings=None, **kwargs):
-        super().__init__(settings={'prefix': 'mix'}, **kwargs)
+        super().__init__(settings={'name': 'mix'}, **kwargs)
         self.settings._update(settings)
 
         self.add_model(propname='pore.molar_density',

--- a/openpnm/utils/_misc.py
+++ b/openpnm/utils/_misc.py
@@ -112,9 +112,9 @@ class PrintableDict(OrderedDict):
 
     """
 
-    def __init__(self, *args, **kwargs):
-        self._value = "Value"
-        self._key = "Key"
+    def __init__(self, *args, key="Key", value="Value", **kwargs):
+        self._value = value
+        self._key = key
         super().__init__(*args, **kwargs)
 
     # def __repr__(self):

--- a/openpnm/utils/_project.py
+++ b/openpnm/utils/_project.py
@@ -21,7 +21,6 @@ class ProjectSettings(SettingsAttr):
     uuid : str
         A universally unique identifier for the object to keep things straight
     """
-    name = 'proj_01'
     uuid = ''
     original_uuid = ''
 

--- a/openpnm/utils/_settings.py
+++ b/openpnm/utils/_settings.py
@@ -158,9 +158,7 @@ class SettingsAttr:
         setattr(self, key, value)
 
     def __str__(self):
-        d = PrintableDict()
-        d._key = 'Settings'
-        d._value = 'Values'
+        d = PrintableDict(key="Settings", value="Values")
         d.update(self.__dict__)
         for item in self.__dir__():
             if not item.startswith('_'):

--- a/openpnm/utils/_workspace.py
+++ b/openpnm/utils/_workspace.py
@@ -1,3 +1,4 @@
+import re
 import logging
 import pickle
 from datetime import datetime
@@ -94,11 +95,16 @@ class Workspace(dict):
         for item in project:
             __main__.__dict__[item.name] = item
 
-    def _validate_name(self, name=None, prefix='proj'):
+    def _validate_name(self, name=None):
         r"""
         Generates a valid name for projects
         """
-        if (name in self.keys()) or (name in [None, '']):
+        if name in [None, '']:
+            name = 'proj_01'  # Give basic name, then let rest of func fix it
+        if name in self.keys():  # If proposed name is taken, increment it
+            if not re.search(r'_\d+$', name):  # If name does not end with _##
+                name = name + '_01'
+            prefix, count = name.rsplit('_', 1)
             n = [0]
             for item in self.keys():
                 if item.startswith(prefix+'_'):

--- a/tests/unit/utils/ProjectTest.py
+++ b/tests/unit/utils/ProjectTest.py
@@ -15,12 +15,17 @@ class ProjectTest:
         self.phase1 = op.phase.GenericPhase(network=self.net)
         self.phase2 = op.phase.GenericPhase(network=self.net)
 
-    def test_change_simulation_name_by_assignment(self):
+    def test_change_project_name_by_assignment(self):
         proj = self.ws.new_project()
         new_name = self.ws._validate_name()
         proj.name = new_name
         assert proj.name == new_name
         assert proj.name in self.ws.keys()
+
+    def test_object_naming(self):
+        pn = op.network.Cubic([3, 3, 3], name='bob')
+        proj = pn.project
+        assert 'bob' in proj.names
 
     # def test_change_simulation_name_by_moving_in_dict(self):
     #     proj = self.ws.new_project()

--- a/tests/unit/utils/ProjectTest.py
+++ b/tests/unit/utils/ProjectTest.py
@@ -10,8 +10,8 @@ class ProjectTest:
     def setup_class(self):
         self.ws = op.Workspace()
         self.ws.clear()
-        self.proj = self.ws.new_project()
-        self.net = op.network.Cubic(shape=[2, 2, 2], project=self.proj)
+        self.net = op.network.Cubic(shape=[2, 2, 2])
+        self.proj = self.net.project
         self.phase1 = op.phase.GenericPhase(network=self.net)
         self.phase2 = op.phase.GenericPhase(network=self.net)
 

--- a/tests/unit/utils/WorkspaceTest.py
+++ b/tests/unit/utils/WorkspaceTest.py
@@ -42,8 +42,7 @@ class WorkspaceTest:
     #     self.ws.clear()
 
     def test_str(self):
-        proj = self.ws.new_project()
-        op.network.Cubic(shape=[3, 3, 3], project=proj)
+        op.network.Cubic(shape=[3, 3, 3])
         s = self.ws.__str__().split('\n')
         assert len(s) == 8
         self.ws.clear()


### PR DESCRIPTION
The PR tidies up the settings a bit, by removing the 'prefix' option and actually removing name from settings entirely.  Including the name in the settings was a big pain, so now it's solely just an attribute of the object.  name is less important that it used to be, but is still needed.

fixes #2431
fixes #2432 