### PR TITLE
hotfix import TerminationCondition for scipy v>=1.14

### DIFF
--- a/openpnm/algorithms/_reactive_transport.py
+++ b/openpnm/algorithms/_reactive_transport.py
@@ -3,7 +3,7 @@ import sys
 
 import numpy as np
 from numpy.linalg import norm
-from scipy.optimize.nonlin import TerminationCondition
+from scipy.optimize._nonlin import TerminationCondition  # Fix: import from _nonlin.py for compatibility with scipy >=1.14, should be addressed more sustainable
 from tqdm.auto import tqdm
 
 from openpnm.algorithms import Transport


### PR DESCRIPTION
**Issue**
With updating to  scipy 1.14, import from `scipy.optimize.nonlin` leads to an import error

**Temporary Fix**
Import from `scipy.optimize._nonlin` instead

**Additional**
The use of `TerminalCondition` should be reviewed. In my opinion, substituting the check done by `TerminalCondition` would reduce the dependencies of the project and would not decrease readability.

Related to #2922 