### PR TITLE
Fixing model collections

### DIFF
--- a/example.py
+++ b/example.py
@@ -21,8 +21,8 @@ pn['pore.domain2'] = Ps
 pn['throat.domain2'] = Ts
 
 # Add network/geometry models to both domains
-pn.add_model_collection(collections.geometry.cones_and_cylinders, domain='domain1')
-pn.add_model_collection(collections.geometry.pyramids_and_cuboids, domain='domain2')
+pn.add_model_collection(collections.geometry.cones_and_cylinders(), domain='domain1')
+pn.add_model_collection(collections.geometry.pyramids_and_cuboids(), domain='domain2')
 
 # FIXME: Must regenerate network models, otherwise, phase models will complain
 pn.regenerate_models()
@@ -40,8 +40,9 @@ air['pore.reaction_sites'][[310, 212, 113]] = True
 air.add_model(propname='pore.reaction',
               model=source_terms.power_law,
               X='pore.concentration',
+              A1=-1, A2=2, A3=0,
               domain='reaction_sites',
-              A1=-1, A2=2, A3=0, regen_mode='deferred')
+              regen_mode='deferred')
 
 # Run Fickian diffusion with reaction
 rxn = op.algorithms.FickianDiffusion(network=pn, phase=air)

--- a/example.py
+++ b/example.py
@@ -29,9 +29,8 @@ pn.regenerate_models()
 
 # Create phase and add phase/physics models
 air = op.phase.Air(network=pn, name="air")
-air.models.update(op.models.collections.physics.standard)
-air.add_model_collection(collections.physics.standard, domain='domain1')
-air.add_model_collection(collections.physics.standard, domain='domain2')
+air.add_model_collection(collections.physics.standard(), domain='domain1')
+air.add_model_collection(collections.physics.standard(), domain='domain2')
 air.regenerate_models()
 
 # Add a nonlinear reaction

--- a/openpnm/core/_base2.py
+++ b/openpnm/core/_base2.py
@@ -467,13 +467,16 @@ class ModelMixin2:
         if regen_mode != 'deferred':
             self.run_model(propname+'@'+domain)
 
-    def add_model_collection(self, models, domain='all'):
-        models = deepcopy(models)
+    def add_model_collection(self, models, regen_mode='deferred', domain='all'):
+        # Catch un-run function
+        if hasattr(models, '__call__'):
+            models = models()
         for k, v in models.items():
-            _ = v.pop('regen_mode', None)
-            model = v.pop('model')
-            self.add_model(propname=k, model=model, domain=domain,
-                           regen_mode='deferred', **v)
+            if 'domain' not in v.keys():
+                v['domain'] = domain
+            if 'regen_mode' not in v.keys():
+                v['regen_mode'] = regen_mode
+            self.add_model(propname=k, **v)
 
     def regenerate_models(self, propnames=None, exclude=[]):
         all_models = self.models.dependency_list()

--- a/openpnm/core/_models.py
+++ b/openpnm/core/_models.py
@@ -202,6 +202,9 @@ class ModelsDict(PrintableDict):
                 raise KeyError(key)
 
     def update(self, d, domain='all'):
+        # Catch un-run function
+        if hasattr(d, '__call__'):
+            d = d()
         parent = self._find_parent()
         for k, v in d.items():
             parent.add_model(propname=k, domain=domain, **v)

--- a/openpnm/core/_models.py
+++ b/openpnm/core/_models.py
@@ -204,7 +204,7 @@ class ModelsDict(PrintableDict):
     def update(self, d, domain='all'):
         # Catch un-run function
         if hasattr(d, '__call__'):
-            d = d()
+            raise Exception('Received dict argument is a function, try running it')
         parent = self._find_parent()
         for k, v in d.items():
             parent.add_model(propname=k, domain=domain, **v)

--- a/openpnm/models/collections/__init__.py
+++ b/openpnm/models/collections/__init__.py
@@ -2,3 +2,12 @@ from . import geometry
 from . import physics
 from . import phase
 from . import network
+from copy import deepcopy as _deepcopy
+
+
+class Geometry(object):
+
+    @classmethod
+    @property
+    def cones_and_cylinders(cls):
+        return _deepcopy(geometry.spheres_and_cylinders())

--- a/openpnm/models/collections/geometry/circles_and_rectangles.py
+++ b/openpnm/models/collections/geometry/circles_and_rectangles.py
@@ -1,69 +1,64 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
 
