### PR TITLE
Fix variable name from 'newshape' to 'shape' in reshape

### DIFF
--- a/src/openpnm/_skgraph/queries/_funcs.py
+++ b/src/openpnm/_skgraph/queries/_funcs.py
@@ -168,7 +168,7 @@ def find_connected_nodes(network, inds, flatten=True, logic="or"):
             if len(inds):
                 temp = temp.astype(float)
                 temp[inds] = np.nan
-            temp = np.reshape(temp, newshape=[len(edges), 2], order="F")
+            temp = np.reshape(temp, shape=[len(edges), 2], order="F")
             neighbors = temp
         else:
             neighbors = [np.array([], dtype=np.int64) for i in range(len(edges))]


### PR DESCRIPTION
Numpy 2.1 changed variable name to shape. In Numpy 2.4 newshape is definitively removed