### PR TITLE
Route `param.*` keys from porespy dicts into network params

### DIFF
--- a/src/openpnm/io/_porespy.py
+++ b/src/openpnm/io/_porespy.py
@@ -22,13 +22,18 @@ def network_from_porespy(filename):
     """
     # Parse the filename
     if isinstance(filename, dict):
-        net = filename
+        net = dict(filename)
     else:
         filename = _parse_filename(filename=filename)
         with open(filename, mode='rb') as f:
             net = pk.load(f)
 
+    # Pop param.* entries so they're routed via __setitem__ into _params
+    # rather than landing as raw dict items via update().
+    params = {k: net.pop(k) for k in list(net) if k.startswith('param.')}
     network = Network()
     network.update(net)
+    for key, value in params.items():
+        network[key] = value
 
     return network

--- a/tests/unit/io/PoreSpyTest.py
+++ b/tests/unit/io/PoreSpyTest.py
@@ -23,6 +23,26 @@ class PoreSpyTest:
         assert net.Np == 1637
         assert net.Nt == 2785
 
+    def test_param_keys_are_routed_to_params(self):
+        net_with_params = dict(self.net)
+        net_with_params['param.voxel_size'] = 1.5e-6
+        net_with_params['param.ndim'] = 3
+        proj = op.io.network_from_porespy(net_with_params)
+        net = proj.network
+        assert net['param.voxel_size'] == 1.5e-6
+        assert net['param.ndim'] == 3
+        # Ensure they survive a project save/load round-trip
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            fname = os.path.join(tmp, 'proj')
+            op.Workspace().save_project(project=net.project, filename=fname)
+            ws = op.Workspace()
+            ws.clear()
+            ws.load_project(filename=fname + '.pnm')
+            loaded = list(ws.values())[0][0]
+            assert loaded['param.voxel_size'] == 1.5e-6
+            assert loaded['param.ndim'] == 3
+
 
 if __name__ == '__main__':
     # All the tests in this file can be run with 'playing' this file


### PR DESCRIPTION
When loading a porespy network dict via `network_from_porespy`, the `network.update(net)` call bypasses `Network.__setitem__`, so any `param.*` entries land as raw dict items instead of being routed into `_params`. That breaks project save/load round-trips: pickle re-invokes `__setitem__` on load, which tries to write to `_params` before `__init__` has set it up.

Fix is to pop `param.*` keys before `update()` and assign them individually so they go through the proper code path.

This pairs with PMEAL/porespy#1165, which starts emitting `param.voxel_size` and `param.ndim` from network extraction so they can be used downstream (e.g., for `rescale_network`).