-circles_and_rectangles = {
+def circles_and_rectangles(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_circles_and_rectangles,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_circles_and_rectangles = {
     'pore.seed': {
         'model': mods.misc.random,
         'element': 'pore',
         'num_range': [0.2, 0.7],
         'seed': None,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.max_size': {
         'model': mods.geometry.pore_size.largest_sphere,
         'iters': 10,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.diameter': {
         'model': mods.misc.product,
         'props': ['pore.max_size', 'pore.seed'],
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.volume': {
         'model': mods.geometry.pore_volume.circle,
         'pore_diameter': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.max_size': {
         'model': mods.misc.from_neighbor_pores,
         'mode': 'min',
         'prop': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.diameter': {
         'model': mods.misc.scaled,
         'factor': 0.5,
         'prop': 'throat.max_size',
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.length': {
         'model': mods.geometry.throat_length.circles_and_rectangles,
         'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.volume': {
         'model': mods.geometry.throat_volume.rectangle,
         'throat_diameter': 'throat.diameter',
         'throat_length': 'throat.length',
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.cross_sectional_area': {
         'model': mods.geometry.throat_cross_sectional_area.rectangle,
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.diffusive_size_factors': {
         'model': mods.geometry.diffusive_size_factors.circles_and_rectangles,
         'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.hydraulic_size_factors': {
         'model': mods.geometry.hydraulic_size_factors.circles_and_rectangles,
         'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-    }
-
+    },
+}

--- a/openpnm/models/collections/geometry/cones_and_cylinders.py
+++ b/openpnm/models/collections/geometry/cones_and_cylinders.py
@@ -1,59 +1,64 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
 
-cones_and_cylinders = {
+def cones_and_cylinders(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_cones_and_cylinders,
+                                regen_mode=regen_mode,
+                                domain=domain)
 
-	'pore.seed': {
-		'model': mods.misc.random,
-		'element': 'pore',
-		'num_range': [0.2, 0.7],
-		'seed': None,
-		},
-	'pore.max_size': {
-		'model': mods.geometry.pore_size.largest_sphere,
-		'iters': 10,
-		},
-	'pore.diameter': {
-		'model': mods.misc.product,
-		'props': ['pore.max_size', 'pore.seed'],
-        },
-	'pore.volume': {
-		'model': mods.geometry.pore_volume.sphere,
-		'pore_diameter': 'pore.diameter',
-		'regen_mode': "explicit",
-		},
-	'throat.max_size': {
-		'model': mods.misc.from_neighbor_pores,
-		'mode': 'min',
-		'prop': 'pore.diameter',
-		},
-	'throat.diameter': {
-		'model': mods.misc.scaled,
-		'factor': 0.5,
-    	'prop': 'throat.max_size',
-    	},
-	'throat.length': {
-		'model': mods.geometry.throat_length.cones_and_cylinders,
-		'pore_diameter': 'pore.diameter',
+
+_cones_and_cylinders = {
+    'pore.seed': {
+        'model': mods.misc.random,
+        'element': 'pore',
+        'num_range': [0.2, 0.7],
+        'seed': None,
+    },
+    'pore.max_size': {
+        'model': mods.geometry.pore_size.largest_sphere,
+        'iters': 10,
+    },
+    'pore.diameter': {
+        'model': mods.misc.product,
+        'props': ['pore.max_size', 'pore.seed'],
+    },
+    'pore.volume': {
+        'model': mods.geometry.pore_volume.sphere,
+        'pore_diameter': 'pore.diameter',
+    },
+    'throat.max_size': {
+        'model': mods.misc.from_neighbor_pores,
+        'mode': 'min',
+        'prop': 'pore.diameter',
+    },
+    'throat.diameter': {
+        'model': mods.misc.scaled,
+        'factor': 0.5,
+        'prop': 'throat.max_size',
+    },
+    'throat.length': {
+        'model': mods.geometry.throat_length.cones_and_cylinders,
+        'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        },
-	'throat.volume': {
-		'model': mods.geometry.throat_volume.cylinder,
-		'throat_diameter': 'throat.diameter',
-		'throat_length': 'throat.length',
-		},
-	'throat.cross_sectional_area': {
-		'model': mods.geometry.throat_cross_sectional_area.cylinder,
-		'throat_diameter': 'throat.diameter',
-		},
-	'throat.diffusive_size_factors': {
-		'model': mods.geometry.diffusive_size_factors.cones_and_cylinders,
-		'pore_diameter': 'pore.diameter',
-		'throat_diameter': 'throat.diameter',
-		},
-	'throat.hydraulic_size_factors': {
-		'model': mods.geometry.hydraulic_size_factors.cones_and_cylinders,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.volume': {
+        'model': mods.geometry.throat_volume.cylinder,
         'throat_diameter': 'throat.diameter',
-        },
-    }
+        'throat_length': 'throat.length',
+    },
+    'throat.cross_sectional_area': {
+        'model': mods.geometry.throat_cross_sectional_area.cylinder,
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.diffusive_size_factors': {
+        'model': mods.geometry.diffusive_size_factors.cones_and_cylinders,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.hydraulic_size_factors': {
+        'model': mods.geometry.hydraulic_size_factors.cones_and_cylinders,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+}

--- a/openpnm/models/collections/geometry/cubes_and_cuboids.py
+++ b/openpnm/models/collections/geometry/cubes_and_cuboids.py
@@ -1,68 +1,64 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
 
-cubes_and_cuboids = {
-	'pore.seed': {
-		'model': mods.misc.random,
+def cubes_and_cuboids(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_cubes_and_cuboids,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_cubes_and_cuboids = {
+    'pore.seed': {
+        'model': mods.misc.random,
         'element': 'pore',
         'num_range': [0.2, 0.7],
         'seed': None,
-        'regen_mode': 'deferred',
-        },
-	'pore.max_size': {
-		'model': mods.geometry.pore_size.largest_sphere,
+    },
+    'pore.max_size': {
+        'model': mods.geometry.pore_size.largest_sphere,
         'iters': 10,
-        'regen_mode': 'deferred',
-        },
-	'pore.diameter': {
-		'model': mods.misc.product,
+    },
+    'pore.diameter': {
+        'model': mods.misc.product,
         'props': ['pore.max_size', 'pore.seed'],
-        'regen_mode': 'deferred',
-		},
-	'pore.volume': {
-		'model': mods.geometry.pore_volume.cube,
+    },
+    'pore.volume': {
+        'model': mods.geometry.pore_volume.cube,
         'pore_diameter': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.max_size': {
-		'model': mods.misc.from_neighbor_pores,
+    },
+    'throat.max_size': {
+        'model': mods.misc.from_neighbor_pores,
         'mode': 'min',
         'prop': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.diameter': {
-		'model': mods.misc.scaled,
+    },
+    'throat.diameter': {
+        'model': mods.misc.scaled,
         'factor': 0.5,
         'prop': 'throat.max_size',
-        'regen_mode': 'deferred',
-        },
-	'throat.length': {
-		'model': mods.geometry.throat_length.cubes_and_cuboids,
+    },
+    'throat.length': {
+        'model': mods.geometry.throat_length.cubes_and_cuboids,
         'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.cross_sectional_area': {
-		'model': mods.geometry.throat_cross_sectional_area.cuboid,
+    },
+    'throat.cross_sectional_area': {
+        'model': mods.geometry.throat_cross_sectional_area.cuboid,
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.volume': {
-		'model': mods.geometry.throat_volume.cuboid,
+    },
+    'throat.volume': {
+        'model': mods.geometry.throat_volume.cuboid,
         'throat_diameter': 'throat.diameter',
         'throat_length': 'throat.length',
-        'regen_mode': 'deferred',
-        },
-	'throat.diffusive_size_factors': {
-		'model': mods.geometry.diffusive_size_factors.cubes_and_cuboids,
+    },
+    'throat.diffusive_size_factors': {
+        'model': mods.geometry.diffusive_size_factors.cubes_and_cuboids,
         'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.hydraulic_size_factors': {
-		'model': mods.geometry.hydraulic_size_factors.cubes_and_cuboids,
+    },
+    'throat.hydraulic_size_factors': {
+        'model': mods.geometry.hydraulic_size_factors.cubes_and_cuboids,
         'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-    }
+    },
+}

--- a/openpnm/models/collections/geometry/pyramids_and_cuboids.py
+++ b/openpnm/models/collections/geometry/pyramids_and_cuboids.py
@@ -1,68 +1,64 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
 
-pyramids_and_cuboids = {
-	'pore.seed': {
-		'model': mods.misc.random,
-		'element': 'pore',
-		'num_range': [0.2, 0.7],
-		'seed': None,
-        'regen_mode': 'deferred',
-		},
-	'pore.max_size': {
-		'model': mods.geometry.pore_size.largest_sphere,
-		'iters': 10,
-        'regen_mode': 'deferred',
-		},
-	'pore.diameter': {
-		'model': mods.misc.product,
-		'props': ['pore.max_size', 'pore.seed'],
-        'regen_mode': 'deferred',
-        },
-	'pore.volume': {
-		'model': mods.geometry.pore_volume.sphere,
-		'pore_diameter': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.max_size': {
-		'model': mods.misc.from_neighbor_pores,
-		'mode': 'min',
+def pyramids_and_cuboids(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_pyramids_and_cuboids,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_pyramids_and_cuboids = {
+    'pore.seed': {
+        'model': mods.misc.random,
+        'element': 'pore',
+        'num_range': [0.2, 0.7],
+        'seed': None,
+    },
+    'pore.max_size': {
+        'model': mods.geometry.pore_size.largest_sphere,
+        'iters': 10,
+    },
+    'pore.diameter': {
+        'model': mods.misc.product,
+        'props': ['pore.max_size', 'pore.seed'],
+    },
+    'pore.volume': {
+        'model': mods.geometry.pore_volume.sphere,
+        'pore_diameter': 'pore.diameter',
+    },
+    'throat.max_size': {
+        'model': mods.misc.from_neighbor_pores,
+        'mode': 'min',
         'prop': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.diameter': {
-		'model': mods.misc.scaled,
-		'factor': 0.5,
-		'prop': 'throat.max_size',
-        'regen_mode': 'deferred',
-		},
-	'throat.length': {
-		'model': mods.geometry.throat_length.pyramids_and_cuboids,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.diameter': {
+        'model': mods.misc.scaled,
+        'factor': 0.5,
+        'prop': 'throat.max_size',
+    },
+    'throat.length': {
+        'model': mods.geometry.throat_length.pyramids_and_cuboids,
+        'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.cross_sectional_area': {
-		'model': mods.geometry.throat_cross_sectional_area.cuboid,
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.volume': {
-		'model': mods.geometry.throat_volume.cuboid,
-		'throat_diameter': 'throat.diameter',
-		'throat_length': 'throat.length',
-        'regen_mode': 'deferred',
-		},
-	'throat.diffusive_size_factors': {
-		'model': mods.geometry.diffusive_size_factors.pyramids_and_cuboids,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.cross_sectional_area': {
+        'model': mods.geometry.throat_cross_sectional_area.cuboid,
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.hydraulic_size_factors': {
-		'model': mods.geometry.hydraulic_size_factors.pyramids_and_cuboids,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.volume': {
+        'model': mods.geometry.throat_volume.cuboid,
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-    }
+        'throat_length': 'throat.length',
+    },
+    'throat.diffusive_size_factors': {
+        'model': mods.geometry.diffusive_size_factors.pyramids_and_cuboids,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.hydraulic_size_factors': {
+        'model': mods.geometry.hydraulic_size_factors.pyramids_and_cuboids,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+}

--- a/openpnm/models/collections/geometry/spheres_and_cylinders.py
+++ b/openpnm/models/collections/geometry/spheres_and_cylinders.py
@@ -1,68 +1,64 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
 
-spheres_and_cylinders = {
-	'pore.seed': {
-		'model': mods.misc.random,
-		'element': 'pore',
-		'num_range': [0.2, 0.7],
-		'seed': None,
-        'regen_mode': 'deferred',
-		},
-	'pore.max_size': {
-		'model': mods.geometry.pore_size.largest_sphere,
-		'iters': 10,
-        'regen_mode': 'deferred',
-		},
-	'pore.diameter': {
-		'model': mods.misc.product,
-		'props': ['pore.max_size', 'pore.seed'],
-        'regen_mode': 'deferred',
-        },
-	'pore.volume': {
-		'model': mods.geometry.pore_volume.sphere,
-		'pore_diameter': 'pore.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.max_size': {
-		'model': mods.misc.from_neighbor_pores,
-		'mode': 'min',
+def spheres_and_cylinders(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_spheres_and_cylinders,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_spheres_and_cylinders = {
+    'pore.seed': {
+        'model': mods.misc.random,
+        'element': 'pore',
+        'num_range': [0.2, 0.7],
+        'seed': None,
+    },
+    'pore.max_size': {
+        'model': mods.geometry.pore_size.largest_sphere,
+        'iters': 10,
+    },
+    'pore.diameter': {
+        'model': mods.misc.product,
+        'props': ['pore.max_size', 'pore.seed'],
+    },
+    'pore.volume': {
+        'model': mods.geometry.pore_volume.sphere,
+        'pore_diameter': 'pore.diameter',
+    },
+    'throat.max_size': {
+        'model': mods.misc.from_neighbor_pores,
+        'mode': 'min',
         'prop': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.diameter': {
-		'model': mods.misc.scaled,
-		'factor': 0.5,
+    },
+    'throat.diameter': {
+        'model': mods.misc.scaled,
+        'factor': 0.5,
         'prop': 'throat.max_size',
-        'regen_mode': 'deferred',
-        },
-	'throat.length': {
-		'model': mods.geometry.throat_length.spheres_and_cylinders,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.length': {
+        'model': mods.geometry.throat_length.spheres_and_cylinders,
+        'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.cross_sectional_area': {
-		'model': mods.geometry.throat_cross_sectional_area.cylinder,
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.volume': {
-		'model': mods.geometry.throat_volume.cylinder,
-		'throat_diameter': 'throat.diameter',
+    },
+    'throat.cross_sectional_area': {
+        'model': mods.geometry.throat_cross_sectional_area.cylinder,
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.volume': {
+        'model': mods.geometry.throat_volume.cylinder,
+        'throat_diameter': 'throat.diameter',
         'throat_length': 'throat.length',
-        'regen_mode': 'deferred',
-        },
-	'throat.diffusive_size_factors': {
-		'model': mods.geometry.diffusive_size_factors.spheres_and_cylinders,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.diffusive_size_factors': {
+        'model': mods.geometry.diffusive_size_factors.spheres_and_cylinders,
+        'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.hydraulic_size_factors': {
-		'model': mods.geometry.hydraulic_size_factors.spheres_and_cylinders,
-		'pore_diameter': 'pore.diameter',
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	}
+    },
+    'throat.hydraulic_size_factors': {
+        'model': mods.geometry.hydraulic_size_factors.spheres_and_cylinders,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+}

--- a/openpnm/models/collections/geometry/squares_and_rectangles.py
+++ b/openpnm/models/collections/geometry/squares_and_rectangles.py
@@ -1,68 +1,64 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
 
-squares_and_rectangles = {
-	'pore.seed': {
-		'model': mods.misc.random,
-		'element': 'pore',
-		'num_range': [0.2, 0.7],
-		'seed': None,
-        'regen_mode': 'deferred',
-		},
-	'pore.max_size': {
-		'model': mods.geometry.pore_size.largest_sphere,
-		'iters': 10,
-        'regen_mode': 'deferred',
-		},
-	'pore.diameter': {
-		'model': mods.misc.product,
-		'props': ['pore.max_size', 'pore.seed'],
-        'regen_mode': 'deferred',
-        },
-	'pore.volume': {
-		'model': mods.geometry.pore_volume.square,
-		'pore_diameter': 'pore.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.max_size': {
-		'model': mods.misc.from_neighbor_pores,
-		'mode': 'min',
+def squares_and_rectangles(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_squares_and_rectangles,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_squares_and_rectangles = {
+    'pore.seed': {
+        'model': mods.misc.random,
+        'element': 'pore',
+        'num_range': [0.2, 0.7],
+        'seed': None,
+    },
+    'pore.max_size': {
+        'model': mods.geometry.pore_size.largest_sphere,
+        'iters': 10,
+    },
+    'pore.diameter': {
+        'model': mods.misc.product,
+        'props': ['pore.max_size', 'pore.seed'],
+    },
+    'pore.volume': {
+        'model': mods.geometry.pore_volume.square,
+        'pore_diameter': 'pore.diameter',
+    },
+    'throat.max_size': {
+        'model': mods.misc.from_neighbor_pores,
+        'mode': 'min',
         'prop': 'pore.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.diameter': {
-		'model': mods.misc.scaled,
-		'factor': 0.5,
+    },
+    'throat.diameter': {
+        'model': mods.misc.scaled,
+        'factor': 0.5,
         'prop': 'throat.max_size',
-        'regen_mode': 'deferred',
-        },
-	'throat.length': {
-		'model': mods.geometry.throat_length.squares_and_rectangles,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.length': {
+        'model': mods.geometry.throat_length.squares_and_rectangles,
+        'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.cross_sectional_area': {
-		'model': mods.geometry.throat_cross_sectional_area.rectangle,
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.volume': {
-		'model': mods.geometry.throat_volume.rectangle,
-		'throat_diameter': 'throat.diameter',
+    },
+    'throat.cross_sectional_area': {
+        'model': mods.geometry.throat_cross_sectional_area.rectangle,
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.volume': {
+        'model': mods.geometry.throat_volume.rectangle,
+        'throat_diameter': 'throat.diameter',
         'throat_length': 'throat.length',
-        'regen_mode': 'deferred',
-        },
-	'throat.diffusive_size_factors': {
-		'model': mods.geometry.diffusive_size_factors.squares_and_rectangles,
-		'pore_diameter': 'pore.diameter',
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.hydraulic_size_factors': {
-		'model': mods.geometry.hydraulic_size_factors.squares_and_rectangles,
-		'pore_diameter': 'pore.diameter',
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	}
+    },
+    'throat.diffusive_size_factors': {
+        'model': mods.geometry.diffusive_size_factors.squares_and_rectangles,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.hydraulic_size_factors': {
+        'model': mods.geometry.hydraulic_size_factors.squares_and_rectangles,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+}

--- a/openpnm/models/collections/geometry/trapezoids_and_rectangles.py
+++ b/openpnm/models/collections/geometry/trapezoids_and_rectangles.py
@@ -1,69 +1,64 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
 
-trapezoids_and_rectangles = {
-	'pore.seed': {
-		'model': mods.misc.random,
-		'element': 'pore',
-		'num_range': [0.2, 0.7],
-		'seed': None,
-        'regen_mode': 'deferred',
-		},
-	'pore.max_size': {
-		'model': mods.geometry.pore_size.largest_sphere,
-		'iters': 10,
-        'regen_mode': 'deferred',
-		},
-	'pore.diameter': {
-		'model': mods.misc.product,
-		'props': ['pore.max_size', 'pore.seed'],
-        'regen_mode': 'deferred',
-        },
-	'pore.volume': {
-		'model': mods.geometry.pore_volume.circle,
-		'pore_diameter': 'pore.diameter',
-        'regen_mode': 'explicit',
-        'regen_mode': 'deferred',
-        },
-	'throat.max_size': {
-		'model': mods.misc.from_neighbor_pores,
-		'mode': 'min',
-		'prop': 'pore.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.diameter': {
-		'model': mods.misc.scaled,
-		'factor': 0.5,
+def trapezoids_and_rectangles(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_trapezoids_and_rectangles,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_trapezoids_and_rectangles = {
+    'pore.seed': {
+        'model': mods.misc.random,
+        'element': 'pore',
+        'num_range': [0.2, 0.7],
+        'seed': None,
+    },
+    'pore.max_size': {
+        'model': mods.geometry.pore_size.largest_sphere,
+        'iters': 10,
+    },
+    'pore.diameter': {
+        'model': mods.misc.product,
+        'props': ['pore.max_size', 'pore.seed'],
+    },
+    'pore.volume': {
+        'model': mods.geometry.pore_volume.circle,
+        'pore_diameter': 'pore.diameter',
+    },
+    'throat.max_size': {
+        'model': mods.misc.from_neighbor_pores,
+        'mode': 'min',
+        'prop': 'pore.diameter',
+    },
+    'throat.diameter': {
+        'model': mods.misc.scaled,
+        'factor': 0.5,
         'prop': 'throat.max_size',
-        'regen_mode': 'deferred',
-        },
-	'throat.length': {
-		'model': mods.geometry.throat_length.trapezoids_and_rectangles,
-		'pore_diameter': 'pore.diameter',
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.volume': {
-		'model': mods.geometry.throat_volume.rectangle,
-		'throat_diameter': 'throat.diameter',
-		'throat_length': 'throat.length',
-        'regen_mode': 'deferred',
-		},
-	'throat.cross_sectional_area': {
-		'model': mods.geometry.throat_cross_sectional_area.rectangle,
-		'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-		},
-	'throat.diffusive_size_factors': {
-		'model': mods.geometry.diffusive_size_factors.trapezoids_and_rectangles,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.length': {
+        'model': mods.geometry.throat_length.trapezoids_and_rectangles,
+        'pore_diameter': 'pore.diameter',
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	'throat.hydraulic_size_factors': {
-		'model': mods.geometry.hydraulic_size_factors.trapezoids_and_rectangles,
-		'pore_diameter': 'pore.diameter',
+    },
+    'throat.volume': {
+        'model': mods.geometry.throat_volume.rectangle,
         'throat_diameter': 'throat.diameter',
-        'regen_mode': 'deferred',
-        },
-	}
+        'throat_length': 'throat.length',
+    },
+    'throat.cross_sectional_area': {
+        'model': mods.geometry.throat_cross_sectional_area.rectangle,
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.diffusive_size_factors': {
+        'model': mods.geometry.diffusive_size_factors.trapezoids_and_rectangles,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+    'throat.hydraulic_size_factors': {
+        'model': mods.geometry.hydraulic_size_factors.trapezoids_and_rectangles,
+        'pore_diameter': 'pore.diameter',
+        'throat_diameter': 'throat.diameter',
+    },
+}

--- a/openpnm/models/collections/phase/air.py
+++ b/openpnm/models/collections/phase/air.py
@@ -1,75 +1,60 @@
-r"""
-
-Example
--------
-import openpnm as op
-pn = op.network.Cubic(shape=[5, 1, 1])
-p = op.phases.GenericPhase(network=pn)
-p.models.update(op.phases.predefined.air)
-p.regenerate_models()
-
-"""
-
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
-air = {
+
+def air(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_air,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_air = {
     'pore.molecular_weight': {
         'model': mods.misc.constant,
         'value': 0.0291,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.critical_pressure': {
         'model': mods.misc.constant,
         'value': 3.786E6,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.critical_temperature': {
         'model': mods.misc.constant,
         'value': 132.5,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.critical_volume': {
         'model': mods.misc.constant,
         'value': 0.002917,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.contact_angle': {
         'model': mods.misc.constant,
         'value': 180.0,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.surface_tension': {
         'model': mods.misc.constant,
         'value': 0.072,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.molar_density': {
         'model': mods.phase.molar_density.ideal_gas,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.diffusivity': {
         'model': mods.phase.diffusivity.fuller,
         'MA': 0.032,
         'MB': 0.028,
         'vA': 16.6,
         'vB': 17.9,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.thermal_conductivity': {
         'model': mods.misc.polynomial,
         'prop': 'pore.temperature',
         'a': [0.00422791, 0.0000789606, -1.56383E-08],
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.electrical_conductivity': {
         'model': mods.misc.constant,
         'value': 1e-15,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.viscosity': {
         'model': mods.misc.polynomial,
         'prop': 'pore.temperature',
         'a': [0.00000182082, 6.51815E-08, -3.48553E-11, 1.11409E-14],
-        'regen_mode': 'deferred',
-        },
-    }
+    },
+}

--- a/openpnm/models/collections/phase/mercury.py
+++ b/openpnm/models/collections/phase/mercury.py
@@ -1,49 +1,51 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
-mercury = {
+
+def mercury(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_mercury,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_mercury = {
     'pore.vapor_pressure': {
         'model': mods.phase.vapor_pressure.antoine,
         'A': 9.85767,
         'B': 3007.129,
         'C': -10.001,
-        'regen_mode': 'deferred',
-        },
+    },
     'throat.contact_angle': {
         'model': mods.misc.constant,
         'value': 140,
-        },
+    },
     'pore.molecular_weight': {
         'model': mods.misc.constant,
         'value': 200.59,
-        },
+    },
     'pore.density': {
         'model': mods.misc.linear,
         'prop': 'pore.temperature',
         'b': 14280.9,
         'm': -2.47004,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.molar_density': {
         'model': mods.phase.molar_density.standard,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.surface_tension': {
         'model': mods.misc.linear,
         'prop': 'pore.temperature',
         'b': 0.56254,
         'm': -0.00028,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.thermal_conductivity': {
         'model': mods.misc.polynomial,
         'prop': 'pore.temperature',
         'a': [3.98691, 0.0170967, -0.0000063862],
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.viscosity': {
         'model': mods.misc.polynomial,
         'prop': 'pore.temperature',
         'a': [0.00355837, -0.0000100131, 1.23684E-08, -5.1684E-12],
-        'regen_mode': 'deferred',
-        },
-    }
+    },
+}

--- a/openpnm/models/collections/phase/water.py
+++ b/openpnm/models/collections/phase/water.py
@@ -1,66 +1,61 @@
 import openpnm.models as mods
+from openpnm.utils import get_model_collection
 
-water = {
+
+def water(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_water,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_water = {
     'pore.molecular_weight': {
         'model': mods.misc.constant,
         'value': 0.01802,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.critical_pressure': {
         'model': mods.misc.constant,
         'value': 2.2064E7,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.critical_temperature': {
         'model': mods.misc.constant,
         'value': 647.1,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.critical_volume': {
         'model': mods.misc.constant,
         'value': 0.003106,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.contact_angle': {
         'model': mods.misc.constant,
         'value': 110.0,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.electrical_conductivity': {
         'model': mods.misc.constant,
         'value': 1e-15,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.diffusivity': {
         'model': mods.misc.constant,
-        'value':  1e-9,
-        'regen_mode': 'deferred',
-        },
+        'value': 1e-9,
+    },
     'pore.density': {
         'model': mods.phase.density.water,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.molar_density': {
         'model': mods.phase.molar_density.standard,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.surface_tension': {
         'model': mods.phase.surface_tension.water,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.thermal_conductivity': {
         'model': mods.phase.thermal_conductivity.water,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.vapor_pressure': {
         'model': mods.phase.vapor_pressure.antoine,
         'A': 8.088,
         'B': 1750.71,
         'C': 236.191,
-        'regen_mode': 'deferred',
-        },
+    },
     'pore.viscosity': {
         'model': mods.phase.viscosity.water,
-        'regen_mode': 'deferred',
-        },
-    }
+    },
+}

--- a/openpnm/models/collections/physics/basic.py
+++ b/openpnm/models/collections/physics/basic.py
@@ -1,13 +1,21 @@
 import openpnm.models.physics as mods
+from openpnm.utils import get_model_collection
 
-basic = {
+
+def basic(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_basic,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_basic = {
     'throat.hydraulic_conductance': {
         'model': mods.hydraulic_conductance.generic_hydraulic,
-        },
+    },
     'throat.diffusive_conductance': {
         'model': mods.diffusive_conductance.generic_diffusive,
-        },
+    },
     'throat.entry_pressure': {
         'model': mods.capillary_pressure.washburn,
-        },
-    }
+    },
+}

--- a/openpnm/models/collections/physics/standard.py
+++ b/openpnm/models/collections/physics/standard.py
@@ -1,22 +1,30 @@
 import openpnm.models.physics as mods
+from openpnm.utils import get_model_collection
 
-standard = {
+
+def standard(regen_mode='deferred', domain=None):
+    return get_model_collection(collection=_standard,
+                                regen_mode=regen_mode,
+                                domain=domain)
+
+
+_standard = {
     'throat.hydraulic_conductance': {
         'model': mods.hydraulic_conductance.generic_hydraulic,
-        },
+    },
     'throat.diffusive_conductance': {
         'model': mods.diffusive_conductance.generic_diffusive,
-        },
+    },
     'throat.entry_pressure': {
         'model': mods.capillary_pressure.washburn,
-        },
+    },
     'throat.thermal_conductance': {
         'model': mods.thermal_conductance.generic_thermal,
-        },
+    },
     'throat.electrical_conductance': {
         'model': mods.electrical_conductance.generic_electrical,
-        },
+    },
     'throat.ad_dif_conductance': {
         'model': mods.ad_dif_conductance.ad_dif,
-        },
-    }
+    },
+}

--- a/openpnm/models/network/_health.py
+++ b/openpnm/models/network/_health.py
@@ -100,7 +100,7 @@ def headless_throats(target):
     Find any throats that point to a non-existent pore
     """
     net = target.network
-    hits = np.any(net.conns > (net.Np -1), axis=1)
+    hits = np.any(net.conns > (net.Np - 1), axis=1)
     return hits
 
 

--- a/openpnm/phase/_air.py
+++ b/openpnm/phase/_air.py
@@ -29,5 +29,5 @@ class Air(GenericPhase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.models.update(air)
+        self.models.update(air())
         self.regenerate_models()

--- a/openpnm/phase/_mercury.py
+++ b/openpnm/phase/_mercury.py
@@ -24,5 +24,5 @@ class Mercury(GenericPhase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.add_model_collection(mercury)
+        self.add_model_collection(mercury())
         self.regenerate_models()

--- a/openpnm/phase/_water.py
+++ b/openpnm/phase/_water.py
@@ -19,5 +19,5 @@ class Water(GenericPhase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.models.update(water)
+        self.models.update(water())
         self.regenerate_models()

--- a/openpnm/utils/_misc.py
+++ b/openpnm/utils/_misc.py
@@ -9,6 +9,7 @@ import scipy.sparse as sparse
 from collections import OrderedDict
 from collections.abc import Iterable
 from docrep import DocstringProcessor
+from copy import deepcopy
 
 
 __all__ = [
@@ -32,6 +33,7 @@ __all__ = [
     'is_valid_propname',
     'prettify_logger_message',
     'remove_prop_deep',
+    'get_model_collection',
 ]
 
 
@@ -620,3 +622,13 @@ def remove_prop_deep(obj, propname):
         obj._parse_element(propname)
         if k.startswith(propname):
             del obj[k]
+
+
+def get_model_collection(collection, regen_mode='deferred', domain=None):
+    d = deepcopy(collection)
+    for k, v in d.items():
+        if regen_mode:
+            v['regen_mode'] = regen_mode
+        if domain:
+            v['domain'] = domain
+    return d

--- a/tests/integration/PoreSpyIO_on_Berea.py
+++ b/tests/integration/PoreSpyIO_on_Berea.py
@@ -58,7 +58,7 @@ op.topotools.trim(network=pn, pores=h['disconnected_pores'])
 gas = op.phase.GenericPhase(network=pn)
 gas['pore.diffusivity'] = 1.0
 gas['pore.viscosity'] = 1.0
-gas.add_model_collection(op.models.collections.physics.basic)
+gas.add_model_collection(op.models.collections.physics.basic())
 gas.regenerate_models()
 
 

--- a/tests/unit/algorithms/AdvectionDiffusionTest.py
+++ b/tests/unit/algorithms/AdvectionDiffusionTest.py
@@ -11,7 +11,7 @@ class AdvectionDiffusionTest:
         np.random.seed(0)
         self.net = op.network.Cubic(shape=[4, 3, 1], spacing=1.)
         self.net.add_model_collection(
-            op.models.collections.geometry.spheres_and_cylinders
+            op.models.collections.geometry.spheres_and_cylinders()
         )
         self.net.regenerate_models()
         self.net['throat.conduit_lengths.pore1'] = 0.1

--- a/tests/unit/algorithms/GenericTransportTest.py
+++ b/tests/unit/algorithms/GenericTransportTest.py
@@ -8,10 +8,14 @@ class GenericTransportTest:
 
     def setup_class(self):
         self.net = op.network.Cubic(shape=[9, 9, 9])
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.phase = op.phase.Air(network=self.net)
-        self.phase.add_model_collection(op.models.collections.physics.basic)
+        self.phase.add_model_collection(
+            op.models.collections.physics.basic()
+        )
         self.phase.regenerate_models()
         self.phase['pore.mole_fraction'] = 0
         self.phase['throat.diffusive_conductance'] = 1.0
@@ -165,7 +169,9 @@ class GenericTransportTest:
 
     # def test_rate_Nt_by_2_conductance(self):
     #     net = op.network.Cubic(shape=[1, 6, 1])
-    #     net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+    #     net.add_model_collection(
+    #         op.models.collections.geometry.spheres_and_cylinders()
+    #     )
     #     net.regenerate_models()
     #     air = op.phase.Air(network=net)
     #     water = op.phase.Water(network=net)

--- a/tests/unit/algorithms/IPTest.py
+++ b/tests/unit/algorithms/IPTest.py
@@ -7,10 +7,14 @@ import matplotlib.pyplot as plt
 class IPTest:
     def setup_class(self):
         self.net = op.network.Cubic(shape=[10, 10, 10], spacing=0.0005)
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.water = op.phase.Water(network=self.net)
-        self.water.add_model_collection(op.models.collections.physics.basic)
+        self.water.add_model_collection(
+            op.models.collections.physics.basic()
+        )
         self.water.regenerate_models()
         mod = op.models.physics.capillary_pressure.washburn
         self.water.add_model(propname="throat.entry_pressure", model=mod)

--- a/tests/unit/algorithms/MixedPercolationCoopTest.py
+++ b/tests/unit/algorithms/MixedPercolationCoopTest.py
@@ -17,7 +17,7 @@ class MixedPercolationCoopTest:
         # Create Topological Network object
         self.net = op.network.Cubic([Np, Np, 1], spacing=1)
         self.net.add_model_collection(
-            op.models.collections.geometry.spheres_and_cylinders
+            op.models.collections.geometry.spheres_and_cylinders()
         )
         self.net.regenerate_models()
         self.net['pore.diameter'] = 0.5
@@ -55,7 +55,9 @@ class MixedPercolationCoopTest:
 
     # def test_coop_pore_filling(self):
     #     pn = op.network.Cubic(shape=[3, 3, 3], spacing=2.5e-5)
-    #     pn.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+    #     pn.add_model_collection(
+    #         op.models.collections.geometry.spheres_and_cylinders()
+    #     )
     #     pn.regenerate_models()
     #     pn['throat.diameter'] = 1.5e-5
     #     pn['pore.diameter'] = 2e-5

--- a/tests/unit/algorithms/MixedPercolationTest.py
+++ b/tests/unit/algorithms/MixedPercolationTest.py
@@ -17,7 +17,7 @@ class MixedPercolationTest:
         # Create Topological Network object
         self.net = op.network.Cubic([Np, Np, 1], spacing=1)
         self.net.add_model_collection(
-            op.models.collections.geometry.spheres_and_cylinders
+            op.models.collections.geometry.spheres_and_cylinders()
         )
         self.net.regenerate_models()
         self.net['pore.diameter'] = 0.5
@@ -404,7 +404,7 @@ class MixedPercolationTest:
     # def test_bidirectional_entry_pressure(self):
     #     pn = op.network.Cubic(shape=[3, 3, 3], spacing=2.5e-5)
     #     pn.add_model_collection(
-    #         op.models.collections.geometry.spheres_and_cylinders
+    #         op.models.collections.geometry.spheres_and_cylinders()
     #     )
     #     pn.regenerate_models()
     #     pn['throat.diameter'] = 2.0e-5

--- a/tests/unit/algorithms/OrdinaryPercolationTest.py
+++ b/tests/unit/algorithms/OrdinaryPercolationTest.py
@@ -8,10 +8,14 @@ class OrdinaryPercolationTest:
 
     def setup_class(self):
         self.net = op.network.Cubic(shape=[5, 5, 5], spacing=0.0005)
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.water = op.phase.Water(network=self.net)
-        self.water.add_model_collection(op.models.collections.physics.standard)
+        self.water.add_model_collection(
+            op.models.collections.physics.standard()
+        )
         self.water.regenerate_models()
         self.air = op.phase.Air(network=self.net)
         mod = op.models.physics.capillary_pressure.washburn

--- a/tests/unit/algorithms/SolversTest.py
+++ b/tests/unit/algorithms/SolversTest.py
@@ -10,7 +10,9 @@ class SolversTest:
 
     def setup_class(self):
         self.net = op.network.Cubic(shape=[10, 10, 10])
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.phase = op.phase.GenericPhase(network=self.net)
         self.phase['throat.conductance'] = np.linspace(1, 5, num=self.net.Nt)

--- a/tests/unit/algorithms/SubclassedTransportTest.py
+++ b/tests/unit/algorithms/SubclassedTransportTest.py
@@ -6,10 +6,14 @@ class SubclassedTransportTest:
 
     def setup_class(self):
         self.net = op.network.Cubic(shape=[9, 9, 9])
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.phase = op.phase.GenericPhase(network=self.net)
-        self.phase.add_model_collection(op.models.collections.physics.standard)
+        self.phase.add_model_collection(
+            op.models.collections.physics.standard()
+        )
         self.phase.regenerate_models()
 
     def test_fickian_diffusion(self):

--- a/tests/unit/algorithms/TransientAdvectionDiffusionTest.py
+++ b/tests/unit/algorithms/TransientAdvectionDiffusionTest.py
@@ -7,7 +7,7 @@ class TransientAdvectionDiffusionTest:
     def setup_class(self):
         self.net = op.network.Cubic(shape=[4, 3, 1], spacing=1.0)
         self.net.add_model_collection(
-            op.models.collections.geometry.spheres_and_cylinders
+            op.models.collections.geometry.spheres_and_cylinders()
         )
         self.net.regenerate_models()
         self.phase = op.phase.GenericPhase(network=self.net)

--- a/tests/unit/algorithms/TransientFickianDiffusionTest.py
+++ b/tests/unit/algorithms/TransientFickianDiffusionTest.py
@@ -8,7 +8,9 @@ class TransientFickianDiffusionTest:
     def setup_class(self):
         np.random.seed(0)
         self.net = op.network.Cubic(shape=[4, 3, 1], spacing=1.0)
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.net['pore.volume'] = 1e-14
         self.phase = op.phase.GenericPhase(network=self.net)

--- a/tests/unit/algorithms/TransientMultiPhysicsTest.py
+++ b/tests/unit/algorithms/TransientMultiPhysicsTest.py
@@ -12,7 +12,9 @@ class TransientMultiPhysicsTest:
         spacing = 1e-1
         # 2d network
         self.net = op.network.Cubic(shape=[10, 10, 1], spacing=spacing)
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         # phase and physics
         self.air = op.phase.Air(network=self.net)

--- a/tests/unit/algorithms/TransientReactiveTransportTest.py
+++ b/tests/unit/algorithms/TransientReactiveTransportTest.py
@@ -9,7 +9,9 @@ class TransientReactiveTransportTest:
     def setup_class(self):
         np.random.seed(0)
         self.net = op.network.Cubic(shape=[3, 3, 1], spacing=1e-6)
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.net['pore.volume'] = 1e-12
         self.phase = op.phase.GenericPhase(network=self.net)

--- a/tests/unit/models/physics/MeniscusTest.py
+++ b/tests/unit/models/physics/MeniscusTest.py
@@ -7,7 +7,9 @@ class MeniscusTest:
     def setup_class(self):
         np.random.seed(1)
         self.net = op.network.Cubic(shape=[5, 1, 5], spacing=5e-5)
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.phase = op.phase.Water(network=self.net)
 

--- a/tests/unit/models/physics/MultiPhaseModelsTest.py
+++ b/tests/unit/models/physics/MultiPhaseModelsTest.py
@@ -8,7 +8,9 @@ import openpnm.models.physics as pm
 class MultiPhaseModelsTest:
     def setup_class(self):
         self.net = op.network.Cubic(shape=[3, 3, 3])
-        self.net.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        self.net.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         self.net.regenerate_models()
         self.phase = op.phase.GenericPhase(network=self.net)
         self.phase['pore.occupancy'] = np.ones(self.net.Np)
@@ -16,7 +18,9 @@ class MultiPhaseModelsTest:
         self.phase['pore.occupancy'][[6, 7, 19, 25]] = 0
         self.phase['throat.occupancy'][[1, 2, 3]] = 0
         np.random.seed(0)
-        self.phase.add_model_collection(op.models.collections.physics.standard)
+        self.phase.add_model_collection(
+            op.models.collections.physics.standard()
+        )
         self.phase['throat.capillary_pressure'] = 7000*np.random.rand(self.phase.Nt)
         self.phase['throat.diffusive_conductance'] = 2
 

--- a/tests/unit/topotools/PlotToolsTest.py
+++ b/tests/unit/topotools/PlotToolsTest.py
@@ -65,7 +65,9 @@ class PlotToolsTest:
 
     def test_generate_voxel_image(self):
         pn = op.network.Cubic(shape=[5, 5, 1])
-        pn.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        pn.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         pn.regenerate_models()
         im = op.topotools.generate_voxel_image(network=pn,
                                                pore_shape='sphere',
@@ -76,7 +78,9 @@ class PlotToolsTest:
     def test_plot_connections_color_by(self):
         pn = op.network.Cubic(shape=[5, 5, 1])
         np.random.seed(10)
-        pn.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        pn.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         pn.regenerate_models()
         Ts = np.array([0, 4, 6, 18])
         im = op.topotools.plot_connections(pn, throats=Ts,
@@ -90,7 +94,9 @@ class PlotToolsTest:
     def test_plot_coordinates_color_by(self):
         pn = op.network.Cubic(shape=[5, 5, 1])
         np.random.seed(10)
-        pn.add_model_collection(op.models.collections.geometry.spheres_and_cylinders)
+        pn.add_model_collection(
+            op.models.collections.geometry.spheres_and_cylinders()
+        )
         pn.regenerate_models()
         Ps = np.array([0, 4, 6, 18])
         im = op.topotools.plot_coordinates(pn, pores=Ps,

--- a/tests/unit/utils/UtilsTest.py
+++ b/tests/unit/utils/UtilsTest.py
@@ -56,11 +56,17 @@ class UtilsTest:
 
     def test_is_symmetric_FickianDiffusion_must_be_symmetric(self):
         net = op.network.Cubic(shape=[5, 5, 5])
-        net.add_model_collection(op.models.collections.geometry.cones_and_cylinders)
+        net.add_model_collection(
+            op.models.collections.geometry.cones_and_cylinders()
+        )
         net.regenerate_models()
         air = op.phase.Air(network=net)
-        air.add_model_collection(op.models.collections.phase.air)
-        air.add_model_collection(op.models.collections.physics.standard)
+        air.add_model_collection(
+            op.models.collections.phase.air()
+        )
+        air.add_model_collection(
+            op.models.collections.physics.standard()
+        )
         air.regenerate_models()
         fd = op.algorithms.FickianDiffusion(network=net, phase=air)
         fd.set_value_BC(pores=net.pores("left"), values=1.0)
@@ -69,11 +75,17 @@ class UtilsTest:
 
     def test_is_symmetric_AdvectionDiffusion_must_be_nonsymmetric(self):
         net = op.network.Cubic(shape=[5, 5, 5])
-        net.add_model_collection(op.models.collections.geometry.cones_and_cylinders)
+        net.add_model_collection(
+            op.models.collections.geometry.cones_and_cylinders()
+        )
         net.regenerate_models()
         air = op.phase.Air(network=net)
-        air.add_model_collection(op.models.collections.phase.air)
-        air.add_model_collection(op.models.collections.physics.standard)
+        air.add_model_collection(
+            op.models.collections.phase.air()
+        )
+        air.add_model_collection(
+            op.models.collections.physics.standard()
+        )
         air.regenerate_models()
         ad = op.algorithms.AdvectionDiffusion(network=net, phase=air)
         ad.set_value_BC(pores=net.pores("left"), values=1.0)


### PR DESCRIPTION
Fixes #2455

This PR changes the API of the models collections to work as function calls rather than dict fetches.  This means that the returned dict can be a deep copy of the dict, so changes to one instance are not reflected in others.  Also, the new function approach allows for a few arguments to be passed, namely ``regen_mode`` and ``domain``.  