### PR TITLE
Add uv.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# uv lockfiles
+uv.lock
+
 docs/_build/
 public/
 


### PR DESCRIPTION
Add uv.lock to .gitignore file, to prevent it from being inadvertently committed. 