### PR TITLE
More robust conduit lengths

### DIFF
--- a/tests/integration/Flow_in_straight_conduit.py
+++ b/tests/integration/Flow_in_straight_conduit.py
@@ -46,4 +46,4 @@ if __name__ == "__main__":
         sf2.set_value_BC(pores=pn5.pores('xmax'), values=0.0)
         sf2.run()
         r2 = sf2.rate(pores=pn5.pores('xmin'))
-        np.allclose(r1, r2, atol=0, rtol=1e-10)
+        assert np.allclose(r1, r2, atol=0, rtol=1e-10)

--- a/tests/integration/Flow_in_straight_conduit.py
+++ b/tests/integration/Flow_in_straight_conduit.py
@@ -1,0 +1,49 @@
+# This test checks to ensure that pores which overlap give the same transport
+# rates as pores which do not but are the same size
+if __name__ == "__main__":
+
+    import openpnm as op
+    import numpy as np
+
+    diameters = [0.9, 1.0, 1.1, 1.5]
+    for D in diameters:
+        pn5 = op.network.Cubic(shape=[5, 1, 1], spacing=1)
+        pn5['pore.diameter'] = D
+        pn5['throat.diameter'] = D
+        pn5.regenerate_models()
+        pn5.add_model(
+            propname='throat.hydraulic_size_factors',
+            model=op.models.geometry.hydraulic_size_factors.spheres_and_cylinders)
+
+        pn3 = op.network.Cubic(shape=[3, 1, 1], spacing=2)
+        pn3['pore.diameter'] = D
+        pn3['throat.diameter'] = D
+        pn3.add_model(
+            propname='throat.hydraulic_size_factors',
+            model=op.models.geometry.hydraulic_size_factors.spheres_and_cylinders)
+        pn3.regenerate_models()
+
+        ph1 = op.phase.Phase(network=pn3)
+        ph1['pore.viscosity'] = 1.0
+        ph1.add_model(
+            propname='throat.hydraulic_conductance',
+            model=op.models.physics.hydraulic_conductance.generic_hydraulic)
+
+        ph2 = op.phase.Phase(network=pn5)
+        ph2['pore.viscosity'] = 1.0
+        ph2.add_model(
+            propname='throat.hydraulic_conductance',
+            model=op.models.physics.hydraulic_conductance.generic_hydraulic)
+
+        sf1 = op.algorithms.StokesFlow(network=pn3, phase=ph1)
+        sf1.set_value_BC(pores=pn3.pores('xmin'), values=1.0)
+        sf1.set_value_BC(pores=pn3.pores('xmax'), values=0.0)
+        sf1.run()
+        r1 = sf1.rate(pores=pn3.pores('xmin'))
+
+        sf2 = op.algorithms.StokesFlow(network=pn5, phase=ph1)
+        sf2.set_value_BC(pores=pn5.pores('xmin'), values=1.0)
+        sf2.set_value_BC(pores=pn5.pores('xmax'), values=0.0)
+        sf2.run()
+        r2 = sf2.rate(pores=pn5.pores('xmin'))
+        np.allclose(r1, r2, atol=0, rtol=1e-10)

--- a/tests/integration/Flow_in_straight_conduit.py
+++ b/tests/integration/Flow_in_straight_conduit.py
@@ -5,8 +5,13 @@ if __name__ == "__main__":
     import openpnm as op
     import numpy as np
 
+    mu = 1.0
+    Pin = 1.0
+    Pout = 0.0
     diameters = [0.9, 1.0, 1.1, 1.5]
-    for D in diameters:
+    Q = np.pi*(np.array(diameters)/2)**4/(8*mu*4) * (Pin - Pout)
+
+    for i, D in enumerate(diameters):
         pn5 = op.network.Cubic(shape=[5, 1, 1], spacing=1)
         pn5['pore.diameter'] = D
         pn5['throat.diameter'] = D
@@ -24,26 +29,27 @@ if __name__ == "__main__":
         pn3.regenerate_models()
 
         ph1 = op.phase.Phase(network=pn3)
-        ph1['pore.viscosity'] = 1.0
+        ph1['pore.viscosity'] = mu
         ph1.add_model(
             propname='throat.hydraulic_conductance',
             model=op.models.physics.hydraulic_conductance.generic_hydraulic)
 
         ph2 = op.phase.Phase(network=pn5)
-        ph2['pore.viscosity'] = 1.0
+        ph2['pore.viscosity'] = mu
         ph2.add_model(
             propname='throat.hydraulic_conductance',
             model=op.models.physics.hydraulic_conductance.generic_hydraulic)
 
         sf1 = op.algorithms.StokesFlow(network=pn3, phase=ph1)
