### PR TITLE
Fix NumPy 2.x compatibility: replace removed np.in1d with np.isin

### DIFF
--- a/src/openpnm/_skgraph/queries/_funcs.py
+++ b/src/openpnm/_skgraph/queries/_funcs.py
@@ -357,7 +357,7 @@ def find_neighbor_nodes(network, inds, flatten=True, include_input=False, logic=
     if len(rows) == 0:
         return []
     n_nodes = am.shape[0]
-    neighbors = am_coo.col[np.in1d(am_coo.row, nodes)]
+    neighbors = am_coo.col[np.isin(am_coo.row, nodes)]
     if logic in ["or", "union", "any"]:
         neighbors = np.unique(neighbors)
     elif logic in ["xor", "exclusive_or"]:

--- a/src/openpnm/_skgraph/simulations/_percolation.py
+++ b/src/openpnm/_skgraph/simulations/_percolation.py
@@ -227,9 +227,9 @@ def remove_isolated_clusters(labels, inlets):
     # Remove cluster numbers == -1, if any
     inv_clusters = inv_clusters[inv_clusters >= 0]
     # Find all pores in invading clusters
-    p_invading = np.in1d(labels.site_labels, inv_clusters)
+    p_invading = np.isin(labels.site_labels, inv_clusters)
     labels.site_labels[~p_invading] = -1
-    t_invading = np.in1d(labels.bond_labels, inv_clusters)
+    t_invading = np.isin(labels.bond_labels, inv_clusters)
     labels.bond_labels[~t_invading] = -1
     return labels
 
@@ -268,5 +268,5 @@ def ispercolating(conns, occupied, inlets, outlets):
     outs = np.unique(clusters.site_labels[outlets])
     if outs[0] == -1:
         outs = outs[1:]
-    hits = np.in1d(ins, outs)
+    hits = np.isin(ins, outs)
     return np.any(hits)

--- a/src/openpnm/network/_network.py
+++ b/src/openpnm/network/_network.py
@@ -816,7 +816,7 @@ class Network(Domain):
         Pn = np.unique(temp).astype(np.int64)
         # Remove inputs if necessary
         if include_input is False:
-            Pn = Pn[~np.in1d(Pn, pores)]
+            Pn = Pn[~np.isin(Pn, pores)]
         # Convert list of lists to a list of ndarrays
         if flatten is False:
             if len(Pn) == 0:  # Deal with no nearby neighbors

--- a/src/openpnm/topotools/_perctools.py
+++ b/src/openpnm/topotools/_perctools.py
@@ -89,7 +89,7 @@ def find_isolated_clusters(network, mask, inlets):
         connected to the given ``inlets``.
     """
     labels = find_clusters(network=network, mask=mask)
-    isolated = np.in1d(labels.pore_labels, labels.pore_labels[inlets], invert=True)
+    isolated = np.isin(labels.pore_labels, labels.pore_labels[inlets], invert=True)
     isolated = np.where(isolated)[0]
     return isolated
 

--- a/tests/unit/models/misc/MiscTest.py
+++ b/tests/unit/models/misc/MiscTest.py
@@ -108,7 +108,7 @@ class MiscTest:
                            propname='pore.seed',
                            prop='throat.seed',
                            mode='min')
-        assert np.all(np.in1d(self.net['pore.seed'], self.net['throat.seed']))
+        assert np.all(np.isin(self.net['pore.seed'], self.net['throat.seed']))
         assert np.isclose(self.net['throat.seed'].mean(), 0.5)
         assert np.isclose(self.net['pore.seed'].mean(), 0.16454849498327762)
 
@@ -121,7 +121,7 @@ class MiscTest:
                            propname='pore.seed',
                            prop='throat.seed',
                            mode='max')
-        assert np.all(np.in1d(self.net['pore.seed'], self.net['throat.seed']))
+        assert np.all(np.isin(self.net['pore.seed'], self.net['throat.seed']))
         assert np.isclose(self.net['throat.seed'].mean(), 0.5)
         assert np.isclose(self.net['pore.seed'].mean(), 0.8595317725752508)
 

--- a/tests/unit/network/GenericNetworkTest.py
+++ b/tests/unit/network/GenericNetworkTest.py
@@ -179,7 +179,7 @@ class NetworkTest:
         a = self.net.find_nearby_pores(pores=[0, 1], r=2,
                                        flatten=True, include_input=True)
         assert np.size(a) == 17
-        assert np.all(np.in1d([0, 1], a))
+        assert np.all(np.isin([0, 1], a))
 
     def test_get_incidence_matrix(self):
         net = op.network.Demo([4, 4, 1])


### PR DESCRIPTION
I am trying to get the CI to run on the PR. I cannot seem to make it happen on the PR from @gaoflow's PR, so I created a new branch and pushed it.  