### PR TITLE
removing circular import from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,8 @@ dev = [
 requires = ["setuptools>=80"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["openpnm"]
+# [tool.setuptools]
+# packages = ["openpnm"]
 
 [tool.setuptools.dynamic]
 version = {attr = "openpnm.__version__.__version__"}


### PR DESCRIPTION
I'm not sure why I even added these lines, because the build seems to work without them.  