-        sf1.set_value_BC(pores=pn3.pores('xmin'), values=1.0)
-        sf1.set_value_BC(pores=pn3.pores('xmax'), values=0.0)
+        sf1.set_value_BC(pores=pn3.pores('xmin'), values=Pin)
+        sf1.set_value_BC(pores=pn3.pores('xmax'), values=Pout)
         sf1.run()
         r1 = sf1.rate(pores=pn3.pores('xmin'))
 
         sf2 = op.algorithms.StokesFlow(network=pn5, phase=ph1)
-        sf2.set_value_BC(pores=pn5.pores('xmin'), values=1.0)
-        sf2.set_value_BC(pores=pn5.pores('xmax'), values=0.0)
+        sf2.set_value_BC(pores=pn5.pores('xmin'), values=Pin)
+        sf2.set_value_BC(pores=pn5.pores('xmax'), values=Pout)
         sf2.run()
         r2 = sf2.rate(pores=pn5.pores('xmin'))
         assert np.allclose(r1, r2, atol=0, rtol=1e-10)
+        assert np.allclose(r1, Q[i], atol=0, rtol=1e-10)

--- a/tests/unit/models/geometry/ConduitDiffusiveSizeFactorsTest.py
+++ b/tests/unit/models/geometry/ConduitDiffusiveSizeFactorsTest.py
@@ -21,10 +21,9 @@ class ConduitDiffusiveSizeFactorsTest:
                     'throat': SF[:, 1],
                     'pore2': SF[:, 2]}
         S_desired = {
-            'pore1': array([0.93875728, 0.97459088]),
-            'throat': array([1.25663706e+14, 4.05813214e-01]),
-            'pore2': array([0.82884551, 0.94886745])
-        }
+            'pore1': array([1.06932839, 0.97459088]),
+            'throat': array([4.02746504, 0.40581321]),
+            'pore2': array([0.97459088, 0.94886745])}
         for k, v in S_actual.items():
             assert_allclose(v, S_desired[k])
 
@@ -34,10 +33,9 @@ class ConduitDiffusiveSizeFactorsTest:
                     'throat': SF[:, 1],
                     'pore2': SF[:, 2]}
         S_desired = {
-            'pore1': array([1.53390798, 1.80140852]),
-            'throat': array([4.00000000e+14, 1.29174358e+00]),
-            'pore2': array([1.65097536, 2.07781253])
-        }
+            'pore1': array([1.62474893, 1.80140852]),
+            'throat': array([12.81981939,  1.29174358]),
+            'pore2': array([1.80140852, 2.07781253])}
         for k, v in S_actual.items():
             assert_allclose(v, S_desired[k])
 
@@ -112,10 +110,9 @@ class ConduitDiffusiveSizeFactorsTest:
                     'throat': SF[:, 1],
                     'pore2': SF[:, 2]}
         S_desired = {
-            'pore1': array([0.49260457, 0.77443401]),
-            'throat': array([1.25663706e+14, 4.05813214e-01]),
-            'pore2': array([0.563723, 0.84600371])
-        }
+            'pore1': array([0.69688454, 0.77443401]),
+            'throat': array([4.02746504, 0.40581321]),
+            'pore2': array([0.77443401, 0.84600371])}
         for k, v in S_actual.items():
             assert_allclose(v, S_desired[k])
 

--- a/tests/unit/models/geometry/ConduitHydraulicSizeFactorsTest.py
+++ b/tests/unit/models/geometry/ConduitHydraulicSizeFactorsTest.py
@@ -21,10 +21,9 @@ class ConduitHydraulicSizeFactorsTest:
                     'throat': SF[:, 1],
                     'pore2': SF[:, 2]}
         S_desired = {
-            'pore1': array([0.01068901, 0.01195694]),
-            'throat': array([6.28318531e+11, 2.02906607e-03]),
-            'pore2': array([0.00771764, 0.00917032])
-        }
+            'pore1': array([0.01655401, 0.01195694]),
+            'throat': array([0.02013733, 0.00202907]),
+            'pore2': array([0.01195694, 0.00917032])}
         for k, v in S_actual.items():
             assert_allclose(v, S_desired[k], rtol=1e-5)
 
