### PR TITLE
Install pypardiso by default on x86_64 platforms

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           uv sync --extra test --extra extras --extra docs --extra interactive
           uv pip install -e . --no-deps
-          uv pip install pypardiso
 
       - name: Running tests
         run: uv run pytest examples/ --nbval-lax

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements/docs.txt
-          pip install pypardiso
 
       - name: Build the documentation
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,11 +49,6 @@ jobs:
             -r requirements.txt \
             -r requirements/tests.txt
 
-      - name: Install pypardiso on non-macOS
-        if: (matrix.os != 'macos-latest')
-        run: |
-          pip install pypardiso            
-
       - name: Running tests
         run:
           pytest . --color=yes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,11 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           uv sync --extra test --extra extras
-          uv pip install pypardiso
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: |
           uv sync --extra test --extra extras
-          uv pip install pypardiso
 
       - name: Disable numba JIT for codecov to include jitted methods
         if: (matrix.python-version == 3.12) && (matrix.os == 'ubuntu-latest')

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ OpenPNM can also be installed from the [conda-forge](https://anaconda.org/conda-
 conda install -c conda-forge openpnm
 ```
 
-> [!WARNING]  
-> For compatibility with ARM64 architecture, we removed `pypardiso` as a hard dependency. However, we still strongly recommend that non-macOS users (including users of older Macs with an Intel CPU) manually install `pypardiso` via `pip install pypardiso` or `conda install -c conda-forge pypardiso`, otherwise OpenPNM simulations will be very slow.
-
 ### For developers
 For developers who intend to change the source code or contribute to OpenPNM, the source code can be downloaded from [Github](https://github.com/PMEAL/OpenPNM/) and installed by running:
 

--- a/openpnm/utils/_workspace.py
+++ b/openpnm/utils/_workspace.py
@@ -50,10 +50,10 @@ class WorkspaceSettings(SettingsAttr):
         except ImportError:
             default_solver = 'ScipySpsolve'
             msg = (
-                'PARDISO solver not installed, run `pip install pypardiso`. '
-                'Otherwise, simulations will be slow. Apple M chips not supported.'
+                'PARDISO solver not installed on this platform. '
+                'Simulations will be slow.'
             )
-            logger.error(msg)
+            logger.warning(msg)
 
     @property
     def loglevel(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "numpy<2.2",
     "pandas>=2.3.2",
     "pyamg>=5.3.0",
+    "pypardiso; platform_machine=='x86_64' or platform_machine=='AMD64'",
     "rich>=14.1.0",
     "scikit-image<0.24",
     "scipy>=1.16.2",


### PR DESCRIPTION
As a suggestion only, conditionally install `pypardiso` by default on compatible platforms.