### PR TITLE
Moving import of h5py inside function

### DIFF
--- a/openpnm/io/_hdf5.py
+++ b/openpnm/io/_hdf5.py
@@ -1,6 +1,5 @@
 import logging
 from openpnm.io import project_to_dict, _parse_filename
-from h5py import File as hdfFile
 import pandas as pd
 
 
@@ -25,6 +24,7 @@ def project_to_hdf5(project, filename=''):
         A handle to an hdf5 file.  This must be closed when done (i.e.
         ``f.close()``.
     """
+    from h5py import File as hdfFile
     if filename == '':
         filename = project.name
     filename = _parse_filename(filename, ext='hdf')

--- a/openpnm/io/_xdmf.py
+++ b/openpnm/io/_xdmf.py
@@ -3,7 +3,6 @@ import pandas as pd
 import xml.etree.cElementTree as ET
 from openpnm.io import project_to_dict, _parse_filename
 from openpnm.utils._misc import is_transient
-import h5py
 
 
 logger = logging.getLogger(__name__)
@@ -29,6 +28,7 @@ def project_to_xdmf(project, filename=''):
     or other attributes.
 
     """
+    import h5py
 
     network = project.network
     algs = project.algorithms


### PR DESCRIPTION
h5py does not work with python 3.10 at the moment.  I am moving their import inside their respective functions so that at least openpnm can be imported.  No sure what flake8 will say...