### PR TITLE
ci: run tests on PRs to any branch, scope push trigger to dev/release

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,10 @@ name: Tests
 
 on:
   push:
-  pull_request:
     branches:
+      - dev
       - release
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- The `Tests` workflow currently only runs on PRs targeting `release`, so PRs into `dev` (including external PRs like #3047) skip the full 3 Python × 3 OS matrix.
- Naively adding `dev` to the `pull_request` filter would double-fire CI for internal devs (push event + pull_request event on the same commits).
- Scope `push:` to just `dev` and `release` (long-lived branches), and let `pull_request:` handle every PR. Net: PRs into `dev` get the matrix, no duplicate runs on feature branches.

## Behavior after this change
- Internal feature branch push → no CI yet
- Open PR (any base) → `pull_request:` runs the matrix once
- PR merges into `dev` or `release` → `push:` runs the matrix once
- External PR → `pull_request:` runs once

## Test plan
- [x] Confirm this PR itself triggers exactly one `Tests` matrix run via `pull_request:`
- [x] After merge, confirm the push to `dev` triggers exactly one matrix run
- [x] Confirm a follow-up push to a feature branch in PMEAL/OpenPNM does *not* trigger CI until a PR is opened