### PR TITLE
Fix IO issues for 'io.network_from_csv'

### DIFF
--- a/openpnm/io/_csv.py
+++ b/openpnm/io/_csv.py
@@ -92,7 +92,7 @@ def network_from_csv(filename):
     # boolean values, the dtype 'O' persists. That can lead to difficult
     # to debug errors later on. Therefore here this fix:
     for k, v in dct.items():
-        if type(v[0]) == bool:
+        if type(v[0]) is bool:
             dct[k] = v.astype(bool)
 
     network = Network()


### PR DESCRIPTION
Here, two issues are addressed:
1) A DtypeWarning appears when using 'io.network_from_csv', that mixed types were encountered. Since specifying the dtype is not generally possible, the flag low_memory=False has to be set to avoid this warning by pandas.
2) For the columns with boolean values, pandas keeps the general Object type (dtype('O')), which can lead to issues later on, especially when trying to use the values directly. Especially nasty to debug when used in combination with topotools. This issue is fixed by adding an additional conversion step at the end of the function 'io.network_from_csv'

Note:
- pytest is currently failing due to updates in scipy 1.15,*, see discussions [here](https://github.com/scipy/scipy/issues/22236) and [here](https://github.com/pytest-dev/pytest/issues/10845#issuecomment-2577509473)