### PR TITLE
Fix NumPy positional-only argument usage

### DIFF
--- a/openpnm/_skgraph/queries/_funcs.py
+++ b/openpnm/_skgraph/queries/_funcs.py
@@ -164,7 +164,7 @@ def find_connected_nodes(network, inds, flatten=True, logic='or'):
             if len(inds):
                 temp = temp.astype(float)
                 temp[inds] = np.nan
-            temp = np.reshape(a=temp, newshape=[len(edges), 2], order='F')
+            temp = np.reshape(temp, newshape=[len(edges), 2], order='F')
             neighbors = temp
         else:
             neighbors = [np.array([], dtype=np.int64) for i in range(len(edges))]


### PR DESCRIPTION
Fixes the error ```TypeError: reshape() got some positional-only arguments passed as keyword arguments: 'a'``` when passing the first argument as a keyword argument.