### PR TITLE
Creating a patch release to fix matplotlib import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,40 +10,41 @@
 
 # Overview of OpenPNM
 
-*OpenPNM* is a comprehensive framework for performing pore network simulations of porous materials.
+OpenPNM is a comprehensive framework for performing pore network simulations of porous materials.
 
 ## More Information
 
-For more details about the package can be found in the [on-line documentation](https://openpnm.org)
+For more details about the package can be found in the [online documentation](https://openpnm.org)
 
 ## Installation and Requirements
 
-### Preferred method
-The preferred way of installing OpenPNM is through [Anaconda Cloud](https://anaconda.org/conda-forge/openpnm) using:
+### [pip](https://pypi.org/project/openpnm/)
+OpenPNM can be installed using `pip` by running the following command in a terminal:
+
+```shell
+pip install openpnm
+```
+
+### [conda-forge](https://anaconda.org/conda-forge/openpnm)
+OpenPNM can also be installed from the [conda-forge](https://anaconda.org/conda-forge/openpnm) repository using:
 
 ```
 conda install -c conda-forge openpnm
 ```
 
-### Alternative method
-OpenPNM can also be installed from the [Python Package Index](https://pypi.org/project/openpnm/) using:
-
-```
-pip install openpnm
-```
-
-However, we don't recommend installing using `pip` since `pypardiso`, which is a blazing fast direct solver, is not available for Windows users who use Python 3.7+.
+> [!WARNING]  
+> For compatibility with ARM64 architecture, we removed `pypardiso` as a hard dependency. However, we still strongly recommend that non-macOS users (including users of older Macs with an Intel CPU) manually install `pypardiso` via `pip install pypardiso` or `conda install -c conda-forge pypardiso`, otherwise OpenPNM simulations will be very slow.
 
 ### For developers
-For developers who intend to change the source code or contribute to OpenPNM, the source code can be downloaded from [Github](https://github.com/pmeal/OpenPNM/) and installed by running:
+For developers who intend to change the source code or contribute to OpenPNM, the source code can be downloaded from [Github](https://github.com/PMEAL/OpenPNM/) and installed by running:
 
 ```
 pip install -e 'path/to/downloaded/files'
 ```
 
-The advantage to installing from the source code is that you can edit the files and have access to your changes each time you import *OpenPNM*.
+The advantage to installing from the source code is that you can edit the files and have access to your changes each time you import OpenPNM.
 
-OpenPNM requires the *Scipy Stack* (Numpy, Scipy, Matplotlib, etc), which is most conveniently obtained by installing the [Anaconda Distribution](https://conda.io/docs/user-guide/install/download.html).
+OpenPNM requires the Scipy Stack (Numpy, Scipy, Matplotlib, etc), which is most conveniently obtained by installing the [Anaconda Distribution](https://www.anaconda.com/download/).
 
 ## Asking Questions and Getting Help
 

--- a/openpnm/__version__.py
+++ b/openpnm/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '3.3.0.dev3'
+__version__ = '3.3.0.dev4'

--- a/openpnm/__version__.py
+++ b/openpnm/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '3.3.0.dev2'
+__version__ = '3.3.0.dev3'

--- a/openpnm/__version__.py
+++ b/openpnm/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '3.3.0.dev1'
+__version__ = '3.3.0.dev2'

--- a/openpnm/__version__.py
+++ b/openpnm/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '3.3.0.dev4'
+__version__ = '3.3.0.dev5'

--- a/openpnm/__version__.py
+++ b/openpnm/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '3.3.0.dev0'
+__version__ = '3.3.0.dev1'

--- a/openpnm/_skgraph/generators/_voronoi_delaunay_dual.py
+++ b/openpnm/_skgraph/generators/_voronoi_delaunay_dual.py
@@ -65,7 +65,7 @@ def voronoi_delaunay_dual(
         points=points,
         shape=shape,
         reflect=reflect,
-        f=1,
+        f=f,
     )
 
     # Generate mask to remove any dims with all 0's

--- a/openpnm/_skgraph/generators/tools/_funcs.py
+++ b/openpnm/_skgraph/generators/tools/_funcs.py
@@ -150,7 +150,7 @@ def parse_points(shape, points, reflect=False, f=1):
 
     """
     # Deal with input arguments
-    shape = np.array(shape, dtype=int)
+    shape = np.array(shape, dtype=float)
     if isinstance(points, int):
         points = generate_base_points(num_points=points,
                                       domain_size=shape,

--- a/openpnm/models/_doctxt.py
+++ b/openpnm/models/_doctxt.py
@@ -1,4 +1,8 @@
-from matplotlib._docstring import Substitution
+try:
+    from matplotlib._docstring import Substitution
+except ModuleNotFoundError:
+    from matplotlib.docstring import Substitution
+
 
 
 __all__ = [

--- a/openpnm/models/geometry/_geodocs.py
+++ b/openpnm/models/geometry/_geodocs.py
@@ -1,4 +1,7 @@
-from matplotlib._docstring import Substitution
+try:
+    from matplotlib._docstring import Substitution
+except ModuleNotFoundError:
+    from matplotlib.docstring import Substitution
 
 
 __all__ = [

--- a/openpnm/models/misc/_neighbor_lookups.py
+++ b/openpnm/models/misc/_neighbor_lookups.py
@@ -105,6 +105,8 @@ def from_neighbor_pores(target, prop, mode='min', ignore_nans=True):
                          neighboring pores
             'mean'       Returns the value of the mean property of the
                          neighboring pores
+            'sum'        Returns the sum of the property of the neighrboring
+                         pores
             ===========  =====================================================
 
     ignore_nans : bool (default is ``True``)
@@ -129,6 +131,8 @@ def from_neighbor_pores(target, prop, mode='min', ignore_nans=True):
             value = np.amax(pvalues, axis=1)
         if mode == 'mean':
             value = np.mean(pvalues, axis=1)
+        if mode == 'sum':
+            value = np.sum(pvalues, axis=1)
     except np.AxisError:  # Handle case of empty pvalues
         value = []
     return np.array(value)

--- a/openpnm/models/misc/_neighbor_lookups.py
+++ b/openpnm/models/misc/_neighbor_lookups.py
@@ -37,6 +37,8 @@ def from_neighbor_throats(target, prop, mode='min', ignore_nans=True):
                          neighboring throats
             'mean'       Returns the value of the mean property of the
                          neighboring throats
+            'sum'        Returns the sum of the property of the neighboring
+                         throats
             ===========  =====================================================
 
     Returns
@@ -69,6 +71,11 @@ def from_neighbor_throats(target, prop, mode='min', ignore_nans=True):
         if ignore_nans:
             np.subtract.at(counts, im.row, nans[im.col])
         values = values/counts
+    if mode == 'sum':
+        if ignore_nans:
+            data[nans] = 0
+        values = np.zeros((network.Np, ))
+        np.add.at(values, im.row, data[im.col])
     return values
 
 

--- a/openpnm/models/phase/_phasedocs.py
+++ b/openpnm/models/phase/_phasedocs.py
@@ -1,4 +1,8 @@
-from matplotlib._docstring import Substitution
+try:
+    from matplotlib._docstring import Substitution
+except ModuleNotFoundError:
+    from matplotlib.docstring import Substitution
+
 
 __all__ = [
     '_phasedocs',

--- a/openpnm/phase/_phase.py
+++ b/openpnm/phase/_phase.py
@@ -95,13 +95,16 @@ class Phase(Domain):
         if element + '.' + prop in self.keys():
             vals = super().__getitem__(element + '.' + prop)
         else:  # If above are not triggered then try to interpolate
-            if self.settings['auto_interpolate']:
-                if (element == 'pore') and ('throat.'+prop not in self.keys()):
+            try:
+                if self.settings['auto_interpolate']:
+                    if (element == 'pore') and ('throat.'+prop not in self.keys()):
+                        raise KeyError(key)
+                    elif (element == 'throat') and ('pore.'+prop not in self.keys()):
+                        raise KeyError(key)
+                    vals = self.interpolate_data(element + '.' + prop)
+                else:
                     raise KeyError(key)
-                elif (element == 'throat') and ('pore.'+prop not in self.keys()):
-                    raise KeyError(key)
-                vals = self.interpolate_data(element + '.' + prop)
-            else:
+            except AttributeError:
                 raise KeyError(key)
 
         # Finally get locs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0.dev3
+current_version = 3.3.0.dev4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<release>\D+)(?P<build>\d+)?
 serialize = {major}.{minor}.{patch}.{release}{build}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0.dev4
+current_version = 3.3.0.dev5
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<release>\D+)(?P<build>\d+)?
 serialize = {major}.{minor}.{patch}.{release}{build}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0.dev0
+current_version = 3.3.0.dev1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<release>\D+)(?P<build>\d+)?
 serialize = {major}.{minor}.{patch}.{release}{build}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0.dev2
+current_version = 3.3.0.dev3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<release>\D+)(?P<build>\d+)?
 serialize = {major}.{minor}.{patch}.{release}{build}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0.dev1
+current_version = 3.3.0.dev2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<release>\D+)(?P<build>\d+)?
 serialize = {major}.{minor}.{patch}.{release}{build}
 


### PR DESCRIPTION
The deprecation of the `matplotlib.docstring` module to `matplotlib._docstring` was fixed in our previous patch, BUT it was not compatible with both new and old versions of matplotlib, so this patch uses a try/except to work with both versions. 