### PR TITLE
Fixing workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -56,6 +56,16 @@ jobs:
         bump_version major $VERSION_FILE
         echo "TAG_NEW=v$(get_version $VERSION_FILE)" >> $GITHUB_ENV
 
+    - name: Strip .dev0 suffix from version file
+      if:
+        contains(github.event.head_commit.message, '#patch') ||
+        contains(github.event.head_commit.message, '#minor') ||
+        contains(github.event.head_commit.message, '#major')
+      run: |
+        # Remove .dev0 suffix from the version file for releases
+        sed -i "s/\.dev0'/'/g" $VERSION_FILE
+        echo "Release version: $(cat $VERSION_FILE)"
+
     - name: Commit files
       if:
         contains(github.event.head_commit.message, '#patch') ||

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       max-parallel: 9
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.12', '3.13']
         # Add macos-latest to the next line once #2451 is fixed
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,11 @@ jobs:
         run: |
           echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
 
+      - name: Disable numba JIT for Python 3.13 due to performance issues
+        if: matrix.python-version == '3.13'
+        run: |
+          echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
+
       - name: Running tests
         run: uv run pytest --cov=. --cov-report=xml --color=yes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools>=80"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "openpnm"
 dynamic = ["version"]
@@ -94,6 +90,13 @@ dev = [
     "openpnm[docs]",
     "openpnm[interactive]",
 ]
+
+[build-system]
+requires = ["setuptools>=80"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["openpnm"]
 
 [tool.setuptools.dynamic]
 version = {attr = "openpnm.__version__.__version__"}


### PR DESCRIPTION
This PR fixes a few important things:
- Updated nightly.yml to use pythons v11-13 #maint
- Disabled Numba for python 3.13 to improve speed. This can be re-enabled once numba supports 3.13. #maint
- Fixed the versioning when merging into release #maint

Apparently we deleted some crucial code when we switched from setup.py to pyproject.yml.  This code has be added to the bump-version.yml file now. Next time we merge onto release and a pypi release is triggered it *should* be a real release.