@@ -34,10 +33,9 @@ class ConduitHydraulicSizeFactorsTest:
                     'throat': SF[:, 1],
                     'pore2': SF[:, 2]}
         S_desired = {
-            'pore1': array([0.06563123, 0.06697876]),
-            'throat': array([5.33333333e+12, 1.72232477e-02]),
-            'pore2': array([0.05072058, 0.05686537])
-        }
+            'pore1': array([0.08485281, 0.06697876]),
+            'throat': array([0.17093093, 0.01722325]),
+            'pore2': array([0.06697876, 0.05686537])}
         for k, v in S_actual.items():
             assert_allclose(v, S_desired[k], rtol=1e-5)
 
@@ -112,10 +110,9 @@ class ConduitHydraulicSizeFactorsTest:
                     'throat': SF[:, 1],
                     'pore2': SF[:, 2]}
         S_desired = {
-            'pore1': array([0.0020471, 0.00612218]),
-            'throat': array([6.28318531e+11, 2.02906607e-03]),
-            'pore2': array([0.00261812, 0.00661558])
-        }
+            'pore1': array([0.00506726, 0.00612218]),
+            'throat': array([0.02013733, 0.00202907]),
+            'pore2': array([0.00612218, 0.00661558])}
         for k, v in S_actual.items():
             assert_allclose(v, S_desired[k], rtol=1e-5)
 

--- a/tests/unit/models/geometry/ConduitLengthsTest.py
+++ b/tests/unit/models/geometry/ConduitLengthsTest.py
@@ -24,12 +24,23 @@ class ConduitLengthsTest:
         with pytest.raises(Exception):
             L_actual = mods.spheres_and_cylinders(self.net)
         self.net["pore.diameter"][1] = 0.9
-        # Overlapping pores
+        # Slightly Overlapping pores
         self.net["pore.diameter"][0] = 1.2
+        L_actual = mods.spheres_and_cylinders(self.net)
+        L_desired = np.array([[0.56568542, 0.03120169, 0.40311289],
+                              [0.40311289, 0.30965898, 0.28722813]])
+        assert_allclose(L_actual, L_desired)
+        # Moderately overlapping pores
+        self.net["throat.diameter"][0] = 0.2
         L_actual = mods.spheres_and_cylinders(self.net)
         L_desired = np.array([[5.78750000e-01, 1.00000000e-15, 4.21250000e-01],
                               [4.03112887e-01, 3.09658980e-01, 2.87228132e-01]])
         assert_allclose(L_actual, L_desired)
+        self.net["throat.diameter"][0] = 0.4
+        # Strongly overlapping pores
+        self.net["pore.diameter"][0] = 2.5
+        with pytest.raises(Exception):
+            mods.spheres_and_cylinders(self.net)
         self.net["pore.diameter"][0] = 0.5
 
     def test_circles_and_rectangles(self):
@@ -40,14 +51,25 @@ class ConduitLengthsTest:
         # Incompatible data with model assumptions
         self.net["pore.diameter"][1] = 0.3
         with pytest.raises(Exception):
-            L_actual = mods.circles_and_squares(self.net)
+            L_actual = mods.spheres_and_cylinders(self.net)
         self.net["pore.diameter"][1] = 0.9
-        # Overlapping pores
+        # Slightly Overlapping pores
         self.net["pore.diameter"][0] = 1.2
-        L_actual = mods.circles_and_rectangles(self.net)
+        L_actual = mods.spheres_and_cylinders(self.net)
+        L_desired = np.array([[0.56568542, 0.03120169, 0.40311289],
+                              [0.40311289, 0.30965898, 0.28722813]])
+        assert_allclose(L_actual, L_desired)
+        # Moderately overlapping pores
+        self.net["throat.diameter"][0] = 0.2
+        L_actual = mods.spheres_and_cylinders(self.net)
         L_desired = np.array([[5.78750000e-01, 1.00000000e-15, 4.21250000e-01],
                               [4.03112887e-01, 3.09658980e-01, 2.87228132e-01]])
         assert_allclose(L_actual, L_desired)
+        self.net["throat.diameter"][0] = 0.4
+        # Strongly overlapping pores
+        self.net["pore.diameter"][0] = 2.5
+        with pytest.raises(Exception):
+            mods.spheres_and_cylinders(self.net)
         self.net["pore.diameter"][0] = 0.5
 
     def test_cones_and_cylinders(self):


### PR DESCRIPTION
The `spheres_and_cylinders` conduit length model was not handling an edge case properly.  When two spheres overlapped, AND the throat was larger than the area of overlap, it was ignoring the contribution of the throat. It was basically assuming that the throat was much smaller than the pores.

I also added an extra check to this function so it raises an exception if the spheres overlap TOO much. We have had some people noticing negative flows and other odd behavior if they weren't being careful about spacing and pore sizes, so I decided to add this check even though we wanted to avoid too much "hand holding".  I think this check is general enough that its acceptable. 