### PR TITLE
Prevent getting logger from root level

### DIFF
--- a/openpnm/utils/_workspace.py
+++ b/openpnm/utils/_workspace.py
@@ -43,12 +43,10 @@ class WorkspaceSettings(SettingsAttr):
 
     @property
     def loglevel(self):
-        logger = logging.getLogger()
         return logger.level
 
     @loglevel.setter
     def loglevel(self, value):
-        logger = logging.getLogger()
         logger.setLevel(value)
 
 


### PR DESCRIPTION
This call was getting the logger from the root level and overwriting the app settings for logging level.
I was having trouble in my app with that
issue #2530
```python
>>> import logging
>>> logging.getLogger().level
30
>>> logging.getLogger().setLevel(10)
>>> logging.getLogger().level
10
>>> import openpnm
>>> logging.getLogger().level
30
```