### PR TITLE
Regenerate components

### DIFF
--- a/openpnm/phase/_mixture.py
+++ b/openpnm/phase/_mixture.py
@@ -90,6 +90,11 @@ class Mixture(Phase):
     #     else:
     #         super().__setitem__(key, value)
 
+    def regenerate_models(self, **kwargs):
+        for c in self.components.values():
+            c.regenerate_models(**kwargs)
+        super().regenerate_models(**kwargs)
+
     def get_comp_vals(self, propname):
         r"""
         Get a dictionary of the requested values from each component in the

--- a/tests/unit/phase/MixtureTest.py
+++ b/tests/unit/phase/MixtureTest.py
@@ -96,6 +96,27 @@ class MixtureTest:
         set_a = set(['pure_N2', 'pure_O2'])
         assert set_a.difference(set(d.keys())) == set()
 
+    def test_regenerate_components(self):
+        net = op.network.Demo()
+        o2 = op.phase.StandardGas(network=net, species='o2', name='pure_O2')
+        n2 = op.phase.StandardGas(network=net, species='n2', name='pure_N2')
+        air = op.phase.StandardGasMixture(network=net, components=[n2, o2])
+        air.y(o2.name, y=0.2)
+        air.y(n2.name, y=0.8)
+        air.regenerate_models()
+        mu1 = air['pore.viscosity'].mean()
+        o2['pore.temperature'] = 333.3
+        air.regenerate_models()
+        mu2 = air['pore.viscosity'].mean()
+        assert mu2 > mu1
+        o2['pore.temperature'] = 298.0
+        o2.regenerate_models()
+        mu3 = air['pore.viscosity'].mean()
+        assert mu2 == mu3
+        air.regenerate_models()
+        mu4 = air['pore.viscosity'].mean()
+        assert mu4 == mu1
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
Overloaded the `regenerate_models` method on the `Mixture` class so that it regenerates the component phases first.