### PR TITLE
Addressed compatibility issue of OpenPNM with numpy 2.2

### DIFF
--- a/openpnm/_skgraph/queries/_funcs.py
+++ b/openpnm/_skgraph/queries/_funcs.py
@@ -164,7 +164,7 @@ def find_connected_nodes(network, inds, flatten=True, logic='or'):
             if len(inds):
                 temp = temp.astype(float)
                 temp[inds] = np.nan
-            temp = np.reshape(temp, shape=[len(edges), 2], order='F')
+            temp = np.reshape(temp, [len(edges), 2], order='F')
             neighbors = temp
         else:
             neighbors = [np.array([], dtype=np.int64) for i in range(len(edges))]

--- a/openpnm/_skgraph/queries/_funcs.py
+++ b/openpnm/_skgraph/queries/_funcs.py
@@ -164,7 +164,7 @@ def find_connected_nodes(network, inds, flatten=True, logic='or'):
             if len(inds):
                 temp = temp.astype(float)
                 temp[inds] = np.nan
-            temp = np.reshape(a=temp, newshape=[len(edges), 2], order='F')
+            temp = np.reshape(temp, shape=[len(edges), 2], order='F')
             neighbors = temp
         else:
             neighbors = [np.array([], dtype=np.int64) for i in range(len(edges))]

--- a/openpnm/io/_pergeos.py
+++ b/openpnm/io/_pergeos.py
@@ -175,7 +175,7 @@ def network_from_pergeos(filename):
                 data = s[key].split('\n')[1:]
                 data = ' '.join(data)
                 arr = np.fromstring(data, dtype=typemap[key], sep=' ')
-                arr = np.reshape(arr, shape=shapemap[key])
+                arr = np.reshape(arr, shapemap[key])
                 net[propmap[key]] = arr
         # End file parsing
 

--- a/openpnm/io/_pergeos.py
+++ b/openpnm/io/_pergeos.py
@@ -175,7 +175,7 @@ def network_from_pergeos(filename):
                 data = s[key].split('\n')[1:]
                 data = ' '.join(data)
                 arr = np.fromstring(data, dtype=typemap[key], sep=' ')
-                arr = np.reshape(arr, newshape=shapemap[key])
+                arr = np.reshape(arr, shape=shapemap[key])
                 net[propmap[key]] = arr
         # End file parsing
 


### PR DESCRIPTION
With NumPy 2.2, the reshape function signature has changed:
https://numpy.org/doc/stable/reference/generated/numpy.reshape.html
The provided array is now a **positional-only** argument and the `newshape` parameter is deprecated in favor of `shape`.

This affected the following files:
- [`openpnm/_skygraph/queries/_funcs.py`](https://github.com/PMEAL/OpenPNM/blob/dev/openpnm/_skgraph/queries/_funcs.py)
- [`openpnm/io/_pergeos.py`](https://github.com/PMEAL/OpenPNM/blob/dev/openpnm/io/_pergeos.py)

Fix:
Scanned the whole repository for affected calls, found and fixed following occurrences
- removed the explicit assignment of `temp` to `a` in the reshape call in `openpnm/_skygraph/queries/_funcs.py` line 167
- removed the `newshape` parameter and use positional arguments for compatibility of numpy versions in `openpnm/_skygraph/queries/_funcs.py` line 167 and  `openpnm/io/_pergeos.py` line 178

Note:
- pytest is currently failing due to updates in scipy 1.15,*, see discussions [here](https://github.com/scipy/scipy/issues/22236) and [here](https://github.com/pytest-dev/pytest/issues/10845#issuecomment-2577509473)
